### PR TITLE
Switch to gh managed runner because public repo

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build-container:
     if: ${{ github.repository == 'noqdev/iambic' && github.event.commits[0].author.name != 'Version Auto Bump' }}
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     name: Build Container
     permissions:
       id-token: write

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -1,10 +1,10 @@
-name: Run test
+name: Run unit and functional test
 on:
   pull_request:
   push:
     branches: [main]
 jobs:
-  run-unit-test:
+  run-unit-and-functional-test:
     runs-on: ubuntu-latest
     name: Run unit test
     permissions:
@@ -12,7 +12,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.x
+      - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:
           # Semantic version range syntax or exact version of a Python version
@@ -31,50 +31,19 @@ jobs:
           files: cov_unit_tests.xml
           flags: unit_tests
           token: ${{secrets.CODECOV_TOKEN}}
-  run-functional-test:
-    # functional test requires various web services
-    runs-on: ubuntu-latest
-    if: ${{ github.repository == 'noqdev/iambic' }}
-    name: Run functional test
-    needs: [run-unit-test]
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python 3.x
-        uses: actions/setup-python@v4
-        with:
-          # Semantic version range syntax or exact version of a Python version
-          python-version: '3.9'
-          # Optional - x64 or x86 architecture, defaults to x64
-          architecture: 'x64'
-      - name: bootstrap
-        id: bootstrap
-        run: |
-          python3 -m venv env
-          . env/bin/activate && pip install poetry setuptools pip --upgrade && poetry install
-      - name: Configure AWS Credentials for building itest image
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          role-to-assume: arn:aws:iam::442632209887:role/iambic_image_builder
-          aws-region: us-east-1
-      # Disable image builder for now since we are not using it
-      #- name: build-itest-image
-      #  id: build-itest-image
-      #  run: |
-      #    aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/l1s5s8m2
-      #    . env/bin/activate && make -f Makefile.itest build_docker_itest upload_docker_itest
       - name: Configure AWS Credentials
+        if: ${{ github.repository == 'noqdev/iambic' }}
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: arn:aws:iam::580605962305:role/IambicHubRole
           aws-region: us-east-1
       - name: run-functional-test
+        if: ${{ github.repository == 'noqdev/iambic' }}
         id: run-functional-test
         run: |
           . env/bin/activate && make functional_test
       - name: Upload coverage reports to Codecov
+        if: ${{ github.repository == 'noqdev/iambic' }}
         uses: codecov/codecov-action@v3
         with:
           files: cov_functional_tests.xml

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -5,17 +5,24 @@ on:
     branches: [main]
 jobs:
   run-unit-test:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     name: Run unit test
     permissions:
       id-token: write
       contents: read
     steps:
       - uses: actions/checkout@v3
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v4
+        with:
+          # Semantic version range syntax or exact version of a Python version
+          python-version: '3.9'
+          # Optional - x64 or x86 architecture, defaults to x64
+          architecture: 'x64'
       - name: run-test
         id: run-test
         run: |
-          python3.10 -m venv env
+          python3 -m venv env
           . env/bin/activate && pip install poetry setuptools pip --upgrade && poetry install && make test
       - name: Upload coverage reports to Codecov
         if: ${{ github.repository == 'noqdev/iambic' }}
@@ -26,7 +33,7 @@ jobs:
           token: ${{secrets.CODECOV_TOKEN}}
   run-functional-test:
     # functional test requires various web services
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     if: ${{ github.repository == 'noqdev/iambic' }}
     name: Run functional test
     needs: [run-unit-test]
@@ -35,10 +42,17 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v3
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v4
+        with:
+          # Semantic version range syntax or exact version of a Python version
+          python-version: '3.9'
+          # Optional - x64 or x86 architecture, defaults to x64
+          architecture: 'x64'
       - name: bootstrap
         id: bootstrap
         run: |
-          python3.10 -m venv env
+          python3 -m venv env
           . env/bin/activate && pip install poetry setuptools pip --upgrade && poetry install
       - name: Configure AWS Credentials for building itest image
         uses: aws-actions/configure-aws-credentials@v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
     name: pytest
     stages: [commit]
     language: system
-    entry: poetry run pytest
+    entry: poetry run pytest . --ignore functional_tests/ -s
     types: [python]
     pass_filenames: false
 

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ push_manifest:
 
 .PHONY: test
 test:
-	python -m pytest --cov iambic --cov-report xml:cov_unit_tests.xml --cov-report html:cov_unit_tests.html . --ignore functional_tests/ -s
+	python -m pytest --cov iambic --cov-report xml:cov_unit_tests.xml --cov-report html:cov_unit_tests.html . --ignore functional_tests/ -s -n auto --dist loadscope
 
 .PHONY: functional_test
 functional_test:

--- a/functional_tests/aws/permission_set/test_update_template.py
+++ b/functional_tests/aws/permission_set/test_update_template.py
@@ -9,6 +9,7 @@ from functional_tests.aws.permission_set.utils import (
 )
 from functional_tests.conftest import IAMBIC_TEST_DETAILS
 from iambic.core import noq_json as json
+from iambic.core.context import ctx
 from iambic.output.text import screen_render_resource_changes
 from iambic.plugins.v0_1_0.aws.identity_center.permission_set.models import (
     PermissionSetAccess,
@@ -26,12 +27,14 @@ EXAMPLE_USER = (
 class UpdatePermissionSetTestCase(IsolatedAsyncioTestCase):
     @classmethod
     def setUpClass(cls):
+        ctx.eval_only = False
         cls.template = asyncio.run(
             generate_permission_set_template_from_base(
                 IAMBIC_TEST_DETAILS.template_dir_path
             )
         )
         asyncio.run(cls.template.apply(IAMBIC_TEST_DETAILS.config.aws))
+        cls.permission_set_arn = None
         sleep(5)
         asyncio.run(
             IAMBIC_TEST_DETAILS.identity_center_account.set_identity_center_details(
@@ -41,31 +44,36 @@ class UpdatePermissionSetTestCase(IsolatedAsyncioTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        sleep(5)
         cls.template.deleted = True
         asyncio.run(cls.template.apply(IAMBIC_TEST_DETAILS.config.aws))
-        sleep(5)
-        asyncio.run(
-            IAMBIC_TEST_DETAILS.identity_center_account.set_identity_center_details(
-                batch_size=5
-            )
-        )
 
-    async def test_update_description(self):
-        self.template.properties.description = "Updated description"
+    async def test_update_valid_description(self):
+        updated_description = "Updated description"
+        assert self.template.properties.description != updated_description
+        self.template.properties.description = updated_description
         changes = await self.template.apply(IAMBIC_TEST_DETAILS.config.aws)
         screen_render_resource_changes([changes])
-        await IAMBIC_TEST_DETAILS.identity_center_account.set_identity_center_details(
-            batch_size=5
+
+        identity_center_client = await IAMBIC_TEST_DETAILS.identity_center_account.get_boto3_client(
+            "sso-admin",
+            region_name=IAMBIC_TEST_DETAILS.identity_center_account.identity_center_details.region_name,
+        )
+        sso_admin_instance_arn = (
+            IAMBIC_TEST_DETAILS.identity_center_account.identity_center_details.instance_arn
+        )
+        permission_set_arn = IAMBIC_TEST_DETAILS.identity_center_account.identity_center_details.permission_set_map[
+            self.template.identifier
+        ][
+            "PermissionSetArn"
+        ]
+        response = identity_center_client.describe_permission_set(
+            InstanceArn=sso_admin_instance_arn,
+            PermissionSetArn=permission_set_arn,
         )
 
         self.assertEqual(
             self.template.properties.description,
-            IAMBIC_TEST_DETAILS.identity_center_account.identity_center_details.permission_set_map[
-                self.template.identifier
-            ][
-                "Description"
-            ],
+            response["PermissionSet"]["Description"],
         )
 
     async def test_account_assignment(self):

--- a/functional_tests/aws/permission_set/utils.py
+++ b/functional_tests/aws/permission_set/utils.py
@@ -59,6 +59,7 @@ def attach_access_rule(
 
 async def generate_permission_set_template_from_base(
     repo_dir: str,
+    extra_salt: str = "",
 ) -> AwsIdentityCenterPermissionSetTemplate:
     permission_sets = await gather_templates(
         repo_dir, AWS_IDENTITY_CENTER_PERMISSION_SET_TEMPLATE_TYPE
@@ -72,7 +73,9 @@ async def generate_permission_set_template_from_base(
         permission_set=permission_set_template.identifier,
     )
 
-    permission_set_template.identifier = f"iambic_test_{random.randint(0, 10000)}"
+    permission_set_template.identifier = (
+        f"iambic_test_{extra_salt}{random.randint(0, 10000)}"
+    )
     permission_set_template.file_path = (
         f"{permission_set_dir}/{permission_set_template.identifier}.yaml"
     )

--- a/functional_tests/aws/permission_set/utils.py
+++ b/functional_tests/aws/permission_set/utils.py
@@ -12,6 +12,7 @@ from iambic.plugins.v0_1_0.aws.identity_center.permission_set.models import (
     AWS_IDENTITY_CENTER_PERMISSION_SET_TEMPLATE_TYPE,
     AwsIdentityCenterPermissionSetTemplate,
     PermissionSetAccess,
+    PermissionSetProperties,
 )
 from iambic.plugins.v0_1_0.aws.identity_center.permission_set.template_generation import (
     collect_aws_permission_sets,
@@ -85,6 +86,23 @@ async def generate_permission_set_template_from_base(
         "This was created by a functional test."
     )
 
+    permission_set_template.write()
+    return permission_set_template
+
+
+async def generate_permission_set_template(
+    repo_dir: str,
+    noise: str = "",
+) -> AwsIdentityCenterPermissionSetTemplate:
+    permission_set_dir = get_template_dir(repo_dir)
+    identifier = f"iambic_test_{noise}{random.randint(0, 10000)}"
+    file_path = f"{permission_set_dir}/{identifier}.yaml"
+    properties = PermissionSetProperties(
+        name=identifier, description="This was created by a functional test."
+    )
+    permission_set_template = AwsIdentityCenterPermissionSetTemplate(
+        identifier=identifier, properties=properties, file_path=file_path
+    )
     permission_set_template.write()
     return permission_set_template
 


### PR DESCRIPTION
What's changed?
* Switch to use gh managed runner due to default runner group does not run public repos
* specify python 3.9 on gh managed runner
* move update_permission_sets functional test to not depend on existing permission in account. (that was causing unpredictable test condition)