### PR TITLE
okta's user-status transition for provisioned->suspended and provisioned->deprovisioned

### DIFF
--- a/iambic/plugins/v0_1_0/okta/user/models.py
+++ b/iambic/plugins/v0_1_0/okta/user/models.py
@@ -225,6 +225,8 @@ class OktaUserTemplate(BaseTemplate, ExpiryModel):
             )
             if current_user:
                 change_details.current_value = current_user
+                self.properties.user_id = current_user.user_id
+                self.write()
         if (
             current_user
             and self.deleted

--- a/iambic/plugins/v0_1_0/okta/user/models.py
+++ b/iambic/plugins/v0_1_0/okta/user/models.py
@@ -256,7 +256,7 @@ class OktaUserTemplate(BaseTemplate, ExpiryModel):
                     log_params,
                 ),
                 maybe_deprovision_user(
-                    self.deleted,
+                    bool(self.deleted),
                     current_user,
                     okta_organization,
                     log_params,

--- a/iambic/plugins/v0_1_0/okta/user/utils.py
+++ b/iambic/plugins/v0_1_0/okta/user/utils.py
@@ -269,44 +269,46 @@ async def update_user_status(
             new_value=new_status,
         )
     )
+
+    # TODO: refactor to use an state machine approach
+    method = "POST"
+    base_endpoint = f"/api/v1/users/{user.user_id}"
+    if current_status == "suspended" and new_status == "active":
+        api_endpoint = f"{base_endpoint}/lifecycle/unsuspend"
+    elif current_status == "active" and new_status == "suspended":
+        api_endpoint = f"{base_endpoint}/lifecycle/suspend"
+    elif new_status == "deprovisioned" and current_status != "deprovisioned":
+        api_endpoint = f"{base_endpoint}/lifecycle/deactivate"
+    elif current_status in ["staged", "deprovisioned"] and new_status in [
+        "active",
+        "provisioned",
+    ]:
+        api_endpoint = f"{base_endpoint}/lifecycle/activate"
+    elif current_status in "provisioned" and new_status == "active":
+        api_endpoint = f"{base_endpoint}/lifecycle/reactivate"
+    elif current_status == "locked_out" and new_status == "active":
+        api_endpoint = f"{base_endpoint}/lifecycle/unlock"
+    elif new_status == "recovery":
+        api_endpoint = f"{base_endpoint}/lifecycle/reset_password"
+    elif new_status == "password_expired":
+        api_endpoint = f"{base_endpoint}/lifecycle/expire_password"
+    elif new_status == "deleted":
+        api_endpoint = f"{base_endpoint}"
+        method = "DELETE"
+    else:
+        log.error(
+            "Error updating user status",
+            user=user.username,
+            current_status=current_status,
+            new_status=new_status,
+            **log_params,
+        )
+        raise Exception(
+            f"Error updating user status. Invalid transition from {current_status} to {new_status}"
+        )
+
     if ctx.execute:
         client = await okta_organization.get_okta_client()
-        method = "POST"
-        # TODO: refactor to use an state machine approach
-        base_endpoint = f"/api/v1/users/{user.user_id}"
-        if current_status == "suspended" and new_status == "active":
-            api_endpoint = f"{base_endpoint}/lifecycle/unsuspend"
-        elif current_status == "active" and new_status == "suspended":
-            api_endpoint = f"{base_endpoint}/lifecycle/suspend"
-        elif new_status == "deprovisioned" and current_status != "deprovisioned":
-            api_endpoint = f"{base_endpoint}/lifecycle/deactivate"
-        elif current_status in ["staged", "deprovisioned"] and new_status in [
-            "active",
-            "provisioned",
-        ]:
-            api_endpoint = f"{base_endpoint}/lifecycle/activate"
-        elif current_status in "provisioned" and new_status == "active":
-            api_endpoint = f"{base_endpoint}/lifecycle/reactivate"
-        elif current_status == "locked_out" and new_status == "active":
-            api_endpoint = f"{base_endpoint}/lifecycle/unlock"
-        elif new_status == "recovery":
-            api_endpoint = f"{base_endpoint}/lifecycle/reset_password"
-        elif new_status == "password_expired":
-            api_endpoint = f"{base_endpoint}/lifecycle/expire_password"
-        elif new_status == "deleted":
-            api_endpoint = f"{base_endpoint}"
-            method = "DELETE"
-        else:
-            log.error(
-                "Error updating user status",
-                user=user.username,
-                current_status=current_status,
-                new_status=new_status,
-                **log_params,
-            )
-            raise Exception(
-                f"Error updating user status. Invalid transition from {current_status} to {new_status}"
-            )
         request, error = await client.get_request_executor().create_request(
             method=method, url=api_endpoint, body={}, headers={}, oauth=False
         )

--- a/iambic/plugins/v0_1_0/okta/user/utils.py
+++ b/iambic/plugins/v0_1_0/okta/user/utils.py
@@ -255,10 +255,6 @@ async def update_user_status(
     current_status: str = user.status.value
     if current_status == new_status:
         return response
-    if new_status == "deprovisioned":
-        # maybe_deprovision_user is called in the main loop
-        # and handles this use case
-        return response
     response.append(
         ProposedChange(
             change_type=ProposedChangeType.UPDATE,

--- a/iambic/plugins/v0_1_0/okta/user/utils.py
+++ b/iambic/plugins/v0_1_0/okta/user/utils.py
@@ -272,6 +272,7 @@ async def update_user_status(
     if ctx.execute:
         client = await okta_organization.get_okta_client()
         method = "POST"
+        # TODO: refactor to use an state machine approach
         base_endpoint = f"/api/v1/users/{user.user_id}"
         if current_status == "suspended" and new_status == "active":
             api_endpoint = f"{base_endpoint}/lifecycle/unsuspend"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -19,6 +19,7 @@ from iambic.config.templates import TEMPLATES
 from iambic.core.logger import log
 from iambic.plugins.v0_1_0.aws.iambic_plugin import AWSConfig
 from iambic.plugins.v0_1_0.aws.models import AWSAccount
+from iambic.core.context import ctx
 
 
 @pytest.fixture(scope="session")
@@ -247,3 +248,18 @@ def mock_aws_account_rw_secretsmanager_session(test_config):
         account_name="test",
         iambic_managed="read_and_write",
     )
+
+
+@pytest.fixture(scope="function")
+def mock_ctx(monkeypatch):
+    def _mock(
+        eval_only: bool = False,
+        use_remote: bool = False,
+        command=None,
+    ):
+        monkeypatch.setattr(ctx, "eval_only", eval_only)
+        monkeypatch.setattr(ctx, "use_remote", use_remote)
+        monkeypatch.setattr(ctx, "command", command)
+        return ctx
+
+    return _mock

--- a/test/plugins/v0_1_0/okta/user/test_utils.py
+++ b/test/plugins/v0_1_0/okta/user/test_utils.py
@@ -7,6 +7,7 @@ from test.plugins.v0_1_0.okta.test_utils import (  # noqa: F401 # intentional fo
 import okta.models
 import pytest
 
+from iambic.core.context import ctx
 import iambic.plugins.v0_1_0.okta.models
 from iambic.core.models import ProposedChangeType
 from iambic.plugins.v0_1_0.okta.iambic_plugin import OktaOrganization
@@ -17,7 +18,9 @@ from iambic.plugins.v0_1_0.okta.user.utils import (
     get_user,
     maybe_deprovision_user,
     update_user_profile,
+    update_user_status,
 )
+from iambic.plugins.v0_1_0.okta.models import UserStatus
 
 
 @pytest.mark.asyncio
@@ -152,6 +155,66 @@ async def test_update_user_profile(
         "current_profile": input_user.profile,
         "new_profile": input_profile,
     }
+
+
+class TestUpdateUserStatus:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "transition",
+        [
+            (UserStatus.provisioned, UserStatus.deprovisioned),
+            (UserStatus.active, UserStatus.deprovisioned),
+            (UserStatus.suspended, UserStatus.active),
+            (UserStatus.active, UserStatus.suspended),
+            (UserStatus.staged, UserStatus.active),
+            (UserStatus.deprovisioned, UserStatus.active),
+            (UserStatus.staged, UserStatus.provisioned),
+            (UserStatus.deprovisioned, UserStatus.provisioned),
+            (UserStatus.provisioned, UserStatus.active),
+            (UserStatus.locked_out, UserStatus.active),
+        ],
+    )
+    async def test_update_user_status(
+        self,
+        mock_okta_organization: OktaOrganization,  # noqa: F811 # intentional for mocks
+        mock_ctx,
+        transition,
+    ):
+        # Have to create user before getting it
+        username = "example_username"
+        idp_name = "example.org"
+        user_properties = UserProperties(
+            username=username,
+            profile={"login": username},
+            status=transition[0].value,
+        )  # type: ignore
+        template = OktaUserTemplate(
+            file_path="example", idp_name=idp_name, properties=user_properties
+        )  # type: ignore
+
+        okta_user = await create_user(
+            template,
+            mock_okta_organization,
+        )
+        okta_user.status = transition[0]
+
+        mock_ctx(eval_only=True)
+        proposed_changes = await update_user_status(
+            okta_user,
+            transition[1].value,
+            mock_okta_organization,
+            {},
+        )
+
+        print(proposed_changes)
+        assert proposed_changes[0].change_type == ProposedChangeType.UPDATE
+        assert proposed_changes[0].resource_type == okta_user.resource_type
+        assert proposed_changes[0].resource_id == okta_user.user_id
+        assert proposed_changes[0].attribute == "status"
+        assert proposed_changes[0].change_summary == {
+            "current_status": transition[0].value,
+            "proposed_status": transition[1].value,
+        }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What's changed in the PR?
Some status changes are not working correctly
- provisioned to suspended
- provisioned to deprovisioned

## Rationale
- for deprovision, remove some guard in the code. We was assumed that behavior would be solve in other place but it was not.
- for suspended, just active users can be suspended.  Retrieve the current status from okta.

## How'd to test?
- not atm
