### PR TITLE
EN-1809 Use pull_request.head.sha

### DIFF
--- a/iambic/plugins/v0_1_0/github/github.py
+++ b/iambic/plugins/v0_1_0/github/github.py
@@ -334,7 +334,7 @@ def handle_iambic_git_apply(
 
     try:
         # merge_sha is used when we trigger a merge
-        merge_sha = pull_request.merge_commit_sha
+        merge_sha = pull_request.head.sha
 
         repo = prepare_local_repo(
             repo_url, get_lambda_repo_path(), pull_request_branch_name


### PR DESCRIPTION
Well, this is embarrassing. I completely misunderstood the meaning of merge_commit_sha and head.sha

head.sha is what's the head reference by the PR (on the remote branch that has the changes in the PR)

merge_commit_sha actually means many different things across the state of the PR. 
1. before merging the PR, merge_commit_sha points to the `test` merge attempt by Github when it tests whether the request is mergeable.
2. after merging the PR, it's the actual merge_commit_sha performed.

We really want pull-request.head.sha because that's what pull-request.merge operations checks against.

How'd I test? 
I build the docker image and tested with https://github.com/noqdev/iambic-templates-itest/pull/274