### PR TITLE
Refactor docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM public.ecr.aws/o4z3c2v2/iambic_container_base:1.0 as runtime-layer
+FROM public.ecr.aws/o4z3c2v2/iambic_container_base:1.0
+
+ARG FUNCTION_DIR="/app"
+WORKDIR ${FUNCTION_DIR}
 
 COPY --chown=iambic:iambic iambic/ ${FUNCTION_DIR}/iambic
 COPY --chown=iambic:iambic poetry.lock ${FUNCTION_DIR}/poetry.lock
@@ -10,13 +13,10 @@ RUN adduser --system --user-group --home ${FUNCTION_DIR} iambic \
  && chmod -R 755 ${FUNCTION_DIR} \
  && chmod -R 777 ${FUNCTION_DIR}
 
-
 RUN pip install poetry setuptools pip --upgrade \
  && poetry install \
  && poetry build \
  && pip install awslambdaric
-
-COPY --from=runtime-layer ${FUNCTION_DIR}/dist ${FUNCTION_DIR}/dist
 
 RUN pip install ${FUNCTION_DIR}/dist/*.whl \
  && rm -rf ${FUNCTION_DIR}/dist

--- a/Dockerfile.base_image
+++ b/Dockerfile.base_image
@@ -11,23 +11,21 @@ ARG PYTHON_VERSION
 # install python
 RUN yum update -y \
  && yum groupinstall "Development Tools" -y \
- && yum install libffi-devel bzip2-devel wget openssl openssl-devel sqlite-devel coreutils -y \
- && yum install git shadow-utils -y
+ && yum install libffi-devel bzip2-devel wget openssl openssl-devel sqlite-devel coreutils -y
 
 # breaking up this line to test building python using all the cores
 RUN wget https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz \
  && tar -xf Python-${PYTHON_VERSION}.tgz \
  && cd Python-${PYTHON_VERSION}/  \
- && ./configure --enable-optimizations --enable-loadable-sqlite-extensions --enable-shared \
- && make -j${NPROC} python \
- && make install
-
-RUN ln -s /Python-${PYTHON_VERSION}/python /usr/bin/python \
+ && ./configure --enable-optimizations --enable-loadable-sqlite-extensions \
+ && make install && ln -s /Python-${PYTHON_VERSION}/python /usr/bin/python \
  && python -m ensurepip --upgrade \
  && python -m pip install --upgrade pip
 
 
 FROM ${ARCH}amazonlinux:${AWS_LINUX_VERSION} as build-layer
+
+RUN yum install git shadow-utils -y
 
 # copy python to the necessary locations
 ARG PYTHON_VERSION


### PR DESCRIPTION
break the python building into the base image

testing:
* I push the resulting image to `testing` tag . I am able to use the lambda app with the resulting image. still need to confirm the resulting image work with the install script.