### PR TITLE
Configure coverage-gutters

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,4 +7,10 @@
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
     "python.formatting.provider": "black",
+    "coverage-gutters.coverageFileNames": [
+        "cov_unit_tests.xml"
+    ],
+    "coverage-gutters.coverageBaseDir": ".",
+    "coverage-gutters.showGutterCoverage": false,
+    "coverage-gutters.showLineCoverage": true
 }


### PR DESCRIPTION
Coverage Gutters is an extension for VSCode to add coverage details inline in VS Code. This PR adds a configuration that makes it work out of the box - Just run `make test` and toggle the extension.  If the extension is not installed, this is a no-op.

![image](https://user-images.githubusercontent.com/7538233/225294627-f7d7d5d4-fb81-424b-8678-13135da1a648.png)

