### PR TITLE
Add partial failure support to managed policy

### DIFF
--- a/functional_tests/aws/managed_policy/test_update_template.py
+++ b/functional_tests/aws/managed_policy/test_update_template.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import asyncio
+from unittest import IsolatedAsyncioTestCase
+
+from functional_tests.aws.managed_policy.utils import (
+    generate_managed_policy_template_from_base,
+)
+from functional_tests.conftest import IAMBIC_TEST_DETAILS
+from iambic.core.context import ctx
+from iambic.plugins.v0_1_0.aws.models import Tag
+
+
+class ManagedPolicyUpdateTestCase(IsolatedAsyncioTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.template = asyncio.run(
+            generate_managed_policy_template_from_base(
+                IAMBIC_TEST_DETAILS.template_dir_path
+            )
+        )
+        cls.all_account_ids = [
+            account.account_id for account in IAMBIC_TEST_DETAILS.config.aws.accounts
+        ]
+        # Only include the template in half the accounts
+        # Make the accounts explicit so it's easier to validate account scoped tests
+        cls.template.included_accounts = cls.all_account_ids[
+            : len(cls.all_account_ids) // 2
+        ]
+        asyncio.run(cls.template.apply(IAMBIC_TEST_DETAILS.config.aws, ctx))
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.template.deleted = True
+        asyncio.run(cls.template.apply(IAMBIC_TEST_DETAILS.config.aws, ctx))
+
+    # tag None string value is not acceptable
+    async def test_update_tag_with_bad_input(self):
+        self.template.properties.tags = [Tag(key="*", value="")]  # bad input
+        template_change_details = await self.template.apply(
+            IAMBIC_TEST_DETAILS.config.aws, ctx
+        )
+
+        assert len(template_change_details.exceptions_seen) > 0

--- a/iambic/plugins/v0_1_0/aws/iam/policy/utils.py
+++ b/iambic/plugins/v0_1_0/aws/iam/policy/utils.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
 import asyncio
+from itertools import chain
 
 from botocore.exceptions import ClientError
 from deepdiff import DeepDiff
+
 from iambic.core import noq_json as json
 from iambic.core.context import ExecutionContext
 from iambic.core.logger import log
 from iambic.core.models import ProposedChange, ProposedChangeType
-from iambic.core.utils import NoqSemaphore, aio_wrapper
+from iambic.core.utils import NoqSemaphore, aio_wrapper, plugin_apply_wrapper
 from iambic.plugins.v0_1_0.aws.models import AWSAccount
 from iambic.plugins.v0_1_0.aws.utils import boto_crud_call, paginated_search
 
@@ -135,7 +137,7 @@ async def delete_managed_policy(iam_client, policy_arn: str, log_params: dict):
     await boto_crud_call(iam_client.delete_policy, PolicyArn=policy_arn)
 
 
-async def update_managed_policy(
+async def apply_update_managed_policy(
     iam_client,
     policy_arn: str,
     template_policy_document: dict,
@@ -161,7 +163,7 @@ async def update_managed_policy(
     if policy_drift:
         policy_drift = json.loads(policy_drift.to_json())
         log_str = "Changes to the PolicyDocument discovered."
-        response.append(
+        proposed_changes = [
             ProposedChange(
                 change_type=ProposedChangeType.UPDATE,
                 attribute="policy_document",
@@ -169,29 +171,44 @@ async def update_managed_policy(
                 current_value=existing_policy_document,
                 new_value=template_policy_document,
             )
-        )
+        ]
+        response.extend(proposed_changes)
 
         if not iambic_import_only:
-            if policy_drift:
-                policy_versions = await list_managed_policy_versions(
-                    iam_client, policy_arn
+            if context.execute:
+                apply_awaitable = new_policy_version(
+                    iam_client,
+                    policy_arn,
+                    template_policy_document,
+                    policy_drift,
+                    log_str,
+                    log_params,
                 )
-                if len(policy_versions) == 5:
-                    await boto_crud_call(
-                        iam_client.delete_policy_version,
-                        PolicyArn=policy_arn,
-                        VersionId=get_oldest_policy_version_id(policy_versions),
-                    )
-
-            log_str = f"{log_str} Updating PolicyDocument..."
-            await boto_crud_call(
-                iam_client.create_policy_version,
-                PolicyArn=policy_arn,
-                PolicyDocument=json.dumps(template_policy_document),
-            )
+                return await plugin_apply_wrapper(apply_awaitable, proposed_changes)
 
         log.info(log_str, **log_params)
     return response
+
+
+async def new_policy_version(
+    iam_client, policy_arn, template_policy_document, policy_drift, log_str, log_params
+):
+    if policy_drift:
+        policy_versions = await list_managed_policy_versions(iam_client, policy_arn)
+        if len(policy_versions) == 5:
+            await boto_crud_call(
+                iam_client.delete_policy_version,
+                PolicyArn=policy_arn,
+                VersionId=get_oldest_policy_version_id(policy_versions),
+            )
+
+    log_str = f"{log_str} Updating PolicyDocument..."
+    await boto_crud_call(
+        iam_client.create_policy_version,
+        PolicyArn=policy_arn,
+        PolicyDocument=json.dumps(template_policy_document),
+    )
+    log.info(log_str, **log_params)
 
 
 async def apply_managed_policy_tags(
@@ -217,47 +234,49 @@ async def apply_managed_policy_tags(
         tag["Key"] for tag in existing_tags if not template_tag_map.get(tag["Key"])
     ]:
         log_str = "Stale tags discovered."
-        response.append(
+        proposed_changes = [
             ProposedChange(
                 change_type=ProposedChangeType.DETACH,
                 attribute="tags",
                 change_summary={"TagKeys": tags_to_remove},
             )
-        )
+        ]
+        response.extend(proposed_changes)
+
         if not iambic_import_only:
             log_str = f"{log_str} Removing tags..."
-            tasks.append(
-                boto_crud_call(
-                    iam_client.untag_policy,
-                    PolicyArn=policy_arn,
-                    TagKeys=tags_to_remove,
-                )
+            apply_awaitable = boto_crud_call(
+                iam_client.untag_policy,
+                PolicyArn=policy_arn,
+                TagKeys=tags_to_remove,
             )
+            tasks.append(plugin_apply_wrapper(apply_awaitable, proposed_changes))
         log.info(log_str, tags=tags_to_remove, **log_params)
 
     if tags_to_apply:
         log_str = "New tags discovered in AWS."
-        for tag in tags_to_apply:
-            response.append(
-                ProposedChange(
-                    change_type=ProposedChangeType.ATTACH,
-                    attribute="tags",
-                    new_value=tag,
-                )
+        proposed_changes = [
+            ProposedChange(
+                change_type=ProposedChangeType.ATTACH,
+                attribute="tags",
+                new_value=tag,
             )
+            for tag in tags_to_apply
+        ]
+        response.extend(proposed_changes)
         if context.execute:
             log_str = f"{log_str} Adding tags..."
-            tasks.append(
-                boto_crud_call(
-                    iam_client.tag_policy, PolicyArn=policy_arn, Tags=tags_to_apply
-                )
+            apply_awaitable = boto_crud_call(
+                iam_client.tag_policy, PolicyArn=policy_arn, Tags=tags_to_apply
             )
+            tasks.append(plugin_apply_wrapper(apply_awaitable, proposed_changes))
         log.info(log_str, tags=tags_to_apply, **log_params)
 
     if tasks:
-        await asyncio.gather(*tasks)
-
-    return response
+        results: list[list[ProposedChange]] = await asyncio.gather(*tasks)
+        return list(chain.from_iterable(results))
+    else:
+        return response
 
 
 async def get_managed_policy_across_accounts(


### PR DESCRIPTION
Support partial failure in AWS Managed policy resources

How to test?

1. Modify a managed policy template's definition (good change) and add a bad tag key with '*'
2. commit the template change
3. iambic git-apply, check proposed_changes.yaml that the good change propagates and bad change is indicated in the proposed_changes.yaml and exit code is -1

Note: I discovered the delete managed policy does not handling existing policy version. It's kinda complicated fix, so I didn't jam it into this PR.