### PR TITLE
EN-1962 defensive measure against duplicate glob pattern

### DIFF
--- a/test/core/test_utils.py
+++ b/test/core/test_utils.py
@@ -200,6 +200,8 @@ async def test_gather_templates(tmpdir):
     file3.write("template_type: NOQ::type1\n")
     file4 = sub_dir2.join("file4.yaml")
     file4.write("template_type: not_noq\n")
+    top_level_file = templates_dir.join("top_level.yaml")
+    top_level_file.write("template_type:  NOQ::top_level\n")
 
     # Test the function
     result = await gather_templates(str(templates_dir), "type1")
@@ -221,4 +223,25 @@ async def test_gather_templates(tmpdir):
         str(file1),
         str(file2),
         str(file3),
+        str(top_level_file),
     }
+
+    # Test the function
+    assert not str(templates_dir).endswith("/")
+    result = await gather_templates(str(templates_dir) + "/", "top_level")
+    assert set(result) == {
+        str(top_level_file),
+    }
+    # despite the function signature returns a list, we expect all
+    # elements to be unique.
+    assert len(result) == len(set(result))
+
+    # Test the function
+    assert not str(templates_dir).endswith("/")
+    result = await gather_templates(str(templates_dir), "top_level")
+    assert set(result) == {
+        str(top_level_file),
+    }
+    # despite the function signature returns a list, we expect all
+    # elements to be unique.
+    assert len(result) == len(set(result))

--- a/test/core/test_utils.py
+++ b/test/core/test_utils.py
@@ -186,7 +186,7 @@ class TestSimplifyDt(unittest.TestCase):
 
 @pytest.mark.asyncio
 async def test_gather_templates(tmpdir):
-    from iambic.core.utils import gather_templates
+    from iambic.core.utils import Path, gather_templates
 
     # Create a test directory structure
     templates_dir = tmpdir.mkdir("templates")
@@ -206,13 +206,13 @@ async def test_gather_templates(tmpdir):
     # Test the function
     result = await gather_templates(str(templates_dir), "type1")
     assert set(result) == {
-        str(file1),
-        str(file3),
+        Path(file1),
+        Path(file3),
     }
 
     result = await gather_templates(str(templates_dir), "type2")
     assert set(result) == {
-        str(file2),
+        Path(file2),
     }
 
     result = await gather_templates(str(templates_dir), "type3")
@@ -220,27 +220,27 @@ async def test_gather_templates(tmpdir):
 
     result = await gather_templates(str(templates_dir))
     assert set(result) == {
-        str(file1),
-        str(file2),
-        str(file3),
-        str(top_level_file),
+        Path(file1),
+        Path(file2),
+        Path(file3),
+        Path(top_level_file),
     }
 
-    # Test the function
+    # Test the function when path is a directory with ending /
     assert not str(templates_dir).endswith("/")
     result = await gather_templates(str(templates_dir) + "/", "top_level")
     assert set(result) == {
-        str(top_level_file),
+        Path(top_level_file),
     }
     # despite the function signature returns a list, we expect all
     # elements to be unique.
     assert len(result) == len(set(result))
 
-    # Test the function
+    # Test the function when path is a directory without ending /
     assert not str(templates_dir).endswith("/")
     result = await gather_templates(str(templates_dir), "top_level")
     assert set(result) == {
-        str(top_level_file),
+        Path(top_level_file),
     }
     # despite the function signature returns a list, we expect all
     # elements to be unique.


### PR DESCRIPTION
What's changed?
* make sure the function play nice with directory ends with / or not
* make sure the glob patterns final results is handled with a set
* support Pathlib.path whenever possible the pydantic models

How'd to test?
* expand unit test on directory ends with "/' or not
* expand unit test on top level yaml (like config file)