### PR TITLE
EN-1957 Address functional test flakiness

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -49,3 +49,11 @@ jobs:
           files: cov_functional_tests.xml
           flags: functional_tests
           token: ${{secrets.CODECOV_TOKEN}}
+      - name: Upload coverage reports to Codecov
+        if: ${{ github.repository == 'noqdev/iambic' }}
+        uses: codecov/codecov-action@v3
+        with:
+          files: cov_functional_tests_config_discovery.xml
+          flags: functional_tests_config_discovery
+          token: ${{secrets.CODECOV_TOKEN}}
+

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,8 @@ test:
 
 .PHONY: functional_test
 functional_test:
-	pytest --cov-report html --cov iambic --cov-report lcov:cov_functional_tests.lcov --cov-report xml:cov_functional_tests.xml --cov-report html:cov_functional_tests.html  functional_tests --ignore functional_tests/test_github_cicd.py -s -n auto --dist loadscope --reruns 3 --reruns-delay 5 -r aR --durations=20
+	pytest --cov-report html --cov iambic --cov-report lcov:cov_functional_tests.lcov --cov-report xml:cov_functional_tests.xml --cov-report html:cov_functional_tests.html  functional_tests --ignore functional_tests/test_github_cicd.py --ignore functional_tests/test_config_discovery.py -s -n auto --dist loadscope --reruns 3 --reruns-delay 5 -r aR --durations=20
+	pytest --cov-report html --cov iambic --cov-report lcov:cov_functional_tests_config_discovery.lcov --cov-report xml:cov_functional_tests_config_discovery.xml --cov-report html:cov_functional_tests_config_discovery.html  functional_tests/test_config_discovery.py -s --durations=20
 # 	pytest --cov-report html --cov iambic functional_tests -s
 # 	pytest --cov-report html --cov iambic functional_tests/aws/role/test_create_template.py -s
 # 	pytest --cov-report html --cov iambic functional_tests/aws/managed_policy/test_template_expiration.py -s


### PR DESCRIPTION
What's changed?
* split up config_discovery functional test to run serially.

Reasoning
* config_discovery is changing templates in account enough that it really flakes up all the other parallelizable functional test.

Infra changes
* config_discovery coverage result will have its own flag `functional_test_config_discovery`