### PR TITLE
EN-1938 Skip test running on commits on  any tags

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -1,6 +1,8 @@
 name: Run test
 on:
   pull_request:
+  push:
+    branches: [main]
 jobs:
   run-unit-test:
     runs-on: self-hosted


### PR DESCRIPTION
What's changed?
* Previously tests is automatically run on any pull-request events and any push events on tags and main branches. This change will only keep tests automatically running in pull-requests and the main branch.

Motivation
* After merges and automatic version bump, we automatically triggers tests running. That's at least two additional test run when changes is already made into main. This makes our runner not available for 20+ min (due to our functional tests cannot be run in overlap runners - for things like permission sets)