### PR TITLE
EN-2059 Add sqs write access to IambicSpokeRole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.4.1 (Target Date May 1st 2023)
+
+PERMISSION CHANGES:
+* IambicHubRole added SQS read/write access to queue named `IAMbicChangeDetectionQueue` to support IAM resource detection. [#355]
+
+BUG FIXES:
+* IAM resource detect mechanism cannot remove SQS message that is already been processed in `IAMbicChangeDetectionQueue` [#355]
+
 ## 0.3.0 (April 21, 2023)
 
 BREAKING CHANGES:
@@ -14,7 +22,7 @@ ENHANCEMENTS:
 * Removed AWS package imports from core
 * Standardized variable naming in templates
 * Improved exception handling in the AWS package
-* Cleaned up additional import only checks on AWS IAM role, user, and group models. 
+* Cleaned up additional import only checks on AWS IAM role, user, and group models.
 
 BUG FIXES:
 * Resolved type error on merge template when new value is None.

--- a/docs/web/docs/3-reference/6-aws_hub_and_spoke_roles.mdx
+++ b/docs/web/docs/3-reference/6-aws_hub_and_spoke_roles.mdx
@@ -67,12 +67,34 @@ and the following permissions:
         "organizations:describe*",
         "organizations:list*",
         "iam:*",
-        "sso:*",
-        "secretsmanager:CreateSecret"
+        "sso:*"
       ],
       "Resource": [
         "*"
       ]
+    },
+    {
+      "Action": [
+        "secretsmanager:CreateSecret",
+        "secretsmanager:GetSecretValue",
+        "secretsmanager:describesecret",
+        "secretsmanager:listsecrets",
+        "secretsmanager:listsecretversionids",
+        "secretsmanager:PutSecretValue"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:secretsmanager:*:*:secret:iambic-config-secrets-*"
+    },
+    {
+      "Action": [
+        "sqs:ReceiveMessage",
+        "sqs:SendMessage",
+        "sqs:DeleteMessage",
+        "sqs:GetQueueUrl",
+        "sqs:GetQueueAttributes"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:sqs:*:*:IAMbicChangeDetectionQueue"
     }
   ]
 }
@@ -84,7 +106,8 @@ If your initial evaluation requires a much more restrictive IAMbicSpokeRole, we 
 StackSet template to create IAMbicSpokeRoleReadOnly. The read only postfix only uses list, read capability of
 `iam` and `sso` (aka IdentityCenter) services. However, in order for `iambic setup` to work, it keeps the
 write ability to SecretManager resources prefixed with `iambic-config-secrets-`. This is necessary to keeps
-track of other secrets used for other plugins.
+track of other secrets used for other plugins. In addition, the write access to SQS is limited to queue
+named `IAMbicChangeDetectionQueue` to monitor IAM resources changes.
 
 The effect of using a read-only Spoke Role would be IAMbic can only handle one directional import from AWS.
 
@@ -93,41 +116,52 @@ directly change the IAMbic configuration to specify the arn of the spoke role.
 
 ```json
 {
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Action": [
-                "identitystore:Describe*",
-                "identitystore:Get*",
-                "identitystore:List*",
-                "organizations:describe*",
-                "organizations:list*",
-                "iam:Get*",
-                "iam:List*",
-                "sso:Describe*",
-                "sso:Get*",
-                "sso:List*",
-                "sso:Search*"
-            ],
-            "Resource": [
-                "*"
-            ],
-            "Effect": "Allow"
-        },
-        {
-            "Action": [
-                "secretsmanager:CreateSecret",
-                "secretsmanager:GetSecretValue",
-                "secretsmanager:describesecret",
-                "secretsmanager:listsecrets",
-                "secretsmanager:listsecretversionids",
-                "secretsmanager:PutSecretValue"
-            ],
-            "Resource": [
-                "arn:aws:secretsmanager:*:*:secret:iambic-config-secrets-*"
-            ],
-            "Effect": "Allow"
-        }
-    ]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "identitystore:Describe*",
+        "identitystore:Get*",
+        "identitystore:List*",
+        "organizations:describe*",
+        "organizations:list*",
+        "iam:Get*",
+        "iam:List*",
+        "sso:Describe*",
+        "sso:Get*",
+        "sso:List*",
+        "sso:Search*"
+      ],
+      "Resource": [
+          "*"
+      ],
+      "Effect": "Allow"
+    },
+    {
+      "Action": [
+        "secretsmanager:CreateSecret",
+        "secretsmanager:GetSecretValue",
+        "secretsmanager:describesecret",
+        "secretsmanager:listsecrets",
+        "secretsmanager:listsecretversionids",
+        "secretsmanager:PutSecretValue"
+      ],
+      "Resource": [
+        "arn:aws:secretsmanager:*:*:secret:iambic-config-secrets-*"
+      ],
+      "Effect": "Allow"
+    },
+    {
+      "Action": [
+        "sqs:ReceiveMessage",
+        "sqs:SendMessage",
+        "sqs:DeleteMessage",
+        "sqs:GetQueueUrl",
+        "sqs:GetQueueAttributes"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:sqs:*:*:IAMbicChangeDetectionQueue"
+    }
+  ]
 }
 ```

--- a/iambic/plugins/v0_1_0/aws/cloud_formation/templates/IambicSpokeRole.yml
+++ b/iambic/plugins/v0_1_0/aws/cloud_formation/templates/IambicSpokeRole.yml
@@ -49,5 +49,15 @@ Resources:
                   - secretsmanager:PutSecretValue
                 Resource:
                   - 'arn:aws:secretsmanager:*:*:secret:iambic-config-secrets-*'
+              - Sid: 'SqsWriteAccessForResourceMonitoring'
+                Effect: Allow
+                Action:
+                  - sqs:ReceiveMessage
+                  - sqs:SendMessage
+                  - sqs:DeleteMessage
+                  - sqs:GetQueueUrl
+                  - sqs:GetQueueAttributes
+                Resource:
+                  - 'arn:aws:sqs:*:*:IAMbicChangeDetectionQueue'
       ManagedPolicyArns:
         - 'arn:aws:iam::aws:policy/ReadOnlyAccess'

--- a/iambic/plugins/v0_1_0/aws/cloud_formation/templates/IambicSpokeRoleReadOnly.yml
+++ b/iambic/plugins/v0_1_0/aws/cloud_formation/templates/IambicSpokeRoleReadOnly.yml
@@ -54,3 +54,13 @@ Resources:
                   - secretsmanager:PutSecretValue
                 Resource:
                   - 'arn:aws:secretsmanager:*:*:secret:iambic-config-secrets-*'
+              - Sid: 'SqsWriteAccessForResourceMonitoring'
+                Effect: Allow
+                Action:
+                  - sqs:ReceiveMessage
+                  - sqs:SendMessage
+                  - sqs:DeleteMessage
+                  - sqs:GetQueueUrl
+                  - sqs:GetQueueAttributes
+                Resource:
+                  - 'arn:aws:sqs:*:*:IAMbicChangeDetectionQueue'


### PR DESCRIPTION
## What's changed in the PR?
* Update IambicSpokeRole with write access to `IAMbicChangeDetectionQueue` for IAM resource detection

## Rationale
* The write access is need to remove the processed message for a resource detection. Otherwise, change detection mechanism will keep re-processing the message over and over again.

## How'd to test?
* I have update the Stack and StackSet template definition on iambic test org. Examine the resulting IAM policies on IambicSpokeRole is updated. 
