### PR TITLE
Fixed #356 Credentials environment variable has higher priority

### DIFF
--- a/test/config/test_wizard.py
+++ b/test/config/test_wizard.py
@@ -1,0 +1,75 @@
+import os
+import shutil
+import tempfile
+from unittest import mock
+
+import pytest
+
+from iambic.config.wizard import ConfigurationWizard
+
+
+@pytest.fixture
+def example_test_filesystem():
+    temp_templates_directory = tempfile.mkdtemp(
+        prefix="iambic_test_temp_templates_directory"
+    )
+    yield temp_templates_directory
+    try:
+        shutil.rmtree(temp_templates_directory)
+    except Exception as e:
+        print(e)
+
+
+@pytest.fixture
+def config_wizard(example_test_filesystem):
+    with mock.patch.dict(os.environ, {}, clear=True):
+        # we really want to skip __init__
+        yield ConfigurationWizard.__new__(
+            ConfigurationWizard, str(example_test_filesystem)
+        )
+
+
+def test_resolve_aws_profile_defaults_from_env_with_environment_variables(
+    config_wizard,
+):
+    with mock.patch.dict(
+        os.environ,
+        {
+            "AWS_ACCESS_KEY_ID": "fake-access-key",
+            "AWS_PROFILE": "fake-profile",
+            "AWS_DEFAULT_PROFILE": "fake-default-profile",
+        },
+        clear=True,
+    ):
+        assert "AWS_ACCESS_KEY_ID" in os.environ
+        assert "AWS_PROFILE" in os.environ
+        assert "AWS_DEFAULT_PROFILE" in os.environ
+        profile = config_wizard.resolve_aws_profile_defaults_from_env()
+        assert profile == "None"
+
+
+def test_resolve_aws_profile_defaults_from_env_with_explicit_profile(config_wizard):
+    with mock.patch.dict(
+        os.environ,
+        {"AWS_PROFILE": "fake-profile", "AWS_DEFAULT_PROFILE": "fake-default-profile"},
+        clear=True,
+    ):
+        assert "AWS_PROFILE" in os.environ
+        assert "AWS_DEFAULT_PROFILE" in os.environ
+        profile = config_wizard.resolve_aws_profile_defaults_from_env()
+        assert profile == "fake-profile"
+
+
+def test_resolve_aws_profile_defaults_from_env_with_fallback_profile(config_wizard):
+    with mock.patch.dict(
+        os.environ, {"AWS_DEFAULT_PROFILE": "fake-default-profile"}, clear=True
+    ):
+        assert "AWS_DEFAULT_PROFILE" in os.environ
+        profile = config_wizard.resolve_aws_profile_defaults_from_env()
+        assert profile == "fake-default-profile"
+
+
+def test_resolve_aws_profile_defaults_from_env_with_nothing(config_wizard):
+    with mock.patch.dict(os.environ, {}, clear=True):
+        profile = config_wizard.resolve_aws_profile_defaults_from_env()
+        assert profile == "None"


### PR DESCRIPTION
## What's changed in the PR?
* If Environment Variables contains credentials, it has higher priority. Wizard should not ask what profile to write into configuration file.

## Rationale
* Often when users try new tools, they put in temporary credentials in environment variables. The current wizard will always default to profile named `default`. This is problematic when users have a profile they don't want the tool to use yet. was-cli (tools that users are familiar with, and also boto3) honor environment variables to have higher priority. 

## How'd to test?
* For the function `resolve_aws_profile_defaults_from_env`, I've added a unit test with various combination.
* For manual testing, do the following test
* without any environment variables setup, the wizard should prompt for user to select a profile
* with environment variables with aws creds, the wizard should not prompt for user to select a profile.
