### PR TITLE
EN-1824 EN-1820: Clear keyboard buffer before questionary prompts

### DIFF
--- a/iambic/config/wizard.py
+++ b/iambic/config/wizard.py
@@ -98,7 +98,7 @@ def clear_stdin_buffer():
 
 
 def monkeypatch_questionary():
-    """Monkeypatches the questionary functions to clear stdin buffer."""
+    """Monkeypatches the questionary functions in use to clear stdin buffer."""
     original_functions = {
         "prompt": questionary.prompt,
         "ask": questionary.Question.ask,


### PR DESCRIPTION
- [X] Add a function to clear the keyboard buffer instead of passing it on to the next prompt
- [X] Monkeypatch Questionary to ensure we clear keyboard buffer before prompting
- [X] Retry when an invalid AWS profile is in use
- [X] Simplify some question verbiage