### PR TITLE
EN-1281 Allow specification of proposed_changes.json output path

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -258,7 +258,8 @@
             "env": {
                 "AWS_PROFILE": "staging/IambicHubRole",
                 "IAMBIC_CONFIG_ASSUME_ROLE": "arn:aws:iam::759357822767:role/IambicSpokeRole",
-                "IAMBIC_CONFIG": "arn:aws:secretsmanager:us-west-2:759357822767:secret:dev/iambic-full"
+                "IAMBIC_CONFIG": "arn:aws:secretsmanager:us-west-2:759357822767:secret:dev/iambic-full",
+                "PLAN_OUTPUT_PATH": "/tmp/proposed_changes.json",
             },
         },
         {

--- a/iambic/lambda/app.py
+++ b/iambic/lambda/app.py
@@ -22,6 +22,7 @@ CONFIG_PATH = os.path.expanduser("~/.iambic/config.yaml")
 os.makedirs(os.path.dirname(CONFIG_PATH), exist_ok=True)
 REPO_BASE_PATH = os.path.expanduser("~/.iambic/repos/")
 os.makedirs(os.path.dirname(REPO_BASE_PATH), exist_ok=True)
+PLAN_OUTPUT_PATH = os.environ.get("PLAN_OUTPUT_PATH", None)
 
 
 class LambdaCommand(Enum):
@@ -99,7 +100,7 @@ def run_handler(event=None, context=None):
         case LambdaCommand.run_git_apply.value:
             return run_git_apply(CONFIG_PATH, None, REPO_BASE_PATH)
         case LambdaCommand.run_git_plan.value:
-            return run_git_plan(CONFIG_PATH, None, REPO_BASE_PATH)
+            return run_git_plan(CONFIG_PATH, None, REPO_BASE_PATH, PLAN_OUTPUT_PATH)
         case LambdaCommand.run_clone_git_repos.value:
             return run_clone_repos(CONFIG_PATH, REPO_BASE_PATH)
         case _:


### PR DESCRIPTION
How to test:

You can VSCode: lambda git-plan, it specifies the output_path to /tmp/proposed_changes.json

The integration path: We will have Github action to add the new environment variable during docker-compose like the following

`docker-compose -f ./docker-compose-cicd.yaml run -e PLAN_OUTPUT_PATH=/tmp/proposed_changes.json -v ~/.ssh/:/root/.ssh/ -v $(pwd)/noq-templates/:/root/.iambic/repos/ iambic-cicd /bin/bash -c "env"`