### PR TITLE
EN-1416 Rearrange the order for type assume_role_policy_document

### DIFF
--- a/iambic/aws/iam/role/models.py
+++ b/iambic/aws/iam/role/models.py
@@ -81,8 +81,11 @@ class RoleTemplate(AWSTemplate, AccessModel):
         description="List of users and groups who can assume into the role",
     )
     assume_role_policy_document: Optional[
-        Union[None, AssumeRolePolicyDocument, list[AssumeRolePolicyDocument]]
-    ] = None
+        Union[None, list[AssumeRolePolicyDocument], AssumeRolePolicyDocument]
+    ] = Field(
+        [],
+        description="Who can assume the Role",
+    )
     tags: Optional[list[Tag]] = Field(
         [],
         description="List of tags attached to the role",


### PR DESCRIPTION
This is something I didn't quite understand the root cause. 

The order seems to matter. When singular form of AssumeRolePolicyDocument is before the plural form, the deserialization will mess up.

I guess that's due to both statement and version is optional. So it will not trigger deserialization error. 