### PR TITLE
EN-1977 Fix template.delete

### DIFF
--- a/iambic/core/models.py
+++ b/iambic/core/models.py
@@ -541,7 +541,13 @@ class BaseTemplate(
             repo = Repo(self.file_path, search_parent_directories=True)
             # why force=True? Expire could have modified the local contents
             # without force=True, git rm would not be able to remove the file
-            repo.index.remove([self.file_path], working_tree=True, force=True)
+            repo.index.remove(
+                [
+                    str(self.file_path)
+                ],  # manual cast to str is necessary because git library only accepts str and not FilePath
+                working_tree=True,
+                force=True,
+            )
         except Exception as e:
             log.error(
                 "Unable to remove file from local Git repo. Deleting manually",

--- a/test/core/test_models.py
+++ b/test/core/test_models.py
@@ -1,11 +1,21 @@
 from __future__ import annotations
 
+import asyncio
+import os
+import shutil
+import tempfile
 from datetime import date, datetime, timezone
 
+import git
+import pytest
 import pytz
+from git.diff import Diff
 
+import iambic.plugins.v0_1_0.example
+from iambic.config.dynamic_config import load_config
 from iambic.core.iambic_enum import IambicManaged
 from iambic.core.models import BaseTemplate, ExpiryModel
+from iambic.core.parser import load_templates
 from iambic.core.template_generation import merge_model
 
 
@@ -101,3 +111,100 @@ def test_expiry_model_from_json_with_null():
     expected_model = ExpiryModel(expires_at=None, deleted=False)
     actual_model = ExpiryModel.parse_raw(json_str)
     assert actual_model == expected_model
+
+
+TEST_TEMPLATE_YAML = """template_type: NOQ::Example::LocalFile
+name: test_template
+expires_at: tomorrow
+properties:
+  name: {name}"""
+
+TEST_TEMPLATE_TYPE = "NOQ::Test"
+TEST_TEMPLATE_DIR = "resources/test/"
+TEST_TEMPLATE_PATH = "resources/test/test_template.yaml"
+TEST_CONFIG_DIR = "config/"
+TEST_CONFIG_PATH = "config/test_config.yaml"
+
+TEST_CONFIG_YAML = """template_type: NOQ::Core::Config
+version: '1'
+
+plugins:
+  - type: DIRECTORY_PATH
+    location: {example_plugin_location}
+    version: v0_1_0
+example:
+  random: 1
+"""
+
+EXAMPLE_PLUGIN_PATH = iambic.plugins.v0_1_0.example.__path__[0]
+
+
+@pytest.fixture
+def templates_repo():
+    temp_templates_directory = tempfile.mkdtemp(
+        prefix="iambic_test_temp_templates_directory"
+    )
+
+    bare_directory = tempfile.mkdtemp(
+        prefix="iambic_test_temp_templates_directory_bare"
+    )
+
+    try:
+        bare_repo = git.Repo.init(f"{bare_directory}", bare=True)
+        repo = bare_repo.clone(temp_templates_directory)
+        repo_config_writer = repo.config_writer()
+        repo_config_writer.set_value(
+            "user", "name", "Iambic Github Functional Test for Github"
+        )
+        repo_config_writer.set_value(
+            "user", "email", "github-cicd-functional-test@iambic.org"
+        )
+        repo_config_writer.release()
+
+        os.makedirs(f"{temp_templates_directory}/{TEST_TEMPLATE_DIR}")
+        os.makedirs(f"{temp_templates_directory}/{TEST_CONFIG_DIR}")
+
+        with open(f"{temp_templates_directory}/{TEST_TEMPLATE_PATH}", "w") as f:
+            f.write(TEST_TEMPLATE_YAML.format(name="before"))
+
+        with open(f"{temp_templates_directory}/{TEST_CONFIG_PATH}", "w") as f:
+            f.write(
+                TEST_CONFIG_YAML.format(example_plugin_location=EXAMPLE_PLUGIN_PATH)
+            )
+
+        repo.git.add(A=True)
+        repo.git.commit(m="before")
+        repo.remotes.origin.push().raise_if_error()
+
+        asyncio.run(load_config(f"{temp_templates_directory}/{TEST_CONFIG_PATH}"))
+        yield f"{temp_templates_directory}/{TEST_CONFIG_PATH}", temp_templates_directory
+    finally:
+        try:
+            shutil.rmtree(temp_templates_directory)
+            shutil.rmtree(bare_directory)
+        except Exception as e:
+            print(e)
+
+
+@pytest.mark.asyncio
+async def test_template_delete(templates_repo: tuple[str, str]):
+    _, repo_dir = templates_repo
+
+    repo = git.Repo(repo_dir)
+    diff_index = repo.index.diff("HEAD")
+    # assert there is no local changes
+    assert len(diff_index) == 0
+
+    template = load_templates([f"{repo_dir}/{TEST_TEMPLATE_PATH}"])[0]
+    template_path = str(template.file_path)
+    template.delete()
+    # verify the template has pending git removal status
+
+    diff_index = repo.index.diff("HEAD")
+    assert len(diff_index) == 1
+    diff_removed: Diff = list(diff_index)[0]
+    assert diff_removed.a_mode == 0
+    # not using pathlib because git diff objects can have paths
+    # that don't actually exist in filesystem. those path
+    # are relative to the git tree
+    assert f"{repo_dir}/{diff_removed.a_path}" == template_path


### PR DESCRIPTION
What's changed?
* cast template.file_path to str before passing to gitpython because gitpython cannot deal with pathlib.path

How'd to test?
* Add unit test