### PR TITLE
Reference the standalone iambic-templates-examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,10 @@ properties:
       expires_at: tomorrow
 ```
 
+## Preview standalone IAMbic templates repository
+
+Preview a standalone [IAMbic templates repository](https://github.com/noqdev/iambic-templates-examples) on how IAMbic tracks multi-cloud IAM assets in GitHub. The repository is made public for you to study. No need to make your repository public.
+
 ## IAMbic - Beta Software
 
 IAMbic is currently in beta, and is not yet recommended for use in production environments. We are actively working to improve the stability and performance of the software, and welcome feedback from the community.


### PR DESCRIPTION
## What's changed in the PR?
* Reference the standalone iambic-templates-examples on README.md

## Rationale
* Others can preview how IAMbic track multi-cloud IAM assets in GitHub.

## How'd to test?
* Preview button
