### PR TITLE
EN-1813 push deleted commits back into PR

### DIFF
--- a/iambic/core/models.py
+++ b/iambic/core/models.py
@@ -491,7 +491,9 @@ class BaseTemplate(
         log.info("Deleting template file", file_path=self.file_path)
         try:
             repo = Repo(self.file_path, search_parent_directories=True)
-            repo.index.remove([self.file_path], working_tree=True)
+            # why force=True? Expire could have modified the local contents
+            # without force=True, git rm would not be able to remove the file
+            repo.index.remove([self.file_path], working_tree=True, force=True)
         except Exception as e:
             log.error(
                 "Unable to remove file from local Git repo. Deleting manually",

--- a/iambic/plugins/v0_1_0/example/local_file/models.py
+++ b/iambic/plugins/v0_1_0/example/local_file/models.py
@@ -9,6 +9,8 @@ from iambic.core.models import (
     BaseModel,
     BaseTemplate,
     ExpiryModel,
+    ProposedChange,
+    ProposedChangeType,
     TemplateChangeDetails,
 )
 
@@ -53,5 +55,10 @@ class ExampleLocalFileTemplate(BaseTemplate, ExpiryModel):
             resource_type=self.template_type,
             template_path=self.file_path,
         )
-        template_changes.proposed_changes = []
+        if self.delete:
+            template_changes.proposed_changes = [
+                ProposedChange(change_type=ProposedChangeType.DELETE)
+            ]
+        else:
+            template_changes.proposed_changes = []
         return template_changes

--- a/iambic/plugins/v0_1_0/github/github.py
+++ b/iambic/plugins/v0_1_0/github/github.py
@@ -333,12 +333,15 @@ def handle_iambic_git_apply(
     os.environ["IAMBIC_SESSION_NAME"] = session_name
 
     try:
+        # merge_sha is used when we trigger a merge
+        merge_sha = pull_request.merge_commit_sha
+
         repo = prepare_local_repo(
             repo_url, get_lambda_repo_path(), pull_request_branch_name
         )
-
-        # merge_sha is used when we trigger a merge
-        merge_sha = pull_request.merge_commit_sha
+        # local_sha_before_git_apply may not match the initial merge
+        # sha because we apply the PR to local checkout tracking branch
+        local_sha_before_git_apply = repo.head.commit.hexsha
 
         if proposed_changes_path:
             # code smell to have to change a module variable
@@ -355,15 +358,19 @@ def handle_iambic_git_apply(
         diff_list = repo.head.commit.diff()
         if len(diff_list) > 0:
             repo.git.commit("-m", COMMIT_MESSAGE_FOR_GIT_APPLY_ABSOLUTE_TIME)
+        else:
+            log.debug("git_apply did not introduce additional changes")
+
+        local_sha_after_git_apply = repo.head.commit.hexsha
+        if local_sha_before_git_apply != local_sha_after_git_apply:
+            # signal changes due to git-apply
             repo.remotes.origin.push(
                 refspec=f"HEAD:{pull_request_branch_name}"
             ).raise_if_error()
-            log_params = {"sha": repo.head.commit.hexsha}
+            log_params = {"sha": local_sha_after_git_apply}
             log.info("git-apply new sha is", **log_params)
             # update merge sha because we add new commits to pull request
-            merge_sha = repo.head.commit.hexsha
-        else:
-            log.debug("git_apply did not introduce additional changes")
+            merge_sha = local_sha_after_git_apply
 
         post_result_as_pr_comment(
             pull_request, context, "git-apply", proposed_changes_path


### PR DESCRIPTION
What has changed?
* If git_apply has deleted cloud resources because of deleted file, push changes back into PR
* add delete support in the example plugin for testing

How did I test?
* Add unit test to check git commits are added back local repo
* Add unit test to check changes are pushed back to remote