### PR TITLE
EN-1944 Implement Github App handling for enforce templates

### DIFF
--- a/iambic/github/templates/iambic-enforce.yml
+++ b/iambic/github/templates/iambic-enforce.yml
@@ -1,0 +1,22 @@
+name: Run Iambic Enforce
+on:
+  workflow_dispatch:
+  schedule:
+    - cron:  '0 */1 * * *' # import at minute 0 past every one hour
+jobs:
+  iambic-import:
+    runs-on: ubuntu-latest
+    environment: production
+    name: Enforce Iambic Managed templates
+    timeout-minutes: 60 # Setting this to 60 min for now. If this takes longer, it needs better performance improvement
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: false
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: trigger_workflow
+        id: trigger_workflow
+        run: |
+          echo "trigger workflow"

--- a/iambic/main.py
+++ b/iambic/main.py
@@ -234,6 +234,7 @@ def run_apply(
     templates: Optional[list[str]],
     repo_dir: str = str(pathlib.Path.cwd()),
     enforced_only: bool = False,
+    output_path: str = "proposed_changes.yaml",
 ) -> list[TemplateChangeDetails]:
     template_changes = []
     exe_message = ExecutionMessage(
@@ -252,7 +253,7 @@ def run_apply(
         return template_changes
     asyncio.run(flag_expired_resources([template.file_path for template in templates]))
     template_changes = asyncio.run(config.run_apply(exe_message, templates))
-    output_proposed_changes(template_changes)
+    output_proposed_changes(template_changes, output_path=output_path)
 
     if ctx.eval_only and template_changes and click.confirm("Proceed?"):
         ctx.eval_only = False

--- a/iambic/plugins/v0_1_0/aws/iam/policy/template_generation.py
+++ b/iambic/plugins/v0_1_0/aws/iam/policy/template_generation.py
@@ -21,6 +21,7 @@ from iambic.core.template_generation import (
 from iambic.core.utils import NoqSemaphore, normalize_dict_keys, resource_file_upsert
 from iambic.plugins.v0_1_0.aws.event_bridge.models import ManagedPolicyMessageDetails
 from iambic.plugins.v0_1_0.aws.iam.policy.models import (
+    AWS_MANAGED_POLICY_TEMPLATE_TYPE,
     AwsIamManagedPolicyTemplate,
     ManagedPolicyProperties,
 )
@@ -320,7 +321,7 @@ async def collect_aws_managed_policies(
             return
 
     existing_template_map = await get_existing_template_map(
-        base_output_dir, "NOQ::AWS::IAM::ManagedPolicy"
+        base_output_dir, AWS_MANAGED_POLICY_TEMPLATE_TYPE
     )
 
     log.info(
@@ -443,7 +444,7 @@ async def generate_aws_managed_policy_templates(
 ):
     aws_account_map = await get_aws_account_map(config)
     existing_template_map = await get_existing_template_map(
-        base_output_dir, "NOQ::IAM::ManagedPolicy"
+        base_output_dir, AWS_MANAGED_POLICY_TEMPLATE_TYPE
     )
     resource_dir = get_template_dir(base_output_dir)
     account_managed_policies = await exe_message.get_sub_exe_files(

--- a/iambic/plugins/v0_1_0/github/github.py
+++ b/iambic/plugins/v0_1_0/github/github.py
@@ -21,12 +21,13 @@ from github.PullRequest import PullRequest
 import iambic.output.markdown
 from iambic.config.dynamic_config import load_config
 from iambic.config.utils import resolve_config_template_path
+from iambic.core.context import ctx
 from iambic.core.git import Repo, clone_git_repo, get_remote_default_branch
 from iambic.core.iambic_enum import Command
 from iambic.core.logger import log
 from iambic.core.models import ExecutionMessage, TemplateChangeDetails
 from iambic.core.utils import yaml
-from iambic.main import run_detect, run_expire, run_git_apply, run_git_plan
+from iambic.main import run_apply, run_detect, run_expire, run_git_apply, run_git_plan
 
 iambic_app = __import__("iambic.lambda.app", globals(), locals(), [], 0)
 lambda_run_handler = getattr(iambic_app, "lambda").app.run_handler
@@ -449,6 +450,7 @@ def _post_artifact_to_companion_repository(
     op_name: str,
     proposed_changes_path: str,
     markdown_summary: str,
+    default_base_name: str = "proposed_changes.yaml",
 ):
     url = None
     try:
@@ -459,10 +461,11 @@ def _post_artifact_to_companion_repository(
             gist_repo_name = f"{templates_repo.full_name}-gist"
             gist_repo = github_client.get_repo(gist_repo_name)
             now_timestamp = datetime.datetime.now()
+            pr_prefix = f"pr-{pull_number}" if pull_number else "no-pr"
             yaml_repo_path = (
-                f"pr-{pull_number}/{op_name}/{now_timestamp}/proposed_changes.yaml"
+                f"{pr_prefix}/{op_name}/{now_timestamp}/{default_base_name}"
             )
-            md_repo_path = f"pr-{pull_number}/{op_name}/{now_timestamp}/summary.md"
+            md_repo_path = f"{pr_prefix}/{op_name}/{now_timestamp}/summary.md"
             gist_repo.create_file(yaml_repo_path, op_name, "".join(lines))
             result = gist_repo.create_file(md_repo_path, op_name, markdown_summary)
             url = result["content"].html_url
@@ -524,6 +527,74 @@ def handle_iambic_git_plan(
         raise e
 
 
+def github_app_workflow_wrapper(workflow_func: Callable, ux_op_name: str) -> Callable:
+    def wrapped_workflow_func(
+        github_client: github.Github,
+        templates_repo: github.Repo,
+        repo_name: str,
+        repo_url: str,
+        default_branch: str,
+        proposed_changes_path: str = None,
+    ):
+        pull_number = (
+            0  # 0 is not a valid pull number in github. workflow implementation
+        )
+        # does not have an associated PR. This is the path of least resistance adaption
+        # for stable session name
+        session_name = get_session_name(repo_name, pull_number)
+        os.environ["IAMBIC_SESSION_NAME"] = session_name
+
+        try:
+            if proposed_changes_path:
+                # code smell to have to change a module variable
+                # to control the destination of proposed_changes.yaml
+                # It's questionable if we still need to depend on the lambda interface
+                # because lambda interface was created to dynamic populate template config
+                # but templates config is now already stored in the templates repo itself.
+                getattr(
+                    iambic_app, "lambda"
+                ).app.PLAN_OUTPUT_PATH = proposed_changes_path
+
+            template_changes = workflow_func(repo_url, default_branch)
+            _process_template_changes(
+                github_client,
+                templates_repo,
+                None,
+                pull_number,
+                proposed_changes_path,
+                template_changes,
+                f"{ux_op_name}",  # TODO this can probably be improved for user-experience
+            )
+        except Exception as e:
+            captured_traceback = traceback.format_exc()
+            log.error("fault", exception=captured_traceback)
+            try:
+                temp_dir = tempfile.mkdtemp(suffix=None, prefix=None, dir=None)
+                with open(f"{temp_dir}/crash.txt", "w") as f:
+                    f.write(captured_traceback)
+                _post_artifact_to_companion_repository(
+                    github_client,
+                    templates_repo,
+                    pull_number,
+                    f"{ux_op_name}",
+                    f"{temp_dir}/crash.txt",
+                    captured_traceback,
+                    default_base_name="crash.txt",
+                )
+            except Exception:
+                captured_traceback = traceback.format_exc()
+                log.error(
+                    "fail to post exception to companion repo",
+                    exception=captured_traceback,
+                )
+            finally:
+                if temp_dir:
+                    shutil.rmtree(temp_dir)
+            raise e
+
+    return wrapped_workflow_func
+
+
 def _process_template_changes(
     github_client: github.Github,
     templates_repo: github.Repo,
@@ -534,7 +605,7 @@ def _process_template_changes(
     op_name: str,  # Examples are "plan", "apply"
 ):
     html_url = ""
-    if len(template_changes) > 0:
+    if template_changes and len(template_changes) > 0:
         rendered_content = iambic.output.markdown.gh_render_resource_changes(
             template_changes
         )
@@ -550,9 +621,10 @@ def _process_template_changes(
         rendered_content = "no changes detected"
 
     rendered_content = f"""Reacting to `{op_name}`\n\n{rendered_content}\n\n <a href="{html_url}">Run</a>"""
-    _post_render_content_as_pr_comment(
-        pull_request, rendered_content, blob_html_url=html_url
-    )
+    if pull_request:
+        _post_render_content_as_pr_comment(
+            pull_request, rendered_content, blob_html_url=html_url
+        )
 
 
 def handle_pull_request(github_client: github.Github, context: dict[str, Any]) -> None:
@@ -594,7 +666,9 @@ def handle_detect_changes_from_eventbridge(
     _handle_detect_changes_from_eventbridge(repo_url, default_branch)
 
 
-def _handle_detect_changes_from_eventbridge(repo_url: str, default_branch: str) -> None:
+def _handle_detect_changes_from_eventbridge(
+    repo_url: str, default_branch: str
+) -> list[TemplateChangeDetails]:
     try:
         repo = prepare_local_repo_for_new_commits(
             repo_url, get_lambda_repo_path(), "detect"
@@ -611,6 +685,7 @@ def _handle_detect_changes_from_eventbridge(repo_url: str, default_branch: str) 
     except Exception as e:
         log.error("fault", exception=str(e))
         raise e
+    return []
 
 
 def handle_import(github_client: github.Github, context: dict[str, Any]) -> None:
@@ -626,7 +701,7 @@ def handle_import(github_client: github.Github, context: dict[str, Any]) -> None
     _handle_import(repo_url, default_branch)
 
 
-def _handle_import(repo_url: str, default_branch: str) -> None:
+def _handle_import(repo_url: str, default_branch: str) -> list[TemplateChangeDetails]:
     try:
         exe_message = ExecutionMessage(
             execution_id=str(uuid.uuid4()), command=Command.IMPORT
@@ -646,6 +721,31 @@ def _handle_import(repo_url: str, default_branch: str) -> None:
     except Exception as e:
         log.error("fault", exception=str(e))
         raise e
+    return []
+
+
+def _handle_enforce(repo_url: str, default_branch: str) -> list[TemplateChangeDetails]:
+    try:
+        local_repo_path = get_lambda_repo_path()
+        _ = prepare_local_repo_for_new_commits(repo_url, local_repo_path, "enforce")
+        config_path = asyncio.run(resolve_config_template_path(local_repo_path))
+        config = asyncio.run(load_config(config_path))
+        # we are not restoring teh original ctx because we expect
+        # this is called in a completely separate process
+        ctx.eval_only = False
+        # running in enforce option mean we are only writing to the cloud.
+        # there will be no templates being changed in the git context
+        template_changes = run_apply(
+            config,
+            [],
+            repo_dir=local_repo_path,
+            enforced_only=True,
+            output_path=getattr(iambic_app, "lambda").app.PLAN_OUTPUT_PATH,
+        )
+        return template_changes
+    except Exception as e:
+        log.error("fault", exception=str(e))
+        raise e
 
 
 def handle_expire(github_client: github.Github, context: dict[str, Any]) -> None:
@@ -661,7 +761,7 @@ def handle_expire(github_client: github.Github, context: dict[str, Any]) -> None
     _handle_expire(repo_url, default_branch)
 
 
-def _handle_expire(repo_url: str, default_branch: str) -> None:
+def _handle_expire(repo_url: str, default_branch: str) -> list[TemplateChangeDetails]:
     try:
         repo = prepare_local_repo_for_new_commits(
             repo_url, get_lambda_repo_path(), "expire"
@@ -694,6 +794,7 @@ def _handle_expire(repo_url: str, default_branch: str) -> None:
     except Exception as e:
         log.error("fault", exception=str(e))
         raise e
+    return []
 
 
 EVENT_DISPATCH_MAP: dict[str, Callable] = {


### PR DESCRIPTION
What's changed?
* Implement iambic-enforce.yml workflow handling in Github App
* For workflow that has no attach PR (import, expire, detect, enforce), they can now post to the companion gist repo

How'd to test?
* manual testing on https://github.com/noqdev/iambic-templates-itest-gist/blob/main/no-pr/enforce/2023-03-29%2000%3A02%3A21.555418/summary.md
** Change the description on role `iambic_test_spoke_account_1_iambic-managed-enforce-sensor`
** manually kick off action in `iambic-templates-itest` for `iambic-enforce`
** verify the description is reset to what's on template.

TODO:
* update unit testing to reflect the changes.