### PR TITLE
EN-1956 Add workflow to release to PyPI

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -1,0 +1,20 @@
+name: Publish to PyPI
+on:
+  workflow_dispatch
+jobs:
+  build-n-publish:
+    if: ${{ github.repository == 'noqdev/iambic' }}
+    name: Build and publish Python 🐍 distributions 📦 to PyPI
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.9"
+    - name: bootstrap
+      run: |
+        pip install poetry setuptools pip --upgrade
+    - run: poetry config pypi-token.pypi "${{ secrets.PYPI_API_KEY }}"
+    - name: Publish package
+      run: poetry publish --build

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -15,6 +15,6 @@ jobs:
     - name: bootstrap
       run: |
         pip install poetry setuptools pip --upgrade
-    - run: poetry config pypi-token.pypi "${{ secrets.PYPI_API_KEY }}"
+    - run: poetry config pypi-token.pypi "${{ secrets.IAMBIC_PYPI_API_KEY }}"
     - name: Publish package
       run: poetry publish --build


### PR DESCRIPTION
What's changed?
* Add a workflow for manual trigger to publish to PyPI

I haven't tested it yet since I don't have access to publish to iambic_core