### PR TITLE
EN-1793: Clean yarn cache to resolve AWS Inspector/Vanta vulns

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,8 @@ WORKDIR ${FUNCTION_DIR}/docs/web
 RUN yarn \
  && yarn install --frozen-lockfile
 
+RUN yarn cache clean
+
 WORKDIR ${FUNCTION_DIR}
 
 ENV PYTHONPATH=${PYTHONPATH}:${FUNCTION_DIR}/.local/lib/python3.11/site-packages


### PR DESCRIPTION
This PR cleans the `yarn cache` after running `yarn` in Docker in an attempt to clean up a large number of AWS Inspector detections on the cache:

![image](https://user-images.githubusercontent.com/7538233/222990266-3a0c51f6-c43e-4e30-a986-132cf65ef82a.png)
