### PR TITLE
EN-1707 Address expire job emitted templates re-arrange list orders

### DIFF
--- a/test/aws/iam/role/test_models.py
+++ b/test/aws/iam/role/test_models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from iambic.aws.iam.role.models import RoleTemplate
+from iambic.aws.iam.role.models import RoleProperties, RoleTemplate
 from iambic.core.models import merge_model
 
 
@@ -119,3 +119,34 @@ def test_merge_role_template_access_rules():
         == existing_document.properties.inline_policies[0].statement[0].expires_at
     )
     assert merged_document.access_rules == existing_document.access_rules
+
+
+def test_role_properties_tags():
+
+    tags_1 = [
+        {"key": "apple", "value": "red", "included_accounts": ["ses"]},
+        {"key": "apple", "value": "yellow", "included_accounts": ["development"]},
+    ]
+    tags_2 = list(reversed(tags_1))
+    assert tags_1 != tags_2
+    properties_1 = RoleProperties(role_name="foo", tags=tags_1)
+    properties_2 = RoleProperties(role_name="foo", tags=tags_2)
+    assert properties_1.tags == properties_2.tags
+
+
+def test_role_proerties_validation():
+
+    tags_1 = [
+        {"key": "apple", "value": "red", "included_accounts": ["ses"]},
+        {"key": "apple", "value": "yellow", "included_accounts": ["development"]},
+    ]
+    properties_1 = RoleProperties(role_name="foo", tags=tags_1)
+    tag_models_1 = properties_1.tags
+    tag_models_2 = list(reversed(properties_1.tags))
+    assert tag_models_1 != tag_models_2  # because we reverse the list
+    properties_1.tags = tag_models_2
+    assert (
+        properties_1.tags == tag_models_2
+    )  # double check the list is reversed because validation doesn't happen after creation
+    properties_1.validate_model_afterward()
+    assert properties_1.tags == tag_models_1


### PR DESCRIPTION
Bug fix: list order bounce between import workflow and expire workflow

Expire workflow directly modifies model attributes. It does not trigger model validator

We now pay the price of model validator before template write. This ensure all template.write will have its model validated. 

How'd I test:
- add unit test to ensure model can be validated post creation using model.validate_model_afterward.