### PR TITLE
EN-2003 Prototype read-only on spoke role

### DIFF
--- a/docs/web/docs/3-reference/6-aws_hub_and_spoke_roles.mdx
+++ b/docs/web/docs/3-reference/6-aws_hub_and_spoke_roles.mdx
@@ -77,3 +77,57 @@ and the following permissions:
   ]
 }
 ```
+
+## A more restrictive Spoke Role permissions
+
+If your initial evaluation requires a much more restrictive IAMbicSpokeRole, we do provide a CloudFormation
+StackSet template to create IAMbicSpokeRoleReadOnly. The read only postfix only uses list, read capability of
+`iam` and `sso` (aka IdentityCenter) services. However, in order for `iambic setup` to work, it keeps the
+write ability to SecretManager resources prefixed with `iambic-config-secrets-`. This is necessary to keeps
+track of other secrets used for other plugins.
+
+The effect of using a read-only Spoke Role would be IAMbic can only handle one directional import from AWS.
+
+You can either use `iambic setup` to instruct the initial setup to use a more restricted IAMbicSpokeRole or
+directly change the IAMbic configuration to specify the arn of the spoke role.
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": [
+                "identitystore:Describe*",
+                "identitystore:Get*",
+                "identitystore:List*",
+                "organizations:describe*",
+                "organizations:list*",
+                "iam:Get*",
+                "iam:List*",
+                "sso:Describe*",
+                "sso:Get*",
+                "sso:List*",
+                "sso:Search*"
+            ],
+            "Resource": [
+                "*"
+            ],
+            "Effect": "Allow"
+        },
+        {
+            "Action": [
+                "secretsmanager:CreateSecret",
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:describesecret",
+                "secretsmanager:listsecrets",
+                "secretsmanager:listsecretversionids",
+                "secretsmanager:PutSecretValue"
+            ],
+            "Resource": [
+                "arn:aws:secretsmanager:*:*:secret:iambic-config-secrets-*"
+            ],
+            "Effect": "Allow"
+        }
+    ]
+}
+```

--- a/iambic/config/wizard.py
+++ b/iambic/config/wizard.py
@@ -767,6 +767,15 @@ class ConfigurationWizard:
                     "Unable to add the AWS Account without creating the required roles."
                 )
                 return
+
+            self.config.aws.spoke_role_is_read_only = bool(
+                questionary.confirm(
+                    "Do you want to restrict IambicSpokeRole to read-only IAM and IdentityCenter service?\n"
+                    "This will limit IAMbic capability to import",
+                    default=False,
+                ).unsafe_ask()
+            )
+
         else:
             if requires_sync:
                 if not questionary.confirm(
@@ -803,15 +812,7 @@ class ConfigurationWizard:
                 )
                 return
 
-        read_only = bool(
-            questionary.confirm(
-                "Do you want to restrict IambicSpokeRole to read-only?\n"
-                "This will limit IAMbic capability to import",
-                default=False,
-            ).unsafe_ask()
-        )
-        self.config.aws.spoke_role_is_read_only = read_only
-
+        read_only = self.config.aws.spoke_role_is_read_only
         session, profile_name = self.get_boto3_session_for_account(account_id)
         if not session:
             return
@@ -1026,7 +1027,7 @@ class ConfigurationWizard:
 
         read_only = bool(
             questionary.confirm(
-                "Do you want to restrict IambicSpokeRole to read-only?\n"
+                "Do you want to restrict IambicSpokeRole to read-only IAM and IdentityCenter service?\n"
                 "This will limit IAMbic capability to import",
                 default=False,
             ).unsafe_ask()

--- a/iambic/plugins/v0_1_0/aws/cloud_formation/templates/IambicHubRole.yml
+++ b/iambic/plugins/v0_1_0/aws/cloud_formation/templates/IambicHubRole.yml
@@ -45,7 +45,7 @@ Resources:
                 Action:
                   - sts:assumerole
                 Resource:
-                  - !Sub 'arn:aws:iam::*:role/${SpokeRoleName}'
+                  - !Sub 'arn:aws:iam::*:role/${SpokeRoleName}*'
         - PolicyName: list_spoke_account_info
           PolicyDocument:
             Version: '2012-10-17'

--- a/iambic/plugins/v0_1_0/aws/cloud_formation/templates/IambicSpokeRoleReadOnly.yml
+++ b/iambic/plugins/v0_1_0/aws/cloud_formation/templates/IambicSpokeRoleReadOnly.yml
@@ -1,0 +1,56 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  This template creates the IAMbic read-only spoke role.
+Parameters:
+  SpokeRoleName:
+    Type: String
+  HubRoleArn:
+    Type: String
+Resources:
+  IambicSpokeRoleReadOnly:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      RoleName: !Ref SpokeRoleName
+      Description: >-
+        This role is used by IAMbic to perform all actions on the account.
+        It is assumed by the Iambic hub role in the hub account.
+        Managed via CloudFormation.
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - sts:AssumeRole
+              - sts:TagSession
+            Principal:
+              AWS: !Ref HubRoleArn
+      Policies:
+        - PolicyName: base_permissions
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - identitystore:Describe*
+                  - identitystore:Get*
+                  - identitystore:List*
+                  - organizations:describe*
+                  - organizations:list*
+                  - iam:Get*
+                  - iam:List*
+                  - sso:Describe*
+                  - sso:Get*
+                  - sso:List*
+                  - sso:Search*
+                Resource:
+                  - '*'
+              - Effect: Allow
+                Action:
+                  - secretsmanager:CreateSecret
+                  - secretsmanager:GetSecretValue
+                  - secretsmanager:describesecret
+                  - secretsmanager:listsecrets
+                  - secretsmanager:listsecretversionids
+                  - secretsmanager:PutSecretValue
+                Resource:
+                  - 'arn:aws:secretsmanager:*:*:secret:iambic-config-secrets-*'

--- a/iambic/plugins/v0_1_0/aws/iambic_plugin.py
+++ b/iambic/plugins/v0_1_0/aws/iambic_plugin.py
@@ -40,6 +40,13 @@ class AWSConfig(BaseModel):
         ),
     )
     sqs_cloudtrail_changes_queues: Optional[list[str]] = []
+    spoke_role_is_read_only: bool = Field(
+        False,
+        description=(
+            "aws iambic spoke role is configured as read_only. "
+            "If true, it will restrict IAMbic capability in AWS"
+        ),
+    )
 
     @validator("organizations", allow_reuse=True)
     def validate_organizations(cls, organizations):

--- a/iambic/plugins/v0_1_0/aws/models.py
+++ b/iambic/plugins/v0_1_0/aws/models.py
@@ -55,8 +55,11 @@ def get_hub_role_arn(account_id: str) -> str:
     return f"arn:aws:iam::{account_id}:role/{IAMBIC_HUB_ROLE_NAME}"
 
 
-def get_spoke_role_arn(account_id: str) -> str:
-    return f"arn:aws:iam::{account_id}:role/{IAMBIC_SPOKE_ROLE_NAME}"
+def get_spoke_role_arn(account_id: str, read_only=False) -> str:
+    spoke_role_postfix = "ReadOnly" if read_only else ""
+    return (
+        f"arn:aws:iam::{account_id}:role/{IAMBIC_SPOKE_ROLE_NAME}{spoke_role_postfix}"
+    )
 
 
 @yaml_object(yaml)
@@ -581,6 +584,10 @@ class AWSOrganization(BaseAWSAccountAndOrgModel):
     hub_role_arn: str = Field(
         description="The role arn to assume into when making calls to the account",
     )
+    spoke_role_is_read_only: bool = Field(
+        False,
+        description="if true, the spoke role name is IambicSpokeRoleReadOnly",
+    )
 
     async def _create_org_account_instance(
         self, account: dict, session: boto3.Session
@@ -615,7 +622,9 @@ class AWSOrganization(BaseAWSAccountAndOrgModel):
             variables=account["variables"],
             identity_center_details=identity_center_details,
             iambic_managed=account_rule.iambic_managed,
-            spoke_role_arn=get_spoke_role_arn(account_id),
+            spoke_role_arn=get_spoke_role_arn(
+                account_id, read_only=self.spoke_role_is_read_only
+            ),
             hub_session_info=dict(boto3_session=session),
             default_region=region_name,
             boto3_session_map={},


### PR DESCRIPTION
What's changed?
* Add a concept of IambicSpokeRoleReadOnly stackset, it attempt to be very conservative on permission needs, mostly Describe*, Get*, List*
* Patch wizard to ask if they want to limit iambic spoke role (this is a patch to ux), UX can still use a lot of improvement

How to test?
Run iambic setup, pick read only and see if it successfully import all the aws org roles