### PR TITLE
Provide a better error message on initial AWS IC call

### DIFF
--- a/iambic/plugins/v0_1_0/aws/models.py
+++ b/iambic/plugins/v0_1_0/aws/models.py
@@ -358,7 +358,7 @@ class AWSAccount(ProviderChild, BaseAWSAccountAndOrgModel):
             except errors.AccessDeniedException as err:
                 raise Exception(
                     "Please ensure you've specified the correct AWS Identity Center region in "
-                    "IAMbic's configuration and that the spoke role has the sso-admin:ListInstances permission. ",
+                    "IAMbic's configuration and that the spoke role has the correct permissions. ",
                     f"Original Exception: {err}",
                 )
 


### PR DESCRIPTION
The initial AWS IdentityCenter call may return a permissions related issue even if the error is because the lookup was performed in a region other than where AWS IdentityCenter is.