### PR TITLE
EN-1929 Add validator for google workspace project id and okta idp name

### DIFF
--- a/test/plugins/v0_1_0/google_workspace/test_iambic_plugin.py
+++ b/test/plugins/v0_1_0/google_workspace/test_iambic_plugin.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import pytest
+
+from iambic.plugins.v0_1_0.google_workspace.iambic_plugin import (
+    GoogleProject,
+    GoogleWorkspaceConfig,
+)
+
+
+def test_google_workspace_config():
+    google_project_1 = GoogleProject(
+        project_id="fake-project-id",
+        type="Group",
+        subjects=[{"domain": "example.org", "service_account": "fake-service-account"}],
+        private_key_id="fake-private-key-id",
+        private_key="fake-private-key",
+        client_id="fake-client-id",
+        client_email="fake-client-email@example.org",
+        auth_uri="https://google.com/",
+        token_uri="https://google.com/",
+        auth_provider_x509_cert_url="https://google.com/",
+        client_x509_cert_url="https://google.com/",
+    )
+
+    google_workspace_config = GoogleWorkspaceConfig(workspaces=[google_project_1])
+    assert google_workspace_config.workspaces[0].project_id == "fake-project-id"
+
+
+def test_google_workspace_config_with_repeated_project_id():
+    google_project_1 = GoogleProject(
+        project_id="fake-project-id",
+        type="Group",
+        subjects=[{"domain": "example.org", "service_account": "fake-service-account"}],
+        private_key_id="fake-private-key-id",
+        private_key="fake-private-key",
+        client_id="fake-client-id",
+        client_email="fake-client-email@example.org",
+        auth_uri="https://google.com/",
+        token_uri="https://google.com/",
+        auth_provider_x509_cert_url="https://google.com/",
+        client_x509_cert_url="https://google.com/",
+    )
+
+    google_project_2 = GoogleProject(
+        project_id="fake-project-id",
+        type="Group",
+        subjects=[{"domain": "example.org", "service_account": "fake-service-account"}],
+        private_key_id="fake-private-key-id",
+        private_key="fake-private-key",
+        client_id="fake-client-id",
+        client_email="fake-client-email@example.org",
+        auth_uri="https://google.com/",
+        token_uri="https://google.com/",
+        auth_provider_x509_cert_url="https://google.com/",
+        client_x509_cert_url="https://google.com/",
+    )
+
+    with pytest.raises(
+        ValueError, match="project_id must be unique within workspaces: fake-project-id"
+    ):
+        _ = GoogleWorkspaceConfig(workspaces=[google_project_1, google_project_2])

--- a/test/plugins/v0_1_0/okta/test_iambic_plugin.py
+++ b/test/plugins/v0_1_0/okta/test_iambic_plugin.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import pytest
+
+from iambic.plugins.v0_1_0.okta.iambic_plugin import OktaConfig, OktaOrganization
+
+
+def test_okta_config():
+    okta_org_1 = OktaOrganization(
+        idp_name="example.org",
+        org_url="https://example.okta.com/",
+        api_token="fake-token",
+    )
+
+    okta_config = OktaConfig(organizations=[okta_org_1])
+    assert okta_config.organizations[0].idp_name == "example.org"
+
+
+def test_okta_config_with_repeated_idp_name():
+    okta_org_1 = OktaOrganization(
+        idp_name="example.org",
+        org_url="https://example.okta.com/",
+        api_token="fake-token",
+    )
+
+    okta_org_2 = OktaOrganization(
+        idp_name="example.org",
+        org_url="https://example.okta.com/",
+        api_token="fake-token",
+    )
+
+    with pytest.raises(
+        ValueError, match="idp_name must be unique within organizations: example.org"
+    ):
+        _ = OktaConfig(organizations=[okta_org_1, okta_org_2])


### PR DESCRIPTION
What's changed?
* Google Workspace Config project_id unique-ness is validated against.
* Okta Config idp_name unique-ness is validated against.

How'd I test?
* Add unit tests