### PR TITLE
Set Github App entrypoint

### DIFF
--- a/deployment/github_app/main.tf
+++ b/deployment/github_app/main.tf
@@ -76,6 +76,7 @@ resource "aws_lambda_function" "iambic_github_app" {
   source_code_hash = trimprefix(data.aws_ecr_image.iambic_private_ecr.id, "sha256:")
 
   image_config {
+    entry_point = ["python", "-m", "awslambdaric"]
     command = ["iambic.plugins.v0_1_0.github.github_app.run_handler"]
   }
 


### PR DESCRIPTION
What is changed?
Previously Lambda App does not explicitly set entry point. To support the most recent docker image (which has entry point to `python iambic.main`), it needs to set its own entry point.

How to test?
Deployed the lambda app to iambic-templates-itest and confirm it's running. see https://github.com/noqdev/iambic-templates-itest/pull/272. 