### PR TITLE
Document compatible versions of GitHub

### DIFF
--- a/docs/web/docs/1-getting_started/7-github.mdx
+++ b/docs/web/docs/1-getting_started/7-github.mdx
@@ -110,6 +110,11 @@ Post-Link
 IAMbic's GitHub integration is designed to facilitate team collaboration on IAMbic templates.
 This page will walk you through the steps of configuring IAMbic, GitHub, and AWS to work together.
 
+### Compatible versions of Github
+
+ * GitHub Free
+ * GitHub Team
+ * Github Enterprise Cloud
 
 ### The typical workflow for using IAMbic with GitHub
 

--- a/iambic/plugins/v0_1_0/github/README.md
+++ b/iambic/plugins/v0_1_0/github/README.md
@@ -1,3 +1,9 @@
 # What is this plugin for?
 
 This is not managing Github cloud resources today. It exists to comply with plugin interface. Github Plugin today provides GithubApp integrations for iambic templates.
+
+# Compatible versions of Github
+
+* GitHub Free
+* GitHub Team
+* Github Enterprise Cloud


### PR DESCRIPTION
## What's changed in the PR?
* List the compatible version of GitHub

## Rationale
* It's likely self-hosted GitHub Enterprise Server is not compatible because of how the plugin contact the API.

## How'd to test?
* Docs update