### PR TITLE
Related to #322. Reference Hub-and-Spoke docs

### DIFF
--- a/iambic/config/wizard.py
+++ b/iambic/config/wizard.py
@@ -368,6 +368,7 @@ class ConfigurationWizard:
                 f"IAMbic detected you are using {identity_arn} for AWS access.\n"
                 f"This identity will require the ability to create"
                 f"CloudFormation stacks, stack sets, and stack set instances.\n"
+                f"Review to-be-created IAMbic roles at https://docs.iambic.org/reference/aws_hub_and_spoke_roles\n"
                 f"Would you like to use this identity?"
             ).ask():
                 self.caller_identity = default_caller_identity


### PR DESCRIPTION
## What's changed in the PR?
* Address when Account ID is automatically detected, the link for Hub-and-Spoke documentation is not displayed.

## Rationale
* Previously, we only show the Hub-and-Spoke docs when we are on the manual account entering. However, if wizard can find its account id through existing credentials, it never displays the link to Hub-and-Spoke documentation.

## How'd to test?
* Export AWS Identity Center session credentials in a terminal. Make sure there is no existing iambic-config in the current running directory
* Run `iambic setup`
* wizard should automatically detect the account id and the Hub-and-Spoke doc link is display.
