### PR TITLE
EN-2056 Fix SQS resource policy

### DIFF
--- a/iambic/plugins/v0_1_0/aws/cloud_formation/templates/IdentityRuleDestination.yml
+++ b/iambic/plugins/v0_1_0/aws/cloud_formation/templates/IdentityRuleDestination.yml
@@ -62,4 +62,24 @@ Resources:
     Properties:
       QueueName: IAMbicChangeDetectionQueue
       MessageRetentionPeriod: 604800
-
+  IAMbicChangeDetectionQueueSQSPolicy: 
+    Type: AWS::SQS::QueuePolicy
+    Properties: 
+      Queues: 
+        - !Ref IAMbicChangeDetectionQueue
+      PolicyDocument: 
+        Statement: 
+          - Action: 
+              - "sqs:SendMessage" 
+            Effect: "Allow"
+            Resource: !GetAtt IAMbicChangeDetectionQueue.Arn
+            Principal:  
+              Service:
+                - "events.amazonaws.com"
+            Condition:
+              ArnEquals:
+                aws:SourceArn: !GetAtt IAMbicEventRule.Arn
+    DependsOn:
+      - IAMbicEventRule
+      - IAMbicChangeDetectionQueue
+      


### PR DESCRIPTION
## What's changed in the PR?
* Explicitly set SQS resource policy to allow event bridge to write to it

## Rationale
* Without setting the sqs resource policy, event bridge cannot actually push messages to it.

## How'd to test?
* Delete stack and re-create stack.
