### PR TITLE
EN-1849 Fix access model mixin merging

### DIFF
--- a/test/plugins/v0_1_0/aws/iam/role/test_template_generation.py
+++ b/test/plugins/v0_1_0/aws/iam/role/test_template_generation.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from iambic.core.template_generation import merge_access_model_list
+from iambic.plugins.v0_1_0.aws.iam.policy.models import AssumeRolePolicyDocument
 from iambic.plugins.v0_1_0.aws.iam.role.models import RoleProperties, RoleTemplate
 from iambic.plugins.v0_1_0.aws.iam.role.template_generation import (
     calculate_import_preference,
@@ -30,3 +32,48 @@ def test_calculate_import_preference():
     template.properties.description = lambda x: x  # lambda is not json-able
     templatized_preferrence = calculate_import_preference(template)
     assert templatized_preferrence is False  # because template preference crashed.
+
+
+def test_merge_access_model_list_for_assume_role_policy_document(aws_accounts: list):
+
+    existing_assume_role_policy = AssumeRolePolicyDocument()
+    existing_assume_role_policy.included_accounts = [
+        account.account_name for account in [aws_accounts[0], aws_accounts[1]]
+    ]
+    existing_list = [existing_assume_role_policy]
+    for policy in existing_list:
+        # the testing condition only matters if resourced_id is not unique
+        assert policy.resource_id == ""
+
+    new_assume_role_policy = AssumeRolePolicyDocument()
+    new_assume_role_policy_include_accounts = [
+        account.account_name for account in [aws_accounts[2]]
+    ]
+    new_assume_role_policy.included_accounts = new_assume_role_policy_include_accounts
+    incoming_list = [
+        new_assume_role_policy,
+        existing_assume_role_policy.copy(deep=True),
+    ]
+    for policy in incoming_list:
+        # the testing condition only matters if resourced_id is not unique
+        assert policy.resource_id == ""
+
+    assert (
+        incoming_list[0] != existing_list[0]
+    )  # this is to ensure we trigger the condition
+    # in which incoming order has been mixed when we cannot relay on resource id
+
+    considered_accounts = aws_accounts[0:3]
+    merged_list = merge_access_model_list(
+        incoming_list, existing_list, considered_accounts
+    )
+    incoming_assume_role_document: AssumeRolePolicyDocument = merged_list[0]
+    assert (
+        incoming_assume_role_document.included_accounts
+        == new_assume_role_policy_include_accounts
+    )
+    existing_assume_role_document: AssumeRolePolicyDocument = merged_list[1]
+    assert (
+        existing_assume_role_document.included_accounts
+        == existing_assume_role_policy.included_accounts
+    )


### PR DESCRIPTION
What changes?
* when calling merge_model from merge_access_model_list, turn of access attribute syncing
** WHY? it's quite complicated, merge_model carries over metadata that is non-cloud; however, merge_model_access_list drives access model handling. If merge_access_model_list naively allow merge_model to do access syncing, it will mistakenly expands access model

Why is this so complicated?
The interaction between AccessModel and ExpiryModel when resource_id is non-unique (for example, assume role policy document) is very complicated because when we have to merge two list which none of the elements can be uniquely identified via resource_id, offline metadata (like expires_at) is very haphazard (only done via list index)

How'd I test?
* Add unit test on AssumeRolePolicyDocument merging
* Trigger the import condition by first take out `resources/aws/iam/role/all_accounts/account_name_administrator.yaml`'s assume role policy document for account `'@!#!@#)(%*#R)QWITFGO)FG+=0984'` and run import again. we should see the role clean insert back into the template.