### PR TITLE
Implement line number hinting when encounter bad templates

### DIFF
--- a/iambic/core/parser.py
+++ b/iambic/core/parser.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import json
+import traceback
+from typing import Union
+
 from pydantic import ValidationError
 from ruamel.yaml.scanner import ScannerError
 
@@ -7,6 +11,58 @@ from iambic.config.templates import TEMPLATES
 from iambic.core.logger import log
 from iambic.core.models import BaseTemplate
 from iambic.core.utils import transform_comments, yaml
+
+
+# line number is zero-th based
+def resolve_location(loc_list: list[str], ruamel_dict) -> Union[None, int]:
+    local_loc_list = loc_list
+    local_ruamel_dict = ruamel_dict
+    last_known_location = None
+    if len(local_loc_list) == 0:
+        return None
+    while len(local_loc_list) > 1:
+        lookup_key = local_loc_list[0]
+        peek_ruamel_dict = ruamel_dict.get(str.lower(lookup_key), None)
+        if peek_ruamel_dict is None:
+            return None
+        else:
+            last_known_location = local_ruamel_dict.lc.data.get(str.lower(lookup_key))
+        local_ruamel_dict = ruamel_dict.get(str.lower(lookup_key), None)
+        local_loc_list = loc_list[1:]
+    line_info = local_ruamel_dict.lc.data.get(str.lower(local_loc_list[0]), None)
+    if line_info is None:
+        if last_known_location is not None:
+            return last_known_location[0]
+        else:
+            return None
+    else:
+        return line_info[0]
+
+
+def format_validation_error(err, ruamel_dict):
+    try:
+        errors = json.loads(err.json())
+        lines = []
+        for error in errors:
+            if error["type"] == "value_error.missing":
+                line_num = resolve_location(error["loc"], ruamel_dict)
+                canonical_key = str.lower(".".join(error["loc"]))
+                if line_num is not None:
+                    missing_key = str.lower(error["loc"][-1])
+                    lines.append(
+                        f"Missing Field: {missing_key} around closest to line {line_num+1}"
+                    )
+                else:
+                    lines.append(f"Missing Field: {canonical_key}")
+            if error["type"].startswith("type_error"):
+                line_num = resolve_location(error["loc"], ruamel_dict)
+                canonical_key = str.lower(".".join(error["loc"]))
+                lines.append(f"line {line_num+1}: {canonical_key} has type issue")
+        return "\n".join(lines)
+    except Exception:
+        # need to still return something to avoid to downstream formatting
+        captured_traceback = traceback.format_exc()
+        return f"Unable to compute hints: {captured_traceback}"
 
 
 def load_templates(
@@ -35,8 +91,12 @@ def load_templates(
                 "Invalid template structure", file_path=template_path, error=repr(err)
             )
             if raise_validation_err:
+                if isinstance(err, ValidationError):
+                    hints = format_validation_error(err, template_dict)
+                else:
+                    hints = ""
                 raise ValueError(
-                    f"{template_path} template has validation error"
+                    f"{template_path} template has validation error. \n{hints}"
                 ) from err
 
     return templates

--- a/test/core/test_parser.py
+++ b/test/core/test_parser.py
@@ -14,6 +14,10 @@ from iambic.core.parser import load_templates
 
 MISSING_REQUIRED_FIELDS_TEMPLATE_YAML = """template_type: NOQ::Example::LocalDatabase
 expires_at: tomorrow
+name:
+  - foo
+properties:
+  foo: bar
 """
 
 MALFORMED_YAML = """template_type: NOQ::Example::LocalDatabase


### PR DESCRIPTION
What is changed?
* take the ValidationException from pedantic and parse it with information from ruamel line count

How'd I test?
* I use a debugger to examine the exception information returned from the existing unit test.

How'd to test locally?

Add a bad template and see the information.

```
Traceback (most recent call last):

  File "/Users/stevenmoy/noqdev/iambic/iambic/core/parser.py", line 48, in load_templates
    templates.append(template_cls(file_path=template_path, **template_dict))

  File "/Users/stevenmoy/noqdev/iambic/iambic/core/models.py", line 60, in __init__
    super().__init__(*args, **kwargs)

  File "pydantic/main.py", line 342, in pydantic.main.BaseModel.__init__

pydantic.error_wrappers.ValidationError: 2 validation errors for ExampleLocalDatabaseTemplate
Properties -> Name
  field required (type=value_error.missing)
Name
  str type expected (type=type_error.str)


The above exception was the direct cause of the following exception:


Traceback (most recent call last):

  File "/Users/stevenmoy/noqdev/iambic/test/core/test_parser.py", line 111, in test_missing_required_fields_templates
    template_instances = load_templates(templates, raise_validation_err=True)

  File "/Users/stevenmoy/noqdev/iambic/iambic/core/parser.py", line 63, in load_templates
    raise ValueError(

ValueError: /var/folders/52/0fv0dv9s06dbps6g9td_bybh0000gn/T/iambic_test_temp_templates_directorytrnxnf5f/resources/example/bad_template.yaml template has validation error. 
Missing Field: properties.name
line 3: name has type issue
```