### PR TITLE
Fix EN-1848 losing account_id templatized variables

### DIFF
--- a/iambic/plugins/v0_1_0/aws/iam/role/template_generation.py
+++ b/iambic/plugins/v0_1_0/aws/iam/role/template_generation.py
@@ -226,6 +226,22 @@ async def _account_id_to_role_map(role_refs):
     return account_id_to_role_map
 
 
+def calculate_import_preference(existing_template):
+    prefer_templatized = False
+    try:
+        if existing_template:
+            # this is expensive just to compute if
+            # the existing template is already bias toward templatized.
+            existing_template_in_str = existing_template.json()
+            prefer_templatized = "{{" in existing_template_in_str
+    except Exception as exc_info:
+        # We are willing to tolerate exception because
+        # we are calculating preference from possibly bad templates on disk
+        log_params = {"exc_info": str(exc_info)}
+        log.error("cannot calculate preference from existing template", **log_params)
+    return prefer_templatized
+
+
 async def create_templated_role(  # noqa: C901
     aws_account_map: dict[str, AWSAccount],
     role_name: str,
@@ -239,6 +255,11 @@ async def create_templated_role(  # noqa: C901
 
     min_accounts_required_for_wildcard_included_accounts = (
         config.min_accounts_required_for_wildcard_included_accounts
+    )
+
+    # calculate preference based on existing template
+    prefer_templatized = calculate_import_preference(
+        existing_template_map.get(role_name)
     )
 
     # Generate the params used for attribute creation
@@ -343,12 +364,18 @@ async def create_templated_role(  # noqa: C901
         role_template_properties[
             "assume_role_policy_document"
         ] = await group_dict_attribute(
-            aws_account_map, num_of_accounts, assume_role_policy_document_resources
+            aws_account_map,
+            num_of_accounts,
+            assume_role_policy_document_resources,
+            prefer_templatized=prefer_templatized,
         )
 
     if permissions_boundary_resources:
         role_template_properties["permissions_boundary"] = await group_dict_attribute(
-            aws_account_map, num_of_accounts, permissions_boundary_resources
+            aws_account_map,
+            num_of_accounts,
+            permissions_boundary_resources,
+            prefer_templatized=prefer_templatized,
         )
 
     if description_resources:
@@ -358,17 +385,29 @@ async def create_templated_role(  # noqa: C901
 
     if managed_policy_resources:
         role_template_properties["managed_policies"] = await group_dict_attribute(
-            aws_account_map, num_of_accounts, managed_policy_resources, False
+            aws_account_map,
+            num_of_accounts,
+            managed_policy_resources,
+            False,
+            prefer_templatized=prefer_templatized,
         )
 
     if inline_policy_document_resources:
         role_template_properties["inline_policies"] = await group_dict_attribute(
-            aws_account_map, num_of_accounts, inline_policy_document_resources, False
+            aws_account_map,
+            num_of_accounts,
+            inline_policy_document_resources,
+            False,
+            prefer_templatized=prefer_templatized,
         )
 
     if tag_resources:
         tags = await group_dict_attribute(
-            aws_account_map, num_of_accounts, tag_resources, True
+            aws_account_map,
+            num_of_accounts,
+            tag_resources,
+            True,
+            prefer_templatized=prefer_templatized,
         )
         if isinstance(tags, dict):
             tags = [tags]

--- a/test/core/test_template_generation.py
+++ b/test/core/test_template_generation.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 from typing import Union
 
+import pytest
 from iambic.core.models import AccessModelMixin, BaseModel
-from iambic.core.template_generation import merge_model
+from iambic.core.template_generation import group_dict_attribute, merge_model
 
 
 class SampleNote(BaseModel, AccessModelMixin):
@@ -80,4 +81,40 @@ def test_merge_model_mix_types_2():
     existing_model = SampleModel(note=[SampleNote(note="foo")])
     new_model = SampleModel(note="bar")
     updated_model: SampleModel = merge_model(new_model, existing_model, [])
-    assert updated_model.note.note == "bar"
+    assert (
+        updated_model.note[0].note == "bar"
+    )  # be careful why it's note[0] because existing list is type list on note
+
+
+@pytest.mark.asyncio
+async def test_group_dict_attribute(aws_accounts: list):
+    number_of_accounts = 1
+    target_account = aws_accounts[0]
+    target_account_id = target_account.account_id
+    account_resources = [
+        {
+            "account_id": target_account_id,
+            "resources": [{"resource_val": f"{target_account_id}"}],
+        }
+    ]
+    aws_accounts_map = {account.account_id: account for account in aws_accounts}
+
+    # validate the case if we don't prefer templatized resources
+    dict_attributes = await group_dict_attribute(
+        aws_accounts_map,
+        number_of_accounts,
+        account_resources,
+        False,
+        prefer_templatized=False,
+    )
+    assert dict_attributes[0] == target_account_id
+
+    # validate the case if we prefer templatized resources
+    dict_attributes = await group_dict_attribute(
+        aws_accounts_map,
+        number_of_accounts,
+        account_resources,
+        False,
+        prefer_templatized=True,
+    )
+    assert dict_attributes[0] == "{{account_id}}"

--- a/test/plugins/v0_1_0/aws/iam/role/test_template_generation.py
+++ b/test/plugins/v0_1_0/aws/iam/role/test_template_generation.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from iambic.plugins.v0_1_0.aws.iam.role.models import RoleProperties, RoleTemplate
+from iambic.plugins.v0_1_0.aws.iam.role.template_generation import (
+    calculate_import_preference,
+)
+
+
+def test_calculate_import_preference():
+    template = RoleTemplate(
+        file_path="foo", identifier="foo", properties=RoleProperties(role_name="foo")
+    )
+    templatized_preferrence = calculate_import_preference(template)
+    assert templatized_preferrence is False  # because we are not using variables
+
+    template = RoleTemplate(
+        file_path="foo",
+        identifier="{{account_name}} admin",
+        properties=RoleProperties(role_name="{{account_name}} admin"),
+    )
+    templatized_preferrence = calculate_import_preference(template)
+    assert templatized_preferrence is True  # because we are using variables
+
+    template = RoleTemplate(
+        file_path="foo",
+        identifier="{{account_name}} admin",
+        properties=RoleProperties(role_name="{{account_name}} admin"),
+    )
+    # break template
+    template.properties.description = lambda x: x  # lambda is not json-able
+    templatized_preferrence = calculate_import_preference(template)
+    assert templatized_preferrence is False  # because template preference crashed.


### PR DESCRIPTION
What has changed?
* allow caller to pass in prefer_templatized during templating attempts (this is because even when there is one account, if the local template is already templatized, we want to keep the templatized result)
** I only implement this for role. if the approach is acceptable, I will add the approach to other resources as well.
* fixed a mix case document merging when existing document implement both the access model and is list and the incoming model is a str primitive.

How'd I test? 
* add unit test
* run import to see what's changed.