### PR TITLE
EN-1977 only allow 1 active gh test run at a time

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
 jobs:
   run-unit-and-functional-test:
+    # Since functional tests include tests that does not handle parallel runs
+    # For example, config_discovery test does not tolerate resources being
+    # destroyed, we are setting the concurrency here to only 1 active run at
+    # a time, other run requested will be queued.
+    concurrency: 'unit-and-functional-test'
     runs-on: ubuntu-latest
     name: Run unit test
     permissions:


### PR DESCRIPTION
What's changed?
* Set concurrency label in gh test run workflow. (only 1 active run at a time, others will be queued)

Rationale?
Since functional tests include tests that does not handle parallel runs
For example, config_discovery test does not tolerate resources being
destroyed, we are setting the concurrency here to only 1 active run at
a time, other run requested will be queued.