### PR TITLE
EN-2026 Publish docs when main branch is updated

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,24 @@
+name: Publish docs
+# This publish docs to https://iambic.org/
+on:
+  push:
+   branches:
+     - main
+jobs:
+  build-container:
+    if: ${{ github.repository == 'noqdev/iambic' && github.event.commits[0].author.name != 'Version Auto Bump' }}
+    runs-on: ubuntu-latest
+    name: docs publishing
+    steps:
+      - uses: actions/checkout@v3
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::242345320040:role/iambic_docs_publisher
+          aws-region: us-east-1
+      - name: publish docs
+        id: publish-docs
+        run: |
+          cd docs/web
+          yarn
+          make build_and_upload


### PR DESCRIPTION
## What's changed in the PR?
* Automatically build and sync docs to https://iambic.org/

## Rationale
* CICD flow for docs of https://iambic.org/

## How'd to test?
* not fully tested locally since I can't assume the same role. the commands run ok until it actually needs to interact with AWS. 
