### PR TITLE
Task/en 1980 optimize template generation

### DIFF
--- a/functional_tests/aws/group/utils.py
+++ b/functional_tests/aws/group/utils.py
@@ -6,6 +6,7 @@ import uuid
 from functional_tests.conftest import IAMBIC_TEST_DETAILS
 from iambic.core.iambic_enum import Command
 from iambic.core.models import ExecutionMessage
+from iambic.core.template_generation import get_existing_template_map
 from iambic.plugins.v0_1_0.aws.iam.group.models import AwsIamGroupTemplate
 from iambic.plugins.v0_1_0.aws.iam.group.template_generation import (
     collect_aws_groups,
@@ -62,15 +63,22 @@ async def group_full_import(detect_messages: list = None):
     exe_message = ExecutionMessage(
         execution_id=str(uuid.uuid4()), command=Command.IMPORT, provider_type="aws"
     )
+    iam_template_map = await get_existing_template_map(
+        repo_dir=IAMBIC_TEST_DETAILS.template_dir_path,
+        template_type="AWS::IAM.*",
+        nested=True,
+    )
+
     await collect_aws_groups(
         exe_message,
         IAMBIC_TEST_DETAILS.config.aws,
-        IAMBIC_TEST_DETAILS.template_dir_path,
+        iam_template_map,
         detect_messages,
     )
     await generate_aws_group_templates(
         exe_message,
         IAMBIC_TEST_DETAILS.config.aws,
         IAMBIC_TEST_DETAILS.template_dir_path,
+        iam_template_map,
         detect_messages,
     )

--- a/functional_tests/aws/managed_policy/utils.py
+++ b/functional_tests/aws/managed_policy/utils.py
@@ -7,6 +7,7 @@ from functional_tests.conftest import IAMBIC_TEST_DETAILS
 from iambic.core.iambic_enum import Command
 from iambic.core.logger import log
 from iambic.core.models import ExecutionMessage
+from iambic.core.template_generation import get_existing_template_map
 from iambic.core.utils import gather_templates
 from iambic.plugins.v0_1_0.aws.iam.policy.models import (
     AWS_MANAGED_POLICY_TEMPLATE_TYPE,
@@ -63,15 +64,22 @@ async def managed_policy_full_import(detect_messages: list = None):
     exe_message = ExecutionMessage(
         execution_id=str(uuid.uuid4()), command=Command.IMPORT, provider_type="aws"
     )
+    iam_template_map = await get_existing_template_map(
+        repo_dir=IAMBIC_TEST_DETAILS.template_dir_path,
+        template_type="AWS::IAM.*",
+        nested=True,
+    )
+
     await collect_aws_managed_policies(
         exe_message,
         IAMBIC_TEST_DETAILS.config.aws,
-        IAMBIC_TEST_DETAILS.template_dir_path,
+        iam_template_map,
         detect_messages,
     )
     await generate_aws_managed_policy_templates(
         exe_message,
         IAMBIC_TEST_DETAILS.config.aws,
         IAMBIC_TEST_DETAILS.template_dir_path,
+        iam_template_map,
         detect_messages,
     )

--- a/functional_tests/aws/permission_set/test_update_template.py
+++ b/functional_tests/aws/permission_set/test_update_template.py
@@ -111,7 +111,7 @@ class UpdatePermissionSetTestCase(IsolatedAsyncioTestCase):
             PermissionSetAccess(users=[EXAMPLE_USER], groups=[EXAMPLE_GROUP])
         ]
         changes = await self.template.apply(IAMBIC_TEST_DETAILS.config.aws)
-        assert changes.exceptions_seen in [None, []]
+        self.assertFalse(bool(changes.exceptions_seen))
 
         await IAMBIC_TEST_DETAILS.identity_center_account.set_identity_center_details(
             batch_size=5

--- a/functional_tests/aws/permission_set/utils.py
+++ b/functional_tests/aws/permission_set/utils.py
@@ -7,6 +7,7 @@ from functional_tests.conftest import IAMBIC_TEST_DETAILS
 from iambic.core.iambic_enum import Command
 from iambic.core.logger import log
 from iambic.core.models import ExecutionMessage
+from iambic.core.template_generation import get_existing_template_map
 from iambic.core.utils import gather_templates
 from iambic.plugins.v0_1_0.aws.identity_center.permission_set.models import (
     AWS_IDENTITY_CENTER_PERMISSION_SET_TEMPLATE_TYPE,
@@ -111,15 +112,21 @@ async def permission_set_full_import(detect_messages: list = None):
     exe_message = ExecutionMessage(
         execution_id=str(uuid.uuid4()), command=Command.IMPORT, provider_type="aws"
     )
+    identity_center_template_map = await get_existing_template_map(
+        repo_dir=IAMBIC_TEST_DETAILS.template_dir_path,
+        template_type="AWS::IdentityCenter.*",
+        nested=True,
+    )
     await collect_aws_permission_sets(
         exe_message,
         IAMBIC_TEST_DETAILS.config.aws,
-        IAMBIC_TEST_DETAILS.template_dir_path,
+        identity_center_template_map,
         detect_messages,
     )
     await generate_aws_permission_set_templates(
         exe_message,
         IAMBIC_TEST_DETAILS.config.aws,
         IAMBIC_TEST_DETAILS.template_dir_path,
+        identity_center_template_map,
         detect_messages,
     )

--- a/functional_tests/aws/role/test_template_generation.py
+++ b/functional_tests/aws/role/test_template_generation.py
@@ -95,7 +95,6 @@ class PartialImportRoleTestCase(IsolatedAsyncioTestCase):
         # Create the policy on all accounts except 1
         await self.template.apply(IAMBIC_TEST_DETAILS.config.aws)
         self.template.write(exclude_unset=False)
-
         await role_full_import(
             [
                 RoleMessageDetails(

--- a/functional_tests/aws/role/utils.py
+++ b/functional_tests/aws/role/utils.py
@@ -6,6 +6,7 @@ import uuid
 from functional_tests.conftest import IAMBIC_TEST_DETAILS
 from iambic.core.iambic_enum import Command
 from iambic.core.models import ExecutionMessage
+from iambic.core.template_generation import get_existing_template_map
 from iambic.plugins.v0_1_0.aws.iam.role.models import AwsIamRoleTemplate, RoleAccess
 from iambic.plugins.v0_1_0.aws.iam.role.template_generation import (
     collect_aws_roles,
@@ -106,15 +107,22 @@ async def role_full_import(detect_messages: list = None):
     exe_message = ExecutionMessage(
         execution_id=str(uuid.uuid4()), command=Command.IMPORT, provider_type="aws"
     )
+    iam_template_map = await get_existing_template_map(
+        repo_dir=IAMBIC_TEST_DETAILS.template_dir_path,
+        template_type="AWS::IAM.*",
+        nested=True,
+    )
+
     await collect_aws_roles(
         exe_message,
         IAMBIC_TEST_DETAILS.config.aws,
-        IAMBIC_TEST_DETAILS.template_dir_path,
+        iam_template_map,
         detect_messages,
     )
     await generate_aws_role_templates(
         exe_message,
         IAMBIC_TEST_DETAILS.config.aws,
         IAMBIC_TEST_DETAILS.template_dir_path,
+        iam_template_map,
         detect_messages,
     )

--- a/functional_tests/aws/user/utils.py
+++ b/functional_tests/aws/user/utils.py
@@ -6,6 +6,7 @@ import uuid
 from functional_tests.conftest import IAMBIC_TEST_DETAILS
 from iambic.core.iambic_enum import Command
 from iambic.core.models import ExecutionMessage
+from iambic.core.template_generation import get_existing_template_map
 from iambic.plugins.v0_1_0.aws.iam.user.models import AwsIamUserTemplate
 from iambic.plugins.v0_1_0.aws.iam.user.template_generation import (
     collect_aws_users,
@@ -56,16 +57,23 @@ async def user_full_import(detect_messages: list = None):
     exe_message = ExecutionMessage(
         execution_id=str(uuid.uuid4()), command=Command.IMPORT, provider_type="aws"
     )
+    iam_template_map = await get_existing_template_map(
+        repo_dir=IAMBIC_TEST_DETAILS.template_dir_path,
+        template_type="AWS::IAM.*",
+        nested=True,
+    )
+
     # Refresh the template
     await collect_aws_users(
         exe_message,
         IAMBIC_TEST_DETAILS.config.aws,
-        IAMBIC_TEST_DETAILS.template_dir_path,
+        iam_template_map,
         detect_messages,
     )
     await generate_aws_user_templates(
         exe_message,
         IAMBIC_TEST_DETAILS.config.aws,
         IAMBIC_TEST_DETAILS.template_dir_path,
+        iam_template_map,
         detect_messages,
     )

--- a/iambic/core/template_generation.py
+++ b/iambic/core/template_generation.py
@@ -20,17 +20,26 @@ from iambic.core.utils import (
 from iambic.plugins.v0_1_0.aws.models import AWSAccount
 
 
-async def get_existing_template_map(repo_dir: str, template_type: str) -> dict:
+async def get_existing_template_map(
+    repo_dir: str, template_type: str, nested: bool = False
+) -> dict:
     """Used to keep track of existing templates on import
 
      Write to the existing file before creating a new one.
 
     :param repo_dir:
     :param template_type:
+    :param nested: If true, will return a map of {template_type: {resource_id: template}}
     :return: {resource_id: template}
     """
     templates = load_templates(await gather_templates(repo_dir, template_type))
-    return {template.resource_id: template for template in templates}
+    if not nested:
+        return {template.resource_id: template for template in templates}
+
+    response = defaultdict(dict)
+    for template in templates:
+        response[template.template_type][template.resource_id] = template
+    return response
 
 
 def templatize_resource(aws_account: AWSAccount, resource):

--- a/iambic/plugins/v0_1_0/aws/handlers.py
+++ b/iambic/plugins/v0_1_0/aws/handlers.py
@@ -15,6 +15,7 @@ from iambic.core.iambic_enum import Command, IambicManaged
 from iambic.core.logger import log
 from iambic.core.models import BaseTemplate, ExecutionMessage, TemplateChangeDetails
 from iambic.core.parser import load_templates
+from iambic.core.template_generation import get_existing_template_map
 from iambic.core.utils import async_batch_processor, gather_templates, yaml
 from iambic.plugins.v0_1_0.aws.event_bridge.models import (
     GroupMessageDetails,
@@ -126,6 +127,7 @@ async def apply_identity_center_templates(
     :param templates: The list of templates to apply.
     :param remote_worker: The remote worker to use for applying templates.
     """
+    await config.set_identity_center_details(exe_message.provider_id)
     return await async_batch_processor(
         [template.apply(config) for template in templates],
         5,
@@ -232,6 +234,7 @@ async def import_service_resources(
     async_generator_callables: list,
     messages: list = None,
     remote_worker=None,
+    existing_template_map: dict = None,
 ):
     base_runner = bool(not exe_message.metadata)
     if not exe_message.metadata:
@@ -256,7 +259,7 @@ async def import_service_resources(
 
             tasks.append(
                 async_collector_callable(
-                    task_message, config, base_output_dir, messages
+                    task_message, config, existing_template_map, messages
                 )
             )
 
@@ -275,7 +278,13 @@ async def import_service_resources(
     if base_runner:
         await asyncio.gather(
             *[
-                async_generator_callable(exe_message, config, base_output_dir, messages)
+                async_generator_callable(
+                    exe_message,
+                    config,
+                    base_output_dir,
+                    existing_template_map,
+                    messages,
+                )
                 for async_generator_callable in async_generator_callables
             ]
         )
@@ -287,6 +296,7 @@ async def import_identity_center_resources(
     base_output_dir: str,
     messages: list = None,
     remote_worker=None,
+    existing_template_map: dict = None,
 ):
     identity_center_config = config.copy()
     identity_center_config.accounts = [
@@ -316,6 +326,7 @@ async def import_identity_center_resources(
         [generate_aws_permission_set_templates],
         messages,
         remote_worker,
+        existing_template_map,
     )
 
 
@@ -329,13 +340,35 @@ async def import_aws_resources(
     tasks = []
 
     if not exe_message.metadata or exe_message.metadata["service"] == "identity_center":
+        identity_center_template_map = None
+        if not remote_worker or exe_message.metadata:
+            identity_center_template_map = await get_existing_template_map(
+                repo_dir=base_output_dir,
+                template_type="AWS::IdentityCenter.*",
+                nested=True,
+            )
+
         tasks.append(
             import_identity_center_resources(
-                exe_message, config, base_output_dir, messages, remote_worker
+                exe_message,
+                config,
+                base_output_dir,
+                messages,
+                remote_worker,
+                identity_center_template_map,
             )
         )
 
     if not exe_message.metadata or exe_message.metadata["service"] == "iam":
+        iam_template_map = None
+
+        if not remote_worker or exe_message.metadata:
+            iam_template_map = await get_existing_template_map(
+                repo_dir=base_output_dir,
+                template_type="AWS::IAM.*",
+                nested=True,
+            )
+
         tasks.append(
             import_service_resources(
                 exe_message,
@@ -356,6 +389,7 @@ async def import_aws_resources(
                 ],
                 messages,
                 remote_worker,
+                iam_template_map,
             )
         )
 
@@ -525,29 +559,48 @@ async def detect_changes(  # noqa: C901
         execution_id=str(uuid.uuid4()), command=Command.IMPORT, provider_type="aws"
     )
     collect_tasks = []
+    iam_template_map = None
+    identity_center_template_map = None
+
+    if role_messages or user_messages or group_messages or managed_policy_messages:
+        iam_template_map = await get_existing_template_map(
+            repo_dir=repo_dir,
+            template_type="AWS::IAM.*",
+            nested=True,
+        )
+
+    if permission_set_messages:
+        identity_center_template_map = await get_existing_template_map(
+            repo_dir=repo_dir,
+            template_type="AWS::IdentityCenter.*",
+            nested=True,
+        )
 
     if role_messages:
         collect_tasks.append(
-            collect_aws_roles(exe_message, config, repo_dir, role_messages)
+            collect_aws_roles(exe_message, config, iam_template_map, role_messages)
         )
     if user_messages:
         collect_tasks.append(
-            collect_aws_users(exe_message, config, repo_dir, user_messages)
+            collect_aws_users(exe_message, config, iam_template_map, user_messages)
         )
     if group_messages:
         collect_tasks.append(
-            collect_aws_groups(exe_message, config, repo_dir, group_messages)
+            collect_aws_groups(exe_message, config, iam_template_map, group_messages)
         )
     if managed_policy_messages:
         collect_tasks.append(
             collect_aws_managed_policies(
-                exe_message, config, repo_dir, managed_policy_messages
+                exe_message, config, iam_template_map, managed_policy_messages
             )
         )
     if permission_set_messages:
         collect_tasks.append(
             collect_aws_permission_sets(
-                exe_message, config, repo_dir, permission_set_messages
+                exe_message,
+                config,
+                identity_center_template_map,
+                permission_set_messages,
             )
         )
 
@@ -558,31 +611,39 @@ async def detect_changes(  # noqa: C901
         if role_messages:
             tasks.append(
                 generate_aws_role_templates(
-                    exe_message, config, repo_dir, role_messages
+                    exe_message, config, repo_dir, iam_template_map, role_messages
                 )
             )
         if user_messages:
             tasks.append(
                 generate_aws_user_templates(
-                    exe_message, config, repo_dir, user_messages
+                    exe_message, config, repo_dir, iam_template_map, user_messages
                 )
             )
         if group_messages:
             tasks.append(
                 generate_aws_group_templates(
-                    exe_message, config, repo_dir, group_messages
+                    exe_message, config, repo_dir, iam_template_map, group_messages
                 )
             )
         if managed_policy_messages:
             tasks.append(
                 generate_aws_managed_policy_templates(
-                    exe_message, config, repo_dir, managed_policy_messages
+                    exe_message,
+                    config,
+                    repo_dir,
+                    iam_template_map,
+                    managed_policy_messages,
                 )
             )
         if permission_set_messages:
             tasks.append(
                 generate_aws_permission_set_templates(
-                    exe_message, config, repo_dir, permission_set_messages
+                    exe_message,
+                    config,
+                    repo_dir,
+                    identity_center_template_map,
+                    permission_set_messages,
                 )
             )
         await asyncio.gather(*tasks)

--- a/iambic/plugins/v0_1_0/aws/iam/group/template_generation.py
+++ b/iambic/plugins/v0_1_0/aws/iam/group/template_generation.py
@@ -14,7 +14,6 @@ from iambic.core.template_generation import (
     base_group_str_attribute,
     create_or_update_template,
     delete_orphaned_templates,
-    get_existing_template_map,
     group_dict_attribute,
     group_int_or_str_attribute,
 )

--- a/iambic/plugins/v0_1_0/aws/iam/policy/template_generation.py
+++ b/iambic/plugins/v0_1_0/aws/iam/policy/template_generation.py
@@ -14,7 +14,6 @@ from iambic.core.template_generation import (
     base_group_str_attribute,
     create_or_update_template,
     delete_orphaned_templates,
-    get_existing_template_map,
     group_dict_attribute,
     group_int_or_str_attribute,
 )
@@ -302,7 +301,7 @@ async def create_templated_managed_policy(  # noqa: C901
 async def collect_aws_managed_policies(
     exe_message: ExecutionMessage,
     config: AWSConfig,
-    base_output_dir: str,
+    iam_template_map: dict,
     detect_messages: list[ManagedPolicyMessageDetails] = None,
 ):
     aws_account_map = await get_aws_account_map(config)
@@ -320,9 +319,7 @@ async def collect_aws_managed_policies(
         if not detect_messages:
             return
 
-    existing_template_map = await get_existing_template_map(
-        base_output_dir, AWS_MANAGED_POLICY_TEMPLATE_TYPE
-    )
+    existing_template_map = iam_template_map.get(AWS_MANAGED_POLICY_TEMPLATE_TYPE, {})
 
     log.info(
         "Generating AWS managed policy templates. Beginning to retrieve AWS IAM Managed Policies.",
@@ -440,12 +437,11 @@ async def generate_aws_managed_policy_templates(
     exe_message: ExecutionMessage,
     config: AWSConfig,
     base_output_dir: str,
+    iam_template_map: dict,
     detect_messages: list[ManagedPolicyMessageDetails] = None,
 ):
     aws_account_map = await get_aws_account_map(config)
-    existing_template_map = await get_existing_template_map(
-        base_output_dir, AWS_MANAGED_POLICY_TEMPLATE_TYPE
-    )
+    existing_template_map = iam_template_map.get(AWS_MANAGED_POLICY_TEMPLATE_TYPE, {})
     resource_dir = get_template_dir(base_output_dir)
     account_managed_policies = await exe_message.get_sub_exe_files(
         *RESOURCE_DIR, file_name_and_extension="output.json", flatten_results=True

--- a/iambic/plugins/v0_1_0/aws/iam/user/template_generation.py
+++ b/iambic/plugins/v0_1_0/aws/iam/user/template_generation.py
@@ -14,7 +14,6 @@ from iambic.core.template_generation import (
     base_group_str_attribute,
     create_or_update_template,
     delete_orphaned_templates,
-    get_existing_template_map,
     group_dict_attribute,
     group_int_or_str_attribute,
 )
@@ -399,7 +398,7 @@ async def create_templated_user(  # noqa: C901
 async def collect_aws_users(
     exe_message: ExecutionMessage,
     config: AWSConfig,
-    base_output_dir: str,
+    iam_template_map: dict,
     detect_messages: list[UserMessageDetails] = None,
 ):
     aws_account_map = await get_aws_account_map(config)
@@ -408,9 +407,7 @@ async def collect_aws_users(
             exe_message.provider_id: aws_account_map[exe_message.provider_id]
         }
 
-    existing_template_map = await get_existing_template_map(
-        base_output_dir, AWS_IAM_USER_TEMPLATE_TYPE
-    )
+    existing_template_map = iam_template_map.get(AWS_IAM_USER_TEMPLATE_TYPE, {})
     set_user_resource_inline_policies_semaphore = NoqSemaphore(
         set_user_resource_inline_policies, 20
     )
@@ -418,8 +415,8 @@ async def collect_aws_users(
         set_user_resource_managed_policies, 30
     )
 
-    set_user_resource_groups_semaphore = NoqSemaphore(set_user_resource_groups, 30)
-    set_user_resource_tags_semaphore = NoqSemaphore(set_user_resource_tags, 50)
+    set_user_resource_groups_semaphore = NoqSemaphore(set_user_resource_groups, 25)
+    set_user_resource_tags_semaphore = NoqSemaphore(set_user_resource_tags, 30)
 
     log.info(
         "Generating AWS user templates. Beginning to retrieve AWS IAM Users.",
@@ -532,6 +529,7 @@ async def generate_aws_user_templates(
     exe_message: ExecutionMessage,
     config: AWSConfig,
     base_output_dir: str,
+    iam_template_map: dict,
     detect_messages: list[UserMessageDetails] = None,
 ):
     aws_account_map = await get_aws_account_map(config)
@@ -543,9 +541,7 @@ async def generate_aws_user_templates(
         if not detect_messages:
             return
 
-    existing_template_map = await get_existing_template_map(
-        base_output_dir, AWS_IAM_USER_TEMPLATE_TYPE
-    )
+    existing_template_map = iam_template_map.get(AWS_IAM_USER_TEMPLATE_TYPE, {})
     user_dir = get_template_dir(base_output_dir)
     account_users = await exe_message.get_sub_exe_files(
         *RESOURCE_DIR, file_name_and_extension="output.json", flatten_results=True

--- a/iambic/plugins/v0_1_0/aws/identity_center/permission_set/template_generation.py
+++ b/iambic/plugins/v0_1_0/aws/identity_center/permission_set/template_generation.py
@@ -15,7 +15,6 @@ from iambic.core.template_generation import (
     base_group_str_attribute,
     create_or_update_template,
     delete_orphaned_templates,
-    get_existing_template_map,
     group_dict_attribute,
     group_int_or_str_attribute,
 )
@@ -374,7 +373,7 @@ async def create_templated_permission_set(  # noqa: C901
 async def collect_aws_permission_sets(
     exe_message: ExecutionMessage,
     config: AWSConfig,
-    base_output_dir: str,
+    identity_center_template_map: dict,
     detect_messages: list[PermissionSetMessageDetails] = None,
 ):
     resource_dir = exe_message.get_directory(*RESOURCE_DIR)
@@ -506,12 +505,13 @@ async def generate_aws_permission_set_templates(
     exe_message: ExecutionMessage,
     config: AWSConfig,
     base_output_dir: str,
+    identity_center_template_map: dict,
     detect_messages: list[PermissionSetMessageDetails] = None,
 ):
     resource_dir = get_template_dir(base_output_dir)
     aws_account_map = await get_aws_account_map(config)
-    existing_template_map = await get_existing_template_map(
-        base_output_dir, AWS_IDENTITY_CENTER_PERMISSION_SET_TEMPLATE_TYPE
+    existing_template_map = identity_center_template_map.get(
+        AWS_IDENTITY_CENTER_PERMISSION_SET_TEMPLATE_TYPE, {}
     )
 
     all_permission_sets = await exe_message.get_sub_exe_files(

--- a/test/plugins/v0_1_0/aws/iam/user/test_template_generation.py
+++ b/test/plugins/v0_1_0/aws/iam/user/test_template_generation.py
@@ -18,6 +18,7 @@ from moto import mock_sts
 import iambic
 from iambic.core.iambic_enum import Command
 from iambic.core.models import ExecutionMessage
+from iambic.core.template_generation import get_existing_template_map
 from iambic.plugins.v0_1_0.aws.iam.user.template_generation import (
     collect_aws_users,
     generate_account_user_resource_files,
@@ -153,7 +154,13 @@ async def test_collect_aws_users(
 ):
     _, templates_base_dir = mock_fs
     config = AWSConfig(accounts=[mock_aws_account])
-    await collect_aws_users(mock_execution_message, config, templates_base_dir)
+    iam_template_map = await get_existing_template_map(
+        repo_dir=templates_base_dir,
+        template_type="AWS::IAM.*",
+        nested=True,
+    )
+
+    await collect_aws_users(mock_execution_message, config, iam_template_map)
     output_path = f"{templates_base_dir}/.iambic/fake_execution_id/iam/user/output.json"
     with open(output_path, "r") as f:
         output_users = json.load(f)
@@ -170,11 +177,18 @@ async def test_generate_aws_role_templates(
 ):
     _, templates_base_dir = mock_fs
     config = AWSConfig(accounts=[mock_aws_account])
+
+    iam_template_map = await get_existing_template_map(
+        repo_dir=templates_base_dir,
+        template_type="AWS::IAM.*",
+        nested=True,
+    )
+
     # have to call collect_aws_users to prep the cloud response
-    await collect_aws_users(mock_execution_message, config, templates_base_dir)
+    await collect_aws_users(mock_execution_message, config, iam_template_map)
     # actually call the function being tested
     await generate_aws_user_templates(
-        mock_execution_message, config, templates_base_dir
+        mock_execution_message, config, templates_base_dir, iam_template_map
     )
     output_path = f"{templates_base_dir}/resources/aws/iam/user/example_account/example_username.yaml"
     assert os.path.exists(output_path)


### PR DESCRIPTION
## Jira Ticket
* https://noqdev.atlassian.net/browse/EN-1980

## Rationale
* get_existing_template_map can be expensive so move the call into the handler instead of in the resource collect and generate functions to reduce look ups and improve performance.

## Testing
* Unit tests
* Functional tests