### PR TITLE
EN-1749: Sparse Configuration Mode

### DIFF
--- a/iambic/config/dynamic_config.py
+++ b/iambic/config/dynamic_config.py
@@ -416,7 +416,12 @@ async def load_config(
     config_dict = yaml.load(open(config_path))
     base_config = Config(file_path=config_path, **config_dict)
     return await process_config(
-        base_config, config_path, config_dict, configure_plugins, approved_plugins_only
+        base_config,
+        config_path,
+        config_dict,
+        configure_plugins,
+        approved_plugins_only,
+        sparse=sparse,
     )
 
 
@@ -426,6 +431,7 @@ async def process_config(
     config_dict,
     configure_plugins: bool = True,
     approved_plugins_only: bool = False,
+    sparse: bool = False,
 ) -> Config:
     from iambic.config.templates import TEMPLATES
 


### PR DESCRIPTION
In this mode, Iambic will not attempt to perform plugin-specific logic, such as assuming roles to list accounts, reading AWS secrets, etc. This is so the SaaS can load a tenant's Iambic configuration without running extra logic.