### PR TITLE
EN-1543 If Account or Resource is read_only, short circuit on evaluation

### DIFF
--- a/iambic/aws/utils.py
+++ b/iambic/aws/utils.py
@@ -158,9 +158,7 @@ def get_account_value(matching_values: list, account_id: str, account_name: str 
 def evaluate_on_account(resource, aws_account, context: ExecutionContext) -> bool:
     from iambic.aws.models import AccessModel
 
-    if context.execute and (
-        aws_account.read_only or getattr(resource, "read_only", False)
-    ):
+    if aws_account.read_only or getattr(resource, "read_only", False):
         return False
     if not issubclass(type(resource), AccessModel):
         return True


### PR DESCRIPTION
Previous implementation will not short circuit on evaluation if the evaluation context is not "execute".

This will lead to plan phase include changes to be made for read_only resources. I think read_only resources only goes from resource configuration -> iambic templates in one-direction. If we include read_only resources in plan phase, it will be very noisy.

This change only consider what should be done in apply and plan phase. Let's say if we plan to have it covered more subcommands, we can consider expand the amount of information in the context object. Since we don't have other subcommands examples, I propose the simple implementation at the moment.