### PR TITLE
EN-1771 Implement traceback in the git plan/apply workflow

### DIFF
--- a/iambic/plugins/v0_1_0/github/github.py
+++ b/iambic/plugins/v0_1_0/github/github.py
@@ -8,6 +8,7 @@ import shutil
 import sys
 import tempfile
 import time
+import traceback
 from enum import Enum
 from typing import Any, Callable
 from urllib.parse import urlparse
@@ -377,10 +378,11 @@ def handle_iambic_git_apply(
         return HandleIssueCommentReturnCode.MERGED
 
     except Exception as e:
-        log.error("fault", exception=str(e))
+        captured_traceback = traceback.format_exc()
+        log.error("fault", exception=captured_traceback)
         pull_request.create_issue_comment(
-            "exception during git-apply is {0} \n {1}".format(
-                pull_request.mergeable_state, e
+            "exception during apply is {0} \n ```{1}```".format(
+                pull_request.mergeable_state, captured_traceback
             )
         )
         raise e
@@ -418,10 +420,11 @@ def handle_iambic_git_plan(
         copy_data_to_data_directory()
         return HandleIssueCommentReturnCode.PLANNED
     except Exception as e:
-        log.error("fault", exception=str(e))
+        captured_traceback = traceback.format_exc()
+        log.error("fault", exception=captured_traceback)
         pull_request.create_issue_comment(
-            "exception during git-plan is {0} \n {1}".format(
-                pull_request.mergeable_state, e
+            "exception during plan is {0} \n ```{1}```".format(
+                pull_request.mergeable_state, captured_traceback
             )
         )
         raise e
@@ -442,10 +445,11 @@ def handle_pull_request(github_client: github.Github, context: dict[str, Any]) -
     try:
         pull_request.create_issue_comment("iambic git-plan")
     except Exception as e:
-        log.error("fault", exception=str(e))
+        captured_traceback = traceback.format_exc()
+        log.error("fault", exception=captured_traceback)
         pull_request.create_issue_comment(
-            "exception during pull-request is {0} \n {1}".format(
-                pull_request.mergeable_state, e
+            "exception during pull-request is {0} \n ```{1}```".format(
+                pull_request.mergeable_state, captured_traceback
             )
         )
         raise e

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import traceback
 
 import pytest
 
@@ -22,6 +23,17 @@ async def test_async_gather_behavior():
     assert len(results) == 2
     assert results[0] == "success"
     assert isinstance(results[1], Exception)
+
+
+def test_exception_traceback_behavior():
+    def raise_exception():
+        raise Exception("hello")
+
+    try:
+        raise_exception()
+    except Exception:
+        captured_message = traceback.format_exc()
+        assert "raise_exception" in captured_message
 
 
 def test_valid_characters():


### PR DESCRIPTION
What's changed.
* During git plan/apply, if it encounters an exception, format the exception with traceback when posting back a comment

How'd I test?
I added unit tests to check the argument to post_issue_comment includes `Traceback`