### PR TITLE
Improve signal-to-noise on status-checks

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
 jobs:
   run-unit-and-functional-test:
+    # Version Auto Bump happens when CICD just auto bump patch version
+    # We have decided to minimize generating work that is not necessary.
+    if: ${{ github.event.commits[0].author.name != 'Version Auto Bump' }}
     # Since functional tests include tests that does not handle parallel runs
     # For example, config_discovery test does not tolerate resources being
     # destroyed, we are setting the concurrency here to only 1 active run at

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 1%


### PR DESCRIPTION
## What's changed in the PR?
* Ignore `Auto Version Bump` and run-test workflow 
* Add repository based codecov.yml configuration, allow 1% drop in code coverage for small things

## Rationale
Auto Version Bump only affects the version string.

## How'd to test?
* Probably need to let GH does another version bump to observe. The snippet is copied from build-container workflow
