### PR TITLE
Init Directory when run_handler is called

### DIFF
--- a/iambic/plugins/v0_1_0/github/github.py
+++ b/iambic/plugins/v0_1_0/github/github.py
@@ -72,6 +72,10 @@ def run_handler(context: dict[str, Any]):
     log_params = {"event_name": event_name}
     log.info("run_handler", **log_params)
     github_client = github.Github(github_token)
+
+    getattr(iambic_app, "lambda").app.init_plan_output_path()
+    getattr(iambic_app, "lambda").app.init_repo_base_path()
+
     # TODO Support Github Enterprise with custom hostname
     # g = Github(base_url="https://{hostname}/api/v3", login_or_token="access_token")
 


### PR DESCRIPTION
To maintain compatibility with the old GitHub actions (not fully transition), we need to initialize the file paths in the run_handler method.