### PR TITLE
EN-2021 write template when group is created

### DIFF
--- a/iambic/plugins/v0_1_0/azure_ad/group/models.py
+++ b/iambic/plugins/v0_1_0/azure_ad/group/models.py
@@ -336,6 +336,7 @@ class AzureActiveDirectoryGroupTemplate(ExpiryModel, AzureADTemplate):
                     group_types=self.properties.group_types,
                 )
                 self.properties.group_id = cloud_group.group_id
+                self.write()
             except ClientResponseError as err:
                 log.exception(
                     "Failed to create user in Azure AD",

--- a/iambic/plugins/v0_1_0/azure_ad/user/models.py
+++ b/iambic/plugins/v0_1_0/azure_ad/user/models.py
@@ -199,6 +199,7 @@ class AzureActiveDirectoryUserTemplate(ExpiryModel, AzureADTemplate):
                     or self.properties.username.split("@")[0],
                 )
                 self.properties.user_id = cloud_user.user_id
+                self.write()
             except ClientResponseError as err:
                 log.exception(
                     "Failed to create user in Azure AD",


### PR DESCRIPTION
## What's changed in the PR?
- add template write after create a resource

## Rationale
- Resources in Az needs an identifier to be manipulate, in other cases like aws just the name.

## How'd to test?
- no
