### PR TITLE
EN-1887 Enhance import log message for AWS multi-account scenario

### DIFF
--- a/iambic/plugins/v0_1_0/aws/iam/group/template_generation.py
+++ b/iambic/plugins/v0_1_0/aws/iam/group/template_generation.py
@@ -342,9 +342,9 @@ async def collect_aws_groups(
         set_group_resource_managed_policies, 30
     )
 
-    log.info("Generating AWS group templates.")
     log.info(
-        "Beginning to retrieve AWS IAM Groups.", accounts=list(aws_account_map.keys())
+        "Generating AWS group templates. Beginning to retrieve AWS IAM Groups.",
+        accounts=list(aws_account_map.keys()),
     )
 
     if detect_messages:
@@ -410,7 +410,10 @@ async def collect_aws_groups(
         )
 
     if not any(account_group["groups"] for account_group in account_groups):
-        log.info("No groups found in any AWS accounts.")
+        log.info(
+            "No groups found in any AWS accounts.",
+            accounts=list(aws_account_map.keys()),
+        )
         return
 
     messages = []
@@ -425,11 +428,17 @@ async def collect_aws_groups(
                 }
             )
 
-    log.info("Setting inline policies in group templates")
+    log.info(
+        "Setting inline policies in group templates",
+        accounts=list(aws_account_map.keys()),
+    )
     await set_group_resource_inline_policies_semaphore.process(messages)
-    log.info("Setting managed policies in group templates")
+    log.info(
+        "Setting managed policies in group templates",
+        accounts=list(aws_account_map.keys()),
+    )
     await set_group_resource_managed_policies_semaphore.process(messages)
-    log.info("Finished retrieving group details")
+    log.info("Finished retrieving group details", accounts=list(aws_account_map.keys()))
 
     account_group_output = json.dumps(account_groups)
     with open(

--- a/iambic/plugins/v0_1_0/aws/iam/policy/template_generation.py
+++ b/iambic/plugins/v0_1_0/aws/iam/policy/template_generation.py
@@ -324,9 +324,8 @@ async def collect_aws_managed_policies(
         base_output_dir, "NOQ::AWS::IAM::ManagedPolicy"
     )
 
-    log.info("Generating AWS managed policy templates.")
     log.info(
-        "Beginning to retrieve AWS IAM Managed Policies.",
+        "Generating AWS managed policy templates. Beginning to retrieve AWS IAM Managed Policies.",
         accounts=list(aws_account_map.keys()),
     )
 
@@ -424,7 +423,10 @@ async def collect_aws_managed_policies(
                 }
             )
 
-    log.info("Finished retrieving managed policy details")
+    log.info(
+        "Finished retrieving managed policy details",
+        accounts=list(aws_account_map.keys()),
+    )
 
     account_managed_policy_output = json.dumps(account_managed_policies)
     with open(

--- a/iambic/plugins/v0_1_0/aws/iam/role/template_generation.py
+++ b/iambic/plugins/v0_1_0/aws/iam/role/template_generation.py
@@ -442,9 +442,9 @@ async def collect_aws_roles(
     )
     set_role_resource_tags_semaphore = NoqSemaphore(set_role_resource_tags, 45)
 
-    log.info("Generating AWS role templates.")
     log.info(
-        "Beginning to retrieve AWS IAM Roles.", accounts=list(aws_account_map.keys())
+        "Generating AWS role templates. Beginning to retrieve AWS IAM Roles.",
+        accounts=list(aws_account_map.keys()),
     )
 
     if detect_messages:
@@ -526,13 +526,19 @@ async def collect_aws_roles(
                 }
             )
 
-    log.info("Setting inline policies in role templates")
+    log.info(
+        "Setting inline policies in role templates",
+        accounts=list(aws_account_map.keys()),
+    )
     await set_role_resource_inline_policies_semaphore.process(messages)
-    log.info("Setting managed policies in role templates")
+    log.info(
+        "Setting managed policies in role templates",
+        accounts=list(aws_account_map.keys()),
+    )
     await set_role_resource_managed_policies_semaphore.process(messages)
-    log.info("Setting tags in role templates")
+    log.info("Setting tags in role templates", accounts=list(aws_account_map.keys()))
     await set_role_resource_tags_semaphore.process(messages)
-    log.info("Finished retrieving role details")
+    log.info("Finished retrieving role details", accounts=list(aws_account_map.keys()))
 
     account_role_output = json.dumps(account_roles)
     with open(

--- a/iambic/plugins/v0_1_0/aws/iam/user/template_generation.py
+++ b/iambic/plugins/v0_1_0/aws/iam/user/template_generation.py
@@ -422,9 +422,9 @@ async def collect_aws_users(
     set_user_resource_groups_semaphore = NoqSemaphore(set_user_resource_groups, 30)
     set_user_resource_tags_semaphore = NoqSemaphore(set_user_resource_tags, 50)
 
-    log.info("Generating AWS user templates.")
     log.info(
-        "Beginning to retrieve AWS IAM Users.", accounts=list(aws_account_map.keys())
+        "Generating AWS user templates. Beginning to retrieve AWS IAM Users.",
+        accounts=list(aws_account_map.keys()),
     )
 
     if detect_messages:
@@ -505,15 +505,21 @@ async def collect_aws_users(
                 }
             )
 
-    log.info("Setting inline policies in user templates")
+    log.info(
+        "Setting inline policies in user templates",
+        accounts=list(aws_account_map.keys()),
+    )
     await set_user_resource_inline_policies_semaphore.process(messages)
-    log.info("Setting managed policies in user templates")
+    log.info(
+        "Setting managed policies in user templates",
+        accounts=list(aws_account_map.keys()),
+    )
     await set_user_resource_managed_policies_semaphore.process(messages)
-    log.info("Setting groups in user templates")
+    log.info("Setting groups in user templates", accounts=list(aws_account_map.keys()))
     await set_user_resource_groups_semaphore.process(messages)
-    log.info("Setting tags in user templates")
+    log.info("Setting tags in user templates", accounts=list(aws_account_map.keys()))
     await set_user_resource_tags_semaphore.process(messages)
-    log.info("Finished retrieving user details")
+    log.info("Finished retrieving user details", accounts=list(aws_account_map.keys()))
 
     account_user_output = json.dumps(account_users)
     with open(


### PR DESCRIPTION
What has changed? 
* AWS users, groups, policies, roles are multi-account capable. Add the fan-out account as log_params in the import flow.

How'd I test?
* Run import to check the log messages. 