### PR TITLE
EN-1788: Raise exception when unable to write template

### DIFF
--- a/iambic/core/template_generation.py
+++ b/iambic/core/template_generation.py
@@ -467,6 +467,7 @@ def create_or_update_template(
                 error=str(err),
                 template_params=template_params,
             )
+            raise
     else:
         try:
             new_template.write()
@@ -477,6 +478,7 @@ def create_or_update_template(
                 error=str(err),
                 template_params=template_params,
             )
+            raise
 
 
 def get_resource_id_to_model_map(models: list[BaseModel]) -> dict[str, BaseModel]:


### PR DESCRIPTION
new stack trace:

```
2023/02/24 15:01:55 [info     ] Found 4 users in the `development` Okta organization
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/ccastrapel/.vscode/extensions/ms-python.python-2023.2.0/pythonFiles/lib/python/debugpy/adapter/../../debugpy/launcher/../../debugpy/__main__.py", line 39, in <module>
    cli.main()
  File "/home/ccastrapel/.vscode/extensions/ms-python.python-2023.2.0/pythonFiles/lib/python/debugpy/adapter/../../debugpy/launcher/../../debugpy/../debugpy/server/cli.py", line 430, in main
    run()
  File "/home/ccastrapel/.vscode/extensions/ms-python.python-2023.2.0/pythonFiles/lib/python/debugpy/adapter/../../debugpy/launcher/../../debugpy/../debugpy/server/cli.py", line 317, in run_module
    run_module_as_main(options.target, alter_argv=True)
  File "/home/ccastrapel/.vscode/extensions/ms-python.python-2023.2.0/pythonFiles/lib/python/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 238, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/home/ccastrapel/.vscode/extensions/ms-python.python-2023.2.0/pythonFiles/lib/python/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 124, in _run_code
    exec(code, run_globals)
  File "/home/ccastrapel/localrepos/iambic/iambic/main.py", line 454, in <module>
    cli()
  File "/home/ccastrapel/localrepos/iambic/env/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/home/ccastrapel/localrepos/iambic/env/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/home/ccastrapel/localrepos/iambic/env/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/ccastrapel/localrepos/iambic/env/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/ccastrapel/localrepos/iambic/env/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/ccastrapel/localrepos/iambic/iambic/main.py", line 379, in import_
    run_import(repo_dir=repo_dir)
  File "/home/ccastrapel/localrepos/iambic/iambic/main.py", line 388, in run_import
    asyncio.run(config.run_import(repo_dir))
  File "/usr/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/lib/python3.10/asyncio/base_events.py", line 646, in run_until_complete
    return future.result()
  File "/home/ccastrapel/localrepos/iambic/iambic/config/dynamic_config.py", line 190, in run_import
    await asyncio.gather(
  File "/home/ccastrapel/localrepos/iambic/iambic/plugins/v0_1_0/google/handlers.py", line 31, in import_google_resources
    await asyncio.gather(*tasks)
  File "/home/ccastrapel/localrepos/iambic/iambic/plugins/v0_1_0/google/group/template_generation.py", line 79, in generate_group_templates
    resource_template = await update_or_create_group_template(
  File "/home/ccastrapel/localrepos/iambic/iambic/plugins/v0_1_0/google/group/template_generation.py", line 52, in update_or_create_group_template
    return common_create_or_update_template(
  File "/home/ccastrapel/localrepos/iambic/iambic/core/template_generation.py", line 462, in create_or_update_template
    merged_template.write()
  File "/home/ccastrapel/localrepos/iambic/iambic/core/models.py", line 482, in write
    with open(self.file_path, "w") as f:
PermissionError: [Errno 13] Permission denied: '../noq-templates/resources/google/groups/noq.dev/all.yaml'
```