### PR TITLE
EN-1832: Sanitize Account Names

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,18 +17,6 @@
             "justMyCode": false
         },
         {
-            "name": "Iambic: Apply All Templates",
-            "type": "python",
-            "request": "launch",
-            "module": "iambic.main",
-            "console": "integratedTerminal",
-            "envFile": "${workspaceFolder}/.env",
-            "args": [
-                "apply",
-            ],
-            "justMyCode": true
-        },
-        {
             "name": "Iambic: Apply Specific Template",
             "type": "python",
             "request": "launch",
@@ -36,9 +24,6 @@
             "console": "integratedTerminal",
             "args": [
                 "apply",
-
-                "--template",
-                "${env:IAMBIC_TEMPLATE_PATH}"
             ],
             "envFile": "${workspaceFolder}/.env",
             "justMyCode": true

--- a/iambic/main.py
+++ b/iambic/main.py
@@ -7,7 +7,6 @@ import sys
 import warnings
 
 import click
-
 from iambic.config.dynamic_config import Config, init_plugins, load_config
 from iambic.config.utils import (
     check_and_update_resource_limit,
@@ -27,6 +26,10 @@ from iambic.request_handler.git_plan import plan_git_changes
 warnings.filterwarnings("ignore", category=FutureWarning, module="botocore.client")
 
 os.environ.setdefault("IAMBIC_REPO_DIR", str(pathlib.Path.cwd()))
+
+IAMBIC_TEMPLATE_PATHS = []
+if configured_template := os.getenv("IAMBIC_TEMPLATE_PATH"):
+    IAMBIC_TEMPLATE_PATHS = [configured_template]
 
 
 def output_proposed_changes(
@@ -58,6 +61,7 @@ def cli():
     required=False,
     multiple=True,
     type=click.Path(exists=True),
+    default=IAMBIC_TEMPLATE_PATHS,
     help="The template file path(s) to expire. Example: ./aws/roles/engineering.yaml",
 )
 @click.option(
@@ -147,6 +151,7 @@ def run_clone_repos(repo_dir: str = str(pathlib.Path.cwd())):
     required=False,
     multiple=True,
     type=click.Path(exists=True),
+    default=IAMBIC_TEMPLATE_PATHS,
     help="The template file path(s) to apply. Example: ./aws/roles/engineering.yaml",
 )
 @click.option(
@@ -264,6 +269,7 @@ def run_git_apply(
     required=False,
     multiple=True,
     type=click.Path(exists=True),
+    default=IAMBIC_TEMPLATE_PATHS,
     help="The template file path(s) to apply. Example: ./resources/aws/roles/engineering.yaml",
 )
 @click.option(
@@ -363,6 +369,7 @@ def import_(repo_dir: str):
     required=False,
     multiple=True,
     type=click.Path(exists=True),
+    default=IAMBIC_TEMPLATE_PATHS,
     help="The template file path(s) to expire. Example: ./aws/roles/engineering.yaml",
 )
 @click.option(

--- a/iambic/plugins/v0_1_0/aws/iam/group/template_generation.py
+++ b/iambic/plugins/v0_1_0/aws/iam/group/template_generation.py
@@ -7,7 +7,6 @@ from collections import defaultdict
 from typing import TYPE_CHECKING
 
 import aiofiles
-
 from iambic.core import noq_json as json
 from iambic.core.logger import log
 from iambic.core.template_generation import (
@@ -32,7 +31,10 @@ from iambic.plugins.v0_1_0.aws.iam.group.utils import (
     list_groups,
 )
 from iambic.plugins.v0_1_0.aws.models import AWSAccount
-from iambic.plugins.v0_1_0.aws.utils import get_aws_account_map, normalize_boto3_resp
+from iambic.plugins.v0_1_0.aws.utils import (
+    get_sanitized_aws_account_map,
+    normalize_boto3_resp,
+)
 
 if TYPE_CHECKING:
     from iambic.plugins.v0_1_0.aws.iambic_plugin import AWSConfig
@@ -299,7 +301,7 @@ async def generate_aws_group_templates(
     base_output_dir: str,
     group_messages: list[GroupMessageDetails] = None,
 ):
-    aws_account_map = await get_aws_account_map(config)
+    aws_account_map = await get_sanitized_aws_account_map(config)
     existing_template_map = await get_existing_template_map(
         base_output_dir, AWS_IAM_GROUP_TEMPLATE_TYPE
     )

--- a/iambic/plugins/v0_1_0/aws/iam/policy/template_generation.py
+++ b/iambic/plugins/v0_1_0/aws/iam/policy/template_generation.py
@@ -7,7 +7,6 @@ from collections import defaultdict
 from typing import TYPE_CHECKING
 
 import aiofiles
-
 from iambic.core import noq_json as json
 from iambic.core.logger import log
 from iambic.core.template_generation import (
@@ -29,7 +28,10 @@ from iambic.plugins.v0_1_0.aws.iam.policy.utils import (
     list_managed_policies,
 )
 from iambic.plugins.v0_1_0.aws.models import AWSAccount
-from iambic.plugins.v0_1_0.aws.utils import get_aws_account_map, normalize_boto3_resp
+from iambic.plugins.v0_1_0.aws.utils import (
+    get_sanitized_aws_account_map,
+    normalize_boto3_resp,
+)
 
 if TYPE_CHECKING:
     from iambic.plugins.v0_1_0.aws.iambic_plugin import AWSConfig
@@ -290,7 +292,7 @@ async def generate_aws_managed_policy_templates(
     base_output_dir: str,
     managed_policy_messages: list[ManagedPolicyMessageDetails] = None,
 ):
-    aws_account_map = await get_aws_account_map(config)
+    aws_account_map = await get_sanitized_aws_account_map(config)
     existing_template_map = await get_existing_template_map(
         base_output_dir, "NOQ::IAM::ManagedPolicy"
     )

--- a/iambic/plugins/v0_1_0/aws/iam/role/template_generation.py
+++ b/iambic/plugins/v0_1_0/aws/iam/role/template_generation.py
@@ -7,7 +7,6 @@ from collections import defaultdict
 from typing import TYPE_CHECKING
 
 import aiofiles
-
 from iambic.core import noq_json as json
 from iambic.core.logger import log
 from iambic.core.template_generation import (
@@ -34,7 +33,10 @@ from iambic.plugins.v0_1_0.aws.iam.role.utils import (
     list_roles,
 )
 from iambic.plugins.v0_1_0.aws.models import AWSAccount
-from iambic.plugins.v0_1_0.aws.utils import get_aws_account_map, normalize_boto3_resp
+from iambic.plugins.v0_1_0.aws.utils import (
+    get_sanitized_aws_account_map,
+    normalize_boto3_resp,
+)
 
 if TYPE_CHECKING:
     from iambic.plugins.v0_1_0.aws.iambic_plugin import AWSConfig
@@ -393,7 +395,8 @@ async def generate_aws_role_templates(
     base_output_dir: str,
     role_messages: list[RoleMessageDetails] = None,
 ):
-    aws_account_map = await get_aws_account_map(config)
+    aws_account_map = await get_sanitized_aws_account_map(config)
+
     existing_template_map = await get_existing_template_map(
         base_output_dir, AWS_IAM_ROLE_TEMPLATE_TYPE
     )

--- a/iambic/plugins/v0_1_0/aws/iam/user/template_generation.py
+++ b/iambic/plugins/v0_1_0/aws/iam/user/template_generation.py
@@ -7,7 +7,6 @@ from collections import defaultdict
 from typing import TYPE_CHECKING
 
 import aiofiles
-
 from iambic.core import noq_json as json
 from iambic.core.logger import log
 from iambic.core.template_generation import (
@@ -34,7 +33,10 @@ from iambic.plugins.v0_1_0.aws.iam.user.utils import (
     list_users,
 )
 from iambic.plugins.v0_1_0.aws.models import AWSAccount
-from iambic.plugins.v0_1_0.aws.utils import get_aws_account_map, normalize_boto3_resp
+from iambic.plugins.v0_1_0.aws.utils import (
+    get_sanitized_aws_account_map,
+    normalize_boto3_resp,
+)
 
 if TYPE_CHECKING:
     from iambic.plugins.v0_1_0.aws.iambic_plugin import AWSConfig
@@ -372,7 +374,7 @@ async def generate_aws_user_templates(
     base_output_dir: str,
     user_messages: list[UserMessageDetails] = None,
 ):
-    aws_account_map = await get_aws_account_map(config)
+    aws_account_map = await get_sanitized_aws_account_map(config)
     existing_template_map = await get_existing_template_map(
         base_output_dir, AWS_IAM_USER_TEMPLATE_TYPE
     )

--- a/iambic/plugins/v0_1_0/aws/identity_center/permission_set/models.py
+++ b/iambic/plugins/v0_1_0/aws/identity_center/permission_set/models.py
@@ -16,7 +16,12 @@ from iambic.core.models import (
     ProposedChangeType,
     TemplateChangeDetails,
 )
-from iambic.core.utils import aio_wrapper, evaluate_on_provider, plugin_apply_wrapper
+from iambic.core.utils import (
+    aio_wrapper,
+    evaluate_on_provider,
+    plugin_apply_wrapper,
+    sanitize_string,
+)
 from iambic.plugins.v0_1_0.aws.iam.policy.models import PolicyStatement
 from iambic.plugins.v0_1_0.aws.identity_center.permission_set.utils import (
     apply_account_assignments,
@@ -727,10 +732,14 @@ class AWSIdentityCenterPermissionSetTemplate(
             resource_type=self.resource_type, resource_id=self.resource_id
         )
 
+        valid_characters_re = r"[\w_+=,.@-]"
+
         for account in config.accounts:
             if not account.identity_center_details:
                 continue
-
+            account.account_name = sanitize_string(
+                account.account_name, valid_characters_re
+            )
             if evaluate_on_provider(self, account, context):
                 if context.execute:
                     log_str = "Applying changes to resource."

--- a/iambic/plugins/v0_1_0/aws/identity_center/permission_set/template_generation.py
+++ b/iambic/plugins/v0_1_0/aws/identity_center/permission_set/template_generation.py
@@ -31,7 +31,10 @@ from iambic.plugins.v0_1_0.aws.identity_center.permission_set.utils import (
     get_permission_set_users_and_groups,
 )
 from iambic.plugins.v0_1_0.aws.models import AWSAccount
-from iambic.plugins.v0_1_0.aws.utils import get_aws_account_map, normalize_boto3_resp
+from iambic.plugins.v0_1_0.aws.utils import (
+    get_sanitized_aws_account_map,
+    normalize_boto3_resp,
+)
 
 if TYPE_CHECKING:
     from iambic.plugins.v0_1_0.aws.iambic_plugin import AWSConfig
@@ -371,7 +374,7 @@ async def generate_aws_permission_set_templates(
     base_output_dir: str,
     permission_set_messages: list[PermissionSetMessageDetails] = None,
 ):
-    aws_account_map = await get_aws_account_map(config)
+    aws_account_map = await get_sanitized_aws_account_map(config)
     existing_template_map = await get_existing_template_map(
         base_output_dir, AWS_IDENTITY_CENTER_PERMISSION_SET_TEMPLATE_TYPE
     )

--- a/iambic/plugins/v0_1_0/aws/utils.py
+++ b/iambic/plugins/v0_1_0/aws/utils.py
@@ -8,10 +8,9 @@ from typing import TYPE_CHECKING, Optional, Union
 
 import boto3
 from botocore.exceptions import ClientError, NoCredentialsError
-
 from iambic.core.iambic_enum import IambicManaged
 from iambic.core.logger import log
-from iambic.core.utils import aio_wrapper, camel_to_snake
+from iambic.core.utils import aio_wrapper, camel_to_snake, sanitize_string
 
 if TYPE_CHECKING:
     from iambic.plugins.v0_1_0.aws.iambic_plugin import AWSConfig
@@ -268,6 +267,16 @@ async def get_aws_account_map(config: AWSConfig) -> dict:
         aws_account_map[aws_account.account_id] = aws_account
 
     return aws_account_map
+
+
+async def get_sanitized_aws_account_map(config: AWSConfig) -> dict:
+    aws_account_map = await get_aws_account_map(config)
+    sanitized_aws_account_map = {}
+    valid_characters_re = r"[\w_+=,.@-]"
+    for k, v in aws_account_map.items():
+        v.account_name = sanitize_string(v.account_name, valid_characters_re)
+        sanitized_aws_account_map[k] = v
+    return sanitized_aws_account_map
 
 
 async def create_assume_role_session(


### PR DESCRIPTION
This PR sanitizes the account name before importing templates or applying a template, making imports and applies to non-standard account names (for example with spaces or special characters) more reproducible

@Will-NOQ - This PR doesn't quite work and it's not the right way to handle it, I could use your help here. Basically, we're currently sanitizing role names before we write them. So if I have a role name called {{account_name}}_readonly and account_name = "Noq Audit", then the role name becomes "NoqAudit_readonly" since a space is an invalid character.

When this is imported, it is not recognized as  {{account_name}}_readonly because `NoqAudit` != `Noq Audit`. 

I think the correct thing to do here is compare the sanitized account name to whatever exists on the role. Here are different approaches we can think about, and there may be more:

1. Add data that won't be saved to Noq::Core::Config YAML for `safe_name` or something, figure this out during runtime, and use it for all account adds and removes. `account.safe_name`. The assumption here is that the same safe pattern can be used across roles, groups, identity center permission sets, etc. 
2. Just figure out the sanitized name in runtime at the different locations where we need it. It is more verbose, but we can change the regex for what is deemed "safe"
3. ... Something else?

The current code isn't valid because it changes the account map dict so it looks like `NoqAudit` is the real account name. this means `included_accounts` would need to include `NoqAudit` and not `NoqAudit` in order to consider a role added on an account.