### PR TITLE
Fixed generate_templates. Respecting read_only. 

### DIFF
--- a/iambic/request_handler/generate.py
+++ b/iambic/request_handler/generate.py
@@ -12,15 +12,15 @@ from iambic.google.models import generate_group_templates
 async def generate_templates(configs: list[Config], output_dir):
     # TODO: Create a setting to enable support for google groups
     # TODO: Ensure google_groups are not excluded from sync
-    tasks = []
-    for config in configs:
-        response_dir_list = [output_dir, ROLE_RESPONSE_DIR]
-        for response_dir in response_dir_list:
-            os.makedirs(str(response_dir), exist_ok=True)
+    response_dir_list = [output_dir, ROLE_RESPONSE_DIR]
+    for response_dir in response_dir_list:
+        os.makedirs(str(response_dir), exist_ok=True)
 
-        if config.google.groups.enabled:
+    tasks = [generate_aws_role_templates(configs, output_dir)]
+    for config in configs:
+        if config.google and config.google.groups.enabled:
             tasks.extend(
                 generate_group_templates(config, "noq.dev", output_dir) for config in configs
             )
-        tasks.append(generate_aws_role_templates(configs, output_dir))
+
     await asyncio.gather(*tasks)


### PR DESCRIPTION
Roles with path "aws-service-role" will be read only.