### PR TITLE
Improve verbage

### DIFF
--- a/iambic/core/parser.py
+++ b/iambic/core/parser.py
@@ -50,14 +50,14 @@ def format_validation_error(err, ruamel_dict):
                 if line_num is not None:
                     missing_key = str.lower(error["loc"][-1])
                     lines.append(
-                        f"Missing Field: {missing_key} around closest to line {line_num+1}"
+                        f"Missing Field: `{missing_key}` around line {line_num+1}"
                     )
                 else:
-                    lines.append(f"Missing Field: {canonical_key}")
+                    lines.append(f"Missing Field: `{canonical_key}`")
             if error["type"].startswith("type_error"):
                 line_num = resolve_location(error["loc"], ruamel_dict)
                 canonical_key = str.lower(".".join(error["loc"]))
-                lines.append(f"line {line_num+1}: {canonical_key} has type issue")
+                lines.append(f"line {line_num+1}: `{canonical_key}` has type issue")
         return "\n".join(lines)
     except Exception:
         # need to still return something to avoid to downstream formatting


### PR DESCRIPTION
Example:

```
ValueError: /var/folders/52/0fv0dv9s06dbps6g9td_bybh0000gn/T/iambic_test_temp_templates_directorydrq7naca/resources/example/bad_template.yaml template has validation error. 
Missing Field: `name` around line 5
line 3: `name` has type issue
```