### PR TITLE
EN-1675 Change pull-request flow to defer to issue-comment to handle plan request

### DIFF
--- a/docs/GITHUB_INTEGRATION.md
+++ b/docs/GITHUB_INTEGRATION.md
@@ -1,0 +1,6 @@
+Security Consideration
+
+
+1. Only main branch is allowed to assume web identity. This is to ensure only approved review changes are run with authentication.
+2. WRITE_PR_COMMENT github token is accessible by any branches in the repo to enable auto planning by issuing comment. WRITE_PR_COMMENT has scope Pull Request Read & Write. This is a compromise. If its undesired, then the author or reviewer has to manually issue "iambic git-plan" to trigger the plan. This is due to workflow-run-A cannot spawn new workflow-run-B.
+3. AUTO_IMPORT_GH_TOKEN github token is only accessible by production deployment rule. AUTO_IMPORT_GH_TOKEN token has scope Contents Read & Write. It's important to protect this token because it is used to import new changes into the repository.

--- a/test/cicd/test_github.py
+++ b/test/cicd/test_github.py
@@ -26,7 +26,7 @@ def mock_github_client():
 
 
 @pytest.fixture
-def issue_comment_context():
+def issue_comment_git_apply_context():
     return {
         "server_url": "https://github.com",
         "run_id": "12345",
@@ -38,6 +38,30 @@ def issue_comment_context():
         "event": {
             "comment": {
                 "body": "iambic git-apply",
+            },
+            "issue": {
+                "number": 1,
+            },
+            "repository": {
+                "clone_url": "https://github.com/example-org/iambic-templates.git",
+            },
+        },
+    }
+
+
+@pytest.fixture
+def issue_comment_git_plan_context():
+    return {
+        "server_url": "https://github.com",
+        "run_id": "12345",
+        "run_attempt": "1",
+        "token": "fake-token",
+        "sha": "fake-sha",
+        "repository": "example.com/iambic-templates",
+        "event_name": "issue_comment",
+        "event": {
+            "comment": {
+                "body": "iambic git-plan",
             },
             "issue": {
                 "number": 1,
@@ -67,50 +91,58 @@ def mock_repository():
 
 
 def test_issue_comment_with_non_clean_mergeable_state(
-    mock_github_client, issue_comment_context, mock_lambda_run_handler
+    mock_github_client, issue_comment_git_apply_context, mock_lambda_run_handler
 ):
     mock_pull_request = mock_github_client.get_repo.return_value.get_pull.return_value
     mock_pull_request.mergeable_state = MERGEABLE_STATE_BLOCKED
-    handle_issue_comment(mock_github_client, issue_comment_context)
+    handle_issue_comment(mock_github_client, issue_comment_git_apply_context)
     assert mock_lambda_run_handler.called is False
     assert mock_pull_request.merge.called is False
 
 
 def test_issue_comment_with_not_applicable_comment_body(
-    mock_github_client, issue_comment_context, mock_lambda_run_handler
+    mock_github_client, issue_comment_git_apply_context, mock_lambda_run_handler
 ):
-    issue_comment_context["event"]["comment"]["body"] = "foo"
-    return_code = handle_issue_comment(mock_github_client, issue_comment_context)
+    issue_comment_git_apply_context["event"]["comment"]["body"] = "foo"
+    return_code = handle_issue_comment(
+        mock_github_client, issue_comment_git_apply_context
+    )
     assert return_code == HandleIssueCommentReturnCode.NO_MATCHING_BODY
 
 
 def test_issue_comment_with_clean_mergeable_state(
-    mock_github_client, issue_comment_context, mock_lambda_run_handler, mock_repository
+    mock_github_client,
+    issue_comment_git_apply_context,
+    mock_lambda_run_handler,
+    mock_repository,
 ):
     mock_pull_request = mock_github_client.get_repo.return_value.get_pull.return_value
     mock_pull_request.mergeable_state = MERGEABLE_STATE_CLEAN
-    mock_pull_request.head.sha = issue_comment_context["sha"]
-    mock_repository.clone_from.return_value.head.commit.hexsha = issue_comment_context[
-        "sha"
-    ]
-    handle_issue_comment(mock_github_client, issue_comment_context)
+    mock_pull_request.head.sha = issue_comment_git_apply_context["sha"]
+    mock_repository.clone_from.return_value.head.commit.hexsha = (
+        issue_comment_git_apply_context["sha"]
+    )
+    handle_issue_comment(mock_github_client, issue_comment_git_apply_context)
     assert mock_lambda_run_handler.called
     assert mock_pull_request.merge.called
 
 
 # invariant: PR is only merged if and only if git-apply is successful
 def test_issue_comment_with_clean_mergeable_state_and_lambda_handler_crashed(
-    mock_github_client, issue_comment_context, mock_lambda_run_handler, mock_repository
+    mock_github_client,
+    issue_comment_git_apply_context,
+    mock_lambda_run_handler,
+    mock_repository,
 ):
     mock_pull_request = mock_github_client.get_repo.return_value.get_pull.return_value
     mock_pull_request.mergeable_state = MERGEABLE_STATE_CLEAN
-    mock_pull_request.head.sha = issue_comment_context["sha"]
-    mock_repository.clone_from.return_value.head.commit.hexsha = issue_comment_context[
-        "sha"
-    ]
+    mock_pull_request.head.sha = issue_comment_git_apply_context["sha"]
+    mock_repository.clone_from.return_value.head.commit.hexsha = (
+        issue_comment_git_apply_context["sha"]
+    )
     mock_lambda_run_handler.side_effect = Exception("unexpected failure")
     with pytest.raises(Exception):
-        handle_issue_comment(mock_github_client, issue_comment_context)
+        handle_issue_comment(mock_github_client, issue_comment_git_apply_context)
     assert mock_lambda_run_handler.called
     assert not mock_pull_request.merge.called
 
@@ -157,6 +189,9 @@ def pull_request_context():
                 "clone_url": "https://github.com/example-org/iambic-templates.git",
             },
         },
+        "iambic": {
+            "GH_OVERRIDE_TOKEN": "fake_override_token",
+        },
     }
 
 
@@ -169,7 +204,12 @@ def test_pull_request_plan(
         "sha"
     ]
     handle_pull_request(mock_github_client, pull_request_context)
-    assert mock_lambda_run_handler.called is True
+    assert (
+        mock_lambda_run_handler.called is False
+    )  # because this flow only directly calls create_issue_comment on the pull request
+    assert (
+        not mock_pull_request.merge.called
+    )  # because this flow only issue the comment
 
 
 @pytest.mark.parametrize(
@@ -186,3 +226,20 @@ def test_pull_request_plan(
 def test_get_session_name(repo_name, pr_number, expected_result):
     session_name = get_session_name(repo_name, pr_number)
     assert session_name == expected_result
+
+
+def test_issue_comment_with_git_plan(
+    mock_github_client,
+    issue_comment_git_plan_context,
+    mock_lambda_run_handler,
+    mock_repository,
+):
+    mock_pull_request = mock_github_client.get_repo.return_value.get_pull.return_value
+    mock_pull_request.mergeable_state = MERGEABLE_STATE_CLEAN
+    mock_pull_request.head.sha = issue_comment_git_plan_context["sha"]
+    mock_repository.clone_from.return_value.head.commit.hexsha = (
+        issue_comment_git_plan_context["sha"]
+    )
+    handle_issue_comment(mock_github_client, issue_comment_git_plan_context)
+    assert mock_lambda_run_handler.called
+    assert not mock_pull_request.merge.called


### PR DESCRIPTION
Previously plan request is handled directly in the event. This requires federated login to allow any pull-request to auth directly with IambicHubRole.

We should protect IambicHubRole to only assumable by main branch. 

This requires us to change the pull_request trigger to simply comment with "iambic git-plan" and let the issue-comment gh action (only on main branch) to auth to IambicHubRole

This does run into the GH design in which workflow-run-A cannot trigger workflow-run-B rule. So the "iambic git-plan" must be done with an identity different from GitHub-actions bot (the identity that runs the GitHub action). 

How did I test?
* update unit test to reflect the pull-request changes
* update integration test to test the new flow. This is an example run: https://github.com/noqdev/iambic-templates-itest/pull/162