### PR TITLE
EN-2042 Fix merge_model from base to none

### DIFF
--- a/iambic/core/template_generation.py
+++ b/iambic/core/template_generation.py
@@ -971,7 +971,9 @@ def merge_model(
                 # any local metadata that needs to survive outside of cloud.
                 setattr(merged_model, key, new_value)
             else:
-                raise NotImplementedError
+                raise TypeError(
+                    f"Type of {type(new_value)} is not supported. Please file a github issue"
+                )
         elif key not in iambic_fields:
             setattr(merged_model, key, new_value)
     return merged_model

--- a/iambic/core/template_generation.py
+++ b/iambic/core/template_generation.py
@@ -965,6 +965,11 @@ def merge_model(
                         new_value, [existing_value], all_provider_children
                     ),
                 )
+            elif new_value is None:
+                # cloud is represented by None, local is a BaseModel.
+                # this will only work if the local BaseModel does not carry
+                # any local metadata that needs to survive outside of cloud.
+                setattr(merged_model, key, new_value)
             else:
                 raise NotImplementedError
         elif key not in iambic_fields:

--- a/test/plugins/v0_1_0/aws/iam/role/test_models.py
+++ b/test/plugins/v0_1_0/aws/iam/role/test_models.py
@@ -5,6 +5,35 @@ from iambic.plugins.v0_1_0.aws.iam.role.models import AwsIamRoleTemplate, RolePr
 from iambic.plugins.v0_1_0.aws.models import AWSAccount, Description
 
 
+def test_merge_role_template_from_base_model_to_none(aws_accounts: list[AWSAccount]):
+    """this tests ensure the merge model is dealing with a attribute merges between local base model and cloud none during merge operation"""
+    existing_properties = {
+        "role_name": "bar",
+        "permissions_boundary": {
+            "policy_arn": "arn:aws:iam::aws:policy/aws-service-role/AccessAnalyzerServiceRolePolicy",
+        },
+    }
+    existing_document = AwsIamRoleTemplate(
+        identifier="{{account_name}}_iambic_test_role",
+        file_path="foo",
+        properties=existing_properties,
+    )
+    new_properties = {
+        "role_name": "bar",
+    }
+    new_document = AwsIamRoleTemplate(
+        identifier="{{account_name}}_iambic_test_role",
+        file_path="foo",
+        properties=new_properties,
+    )
+    merged_document: AwsIamRoleTemplate = merge_model(
+        new_document, existing_document, aws_accounts
+    )
+    assert existing_document.properties.permissions_boundary is not None
+    assert new_document.properties.permissions_boundary is None
+    assert merged_document.properties.permissions_boundary is None
+
+
 def test_merge_role_template_without_sid(aws_accounts: list[AWSAccount]):
     existing_properties = {
         "role_name": "bar",


### PR DESCRIPTION
## What's changed in the PR?
* When a base model attribute goes from base model to none, we will not do recursive merge and just set it to none

## Rationale
* Our previous logic only handles merging old_base_model with new_base_model, and merging old_base_model with a list of base_model. We miss the obvious use case of going from old_base_model to none (when the cloud version eliminate the attribute) 

## How'd to test?
* I added unit test
