### PR TITLE
EN-1620 add metadata to session name

### DIFF
--- a/iambic/aws/models.py
+++ b/iambic/aws/models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 from enum import Enum
 from typing import TYPE_CHECKING, List, Optional, Union
 
@@ -143,6 +144,7 @@ class BaseAWSAccountAndOrgModel(PydanticBaseModel):
                 self.assume_role_arn,
                 region_name,
                 external_id=self.external_id,
+                session_name=os.environ.get("IAMBIC_SESSION_NAME", None),
             )
             if boto3_session:
                 self.boto3_session_map[region_name] = boto3_session
@@ -224,6 +226,7 @@ class AWSAccount(BaseAWSAccountAndOrgModel):
                 self.assume_role_arn,
                 region_name,
                 external_id=self.external_id,
+                session_name=os.environ.get("IAMBIC_SESSION_NAME", None),
             )
             if boto3_session:
                 self.boto3_session_map[region_name] = boto3_session
@@ -426,6 +429,7 @@ class AWSOrganization(BaseAWSAccountAndOrgModel):
                 assume_role_arn,
                 region_name,
                 external_id=self.external_id,
+                session_name=os.environ.get("IAMBIC_SESSION_NAME", None),
             )
             if boto3_session:
                 try:

--- a/iambic/aws/utils.py
+++ b/iambic/aws/utils.py
@@ -346,6 +346,8 @@ async def create_assume_role_session(
     external_id: Optional[str] = None,
     session_name: str = "iambic",
 ) -> boto3.Session:
+    if session_name is None:
+        session_name = "iambic"
     try:
         sts = boto3_session.client(
             "sts",

--- a/iambic/cicd/github.py
+++ b/iambic/cicd/github.py
@@ -2,13 +2,15 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shutil
 from enum import Enum
 from typing import Any, Callable
 from urllib.parse import urlparse
 
 import yaml
-from github import Github, PullRequest
+from github import Github
+from github.PullRequest import PullRequest
 
 from iambic.core.git import Repo, clone_git_repo
 from iambic.core.logger import log
@@ -153,6 +155,34 @@ def copy_data_to_data_directory() -> None:
         shutil.copy(filepath, f"{dest_dir}/proposed_changes.yaml")
 
 
+IAMBIC_SESSION_NAME_TEMPLATE = "org={org},repo={repo},pr={number}"
+SESSION_NAME_REGEX = re.compile("[\\w=,.@-]+")
+
+
+def get_session_name(repo_name: str, pull_request_number: str) -> str:
+    org = ""
+    repo = ""
+    repo_parts = repo_name.split("/")
+    if len(repo_parts) == 2:
+        repo = repo_parts[1]
+        org = repo_parts[0]
+    else:
+        repo = repo_name
+    pending_session_name = IAMBIC_SESSION_NAME_TEMPLATE.format(
+        org=org, repo=repo, number=pull_request_number
+    )
+    session_name = "".join(
+        [c for c in pending_session_name if SESSION_NAME_REGEX.match(c)]
+    )
+    if session_name != pending_session_name:
+        log_params = {
+            "pending_session_name": pending_session_name,
+            "session_name": session_name,
+        }
+        log.error("lossy-session-name", **log_params)
+    return session_name
+
+
 def handle_issue_comment(
     github_client: Github, context: dict[str, Any]
 ) -> HandleIssueCommentReturnCode:
@@ -182,6 +212,10 @@ def handle_issue_comment(
             "mergeable_state is {0}".format(pull_request.mergeable_state)
         )
         return HandleIssueCommentReturnCode.MERGEABLE_STATE_NOT_CLEAN
+
+    session_name = get_session_name(repo_name, pull_number)
+    os.environ["IAMBIC_SESSION_NAME"] = session_name
+
     try:
         prepare_local_repo(repo_url, lambda_repo_path, pull_request_branch_name)
         lambda_run_handler(None, {"command": "git_apply"})
@@ -212,6 +246,9 @@ def handle_pull_request(github_client: Github, context: dict[str, Any]) -> None:
     pull_request_branch_name = pull_request.head.ref
     log_params = {"pull_request_branch_name": pull_request_branch_name}
     log.info("PR remote branch name", **log_params)
+
+    session_name = get_session_name(repo_name, pull_number)
+    os.environ["IAMBIC_SESSION_NAME"] = session_name
 
     try:
         prepare_local_repo_from_remote_branch(

--- a/test/cicd/test_github.py
+++ b/test/cicd/test_github.py
@@ -12,6 +12,7 @@ from iambic.cicd.github import (
     HandleIssueCommentReturnCode,
     ensure_body_length_fits_github_spec,
     format_github_url,
+    get_session_name,
     handle_issue_comment,
     handle_pull_request,
     prepare_local_repo,
@@ -169,3 +170,19 @@ def test_pull_request_plan(
     ]
     handle_pull_request(mock_github_client, pull_request_context)
     assert mock_lambda_run_handler.called is True
+
+
+@pytest.mark.parametrize(
+    "repo_name,pr_number,expected_result",
+    [
+        (
+            "noqdev/iambic-templates-itest",
+            "1",
+            "org=noqdev,repo=iambic-templates-itest,pr=1",
+        ),
+        ("noqdev/a^b", "1", "org=noqdev,repo=ab,pr=1"),
+    ],
+)
+def test_get_session_name(repo_name, pr_number, expected_result):
+    session_name = get_session_name(repo_name, pr_number)
+    assert session_name == expected_result


### PR DESCRIPTION
How do test?
+ add unit test on test_github.py::test_get_session_name
* existing functional test test_github_cicd will have the new session name, and can be verified using cloudtrail

Concern:
* current implementation is lossy in the event there are invalid character. if we want to address, we have to come up with a custom code to escape it. (defer to future?)