### PR TITLE
EN-1852 Strongly prefer templatized version of templates

### DIFF
--- a/iambic/core/template_generation.py
+++ b/iambic/core/template_generation.py
@@ -198,7 +198,7 @@ async def base_group_str_attribute(
 async def base_group_dict_attribute(
     aws_account_map: dict[str, AWSAccount],
     account_resources: list[dict],
-    prefer_templatized=False,
+    prefer_templatized=False,  # clarification that this keyword parameter has no impact at the moment
 ) -> list[dict]:
     """Groups an attribute that is a dict or list of dicts with matching aws_accounts
 
@@ -313,15 +313,17 @@ async def base_group_dict_attribute(
             elif len(resource_hashes) == 1:
                 resource_hash = resource_hashes[0]
             else:
-                if prefer_templatized:
-                    resource_hash = resource_hashes[
-                        -1
-                    ]  # take the last one because it's the templatized version
-                else:
-                    # Take priority over raw output
-                    resource_hash = [
-                        rv for rv in resource_hashes if "{{" not in str(hash_map[rv])
-                    ][0]
+                # note about the decision we prefer post-templatized version
+                # we aggressively templatized the incoming information.
+                # a note for future reader: if you attempt to conditional decide
+                # to templatize or not, you have to be careful regarding greedy
+                # algorithm that does not arrive at the same termination state.
+                # Concretely, if a literal can both be repeated across accounts
+                # or templatized across accounts, greedy algorithm may reach
+                # different states.
+                resource_hash = resource_hashes[
+                    -1
+                ]  # take the last one because it's the templatized version
 
             grouped_resource_map[resource_hash] = {
                 "resource_val": hash_map[resource_hash],

--- a/test/core/test_template_generation.py
+++ b/test/core/test_template_generation.py
@@ -106,14 +106,14 @@ async def test_group_dict_attribute(aws_accounts: list):
     aws_accounts_map = {account.account_id: account for account in aws_accounts}
 
     # validate the case if we don't prefer templatized resources
-    dict_attributes = await group_dict_attribute(
-        aws_accounts_map,
-        number_of_accounts,
-        account_resources,
-        False,
-        prefer_templatized=False,
-    )
-    assert dict_attributes[0] == target_account_id
+    # dict_attributes = await group_dict_attribute(
+    #     aws_accounts_map,
+    #     number_of_accounts,
+    #     account_resources,
+    #     False,
+    #     prefer_templatized=False,
+    # )
+    # assert dict_attributes[0] == target_account_id
 
     # validate the case if we prefer templatized resources
     dict_attributes = await group_dict_attribute(


### PR DESCRIPTION
What's changed?
* when we group strings, we aggressively templatized the string regardless there are matches across aws account.
* when we group dictionary, we aggressively prefer the templatized version.

How'd test?
* for string, we added unit tests that check against repeated literal vs repeated templatized strings. we also added tests that enumerate the permutations of the incoming list and ensure incoming list order does not affect the grouped results.
* for dict, we are removing a previous test that allows for non-templatized version.

Import test:
* start with a new templates repo, import once and commit the generated templates.
* run import again to see there is no changes to the templates repo (assuming there is no cloud resource change sneak in while you are testing)