### PR TITLE
Update publish-docs.yml

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -9,6 +9,9 @@ jobs:
     if: ${{ github.repository == 'noqdev/iambic' && github.event.commits[0].author.name != 'Version Auto Bump' }}
     runs-on: ubuntu-latest
     name: docs publishing
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v3
       - name: Configure AWS Credentials


### PR DESCRIPTION
add the missing permission: https://github.com/aws-actions/configure-aws-credentials/issues/271#issuecomment-931012696

## What's changed in the PR?
* Added id-token write permission in order to use aws credentials provider gh action

## Rationale
* from the provider's discussion: https://github.com/aws-actions/configure-aws-credentials/issues/271#issuecomment-931012696

## How'd to test?
* unfortunately for auth issues gh, this needs testing on gh. for what's worth, it does seem reasonable to the gh action we use for publishing docker images. https://github.com/noqdev/iambic/blob/main/.github/workflows/build-container.yml#L19
