### PR TITLE
Minor grammar fixes noticed while following getting-started-guide

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,11 @@
-## What's changed in the PR?
-* Describe the changes in high level term.
+## What changed?
+* Describe the change in high level terms.
 
 ## Rationale
-* Explain the PR implement in a particular approach?
+* Explain the rationale behind this change and the approach.
 
-## How'd to test?
-* Did you introduce unit test? functional test? in the event of manual verification, list the instruction for your reviewers to follow.
+## How was it tested?
+If it was manually verified, list the instructions for your reviewers to follow.
+- [ ] Unit Tests
+- [ ] Functional Tests
+- [ ] Manually Verified

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -1,7 +1,7 @@
 # Docker
 
 
-Iambic ships with a docker container and a docker-compose.yaml file that can be ran either locally, in AWS Lambda, GitHub Actions, and potentially other places.
+Iambic ships with a docker container and a docker-compose.yaml file that can be run either locally, in AWS Lambda, GitHub Actions, and potentially other places.
 
 The container is purpose built to support Python 3.10 in AWS Lambda because at the current time, AWS Lambda does not support Python 3.10 (See: <https://github.com/aws/aws-lambda-base-images/issues/31>). See the Dockerfile for more information.
 

--- a/docs/web/docs/3-reference/3-schemas/aws_iam_group_template.json
+++ b/docs/web/docs/3-reference/3-schemas/aws_iam_group_template.json
@@ -62,7 +62,7 @@
     },
     "deleted": {
       "title": "Deleted",
-      "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran.",
+      "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run.",
       "default": false,
       "type": "boolean"
     },
@@ -187,7 +187,7 @@
         },
         "deleted": {
           "title": "Deleted",
-          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran.",
+          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run.",
           "default": false,
           "type": "boolean"
         },
@@ -333,7 +333,7 @@
         },
         "deleted": {
           "title": "Deleted",
-          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran.",
+          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run.",
           "default": false,
           "type": "boolean"
         },
@@ -505,7 +505,7 @@
         },
         "deleted": {
           "title": "Deleted",
-          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran.",
+          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run.",
           "default": false,
           "type": "boolean"
         },

--- a/docs/web/docs/3-reference/3-schemas/aws_iam_group_template.mdx
+++ b/docs/web/docs/3-reference/3-schemas/aws_iam_group_template.mdx
@@ -18,7 +18,7 @@ configurations for other models used in IAMbic.*
     - *string*
     - *string*
     - *string*
-- **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
+- **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run. Default: `false`.
 - **`template_type`** *(string)*: Default: `"NOQ::AWS::IAM::Group"`.
 - **`owner`** *(string)*: Owner of the group.
 - **`iambic_managed`**: Controls the directionality of Iambic changes. Default: `"undefined"`.
@@ -57,7 +57,7 @@ configurations for other models used in IAMbic. Cannot contain additional proper
       - *string*
       - *string*
       - *string*
-  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
+  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run. Default: `false`.
   - **`included_accounts`** *(array)*: A list of account ids and/or account names this statement applies to. Account ids/names can be represented as a regex and string. Default: `["*"]`.
     - **Items** *(string)*
   - **`excluded_accounts`** *(array)*: A list of account ids and/or account names this statement explicitly does not apply to. Account ids/names can be represented as a regex and string. Default: `[]`.
@@ -103,7 +103,7 @@ configurations for other models used in IAMbic. Cannot contain additional proper
       - *string*
       - *string*
       - *string*
-  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
+  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run. Default: `false`.
   - **`included_accounts`** *(array)*: A list of account ids and/or account names this statement applies to. Account ids/names can be represented as a regex and string. Default: `["*"]`.
     - **Items** *(string)*
   - **`excluded_accounts`** *(array)*: A list of account ids and/or account names this statement explicitly does not apply to. Account ids/names can be represented as a regex and string. Default: `[]`.
@@ -153,7 +153,7 @@ configurations for other models used in IAMbic. Cannot contain additional proper
       - *string*
       - *string*
       - *string*
-  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
+  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run. Default: `false`.
   - **`included_accounts`** *(array)*: A list of account ids and/or account names this statement applies to. Account ids/names can be represented as a regex and string. Default: `["*"]`.
     - **Items** *(string)*
   - **`excluded_accounts`** *(array)*: A list of account ids and/or account names this statement explicitly does not apply to. Account ids/names can be represented as a regex and string. Default: `[]`.

--- a/docs/web/docs/3-reference/3-schemas/aws_iam_managed_policy_template.json
+++ b/docs/web/docs/3-reference/3-schemas/aws_iam_managed_policy_template.json
@@ -62,7 +62,7 @@
     },
     "deleted": {
       "title": "Deleted",
-      "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran.",
+      "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run.",
       "default": false,
       "type": "boolean"
     },
@@ -301,7 +301,7 @@
         },
         "deleted": {
           "title": "Deleted",
-          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran.",
+          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run.",
           "default": false,
           "type": "boolean"
         },
@@ -572,7 +572,7 @@
         },
         "deleted": {
           "title": "Deleted",
-          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran.",
+          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run.",
           "default": false,
           "type": "boolean"
         },

--- a/docs/web/docs/3-reference/3-schemas/aws_iam_managed_policy_template.mdx
+++ b/docs/web/docs/3-reference/3-schemas/aws_iam_managed_policy_template.mdx
@@ -18,7 +18,7 @@ configurations for other models used in IAMbic.*
     - *string*
     - *string*
     - *string*
-- **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
+- **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run. Default: `false`.
 - **`template_type`** *(string)*: Default: `"NOQ::AWS::IAM::ManagedPolicy"`.
 - **`owner`** *(string)*
 - **`iambic_managed`**: Controls the directionality of Iambic changes. Default: `"undefined"`.
@@ -96,7 +96,7 @@ configurations for other models used in IAMbic. Cannot contain additional proper
       - *string*
       - *string*
       - *string*
-  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
+  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run. Default: `false`.
   - **`included_accounts`** *(array)*: A list of account ids and/or account names this statement applies to. Account ids/names can be represented as a regex and string. Default: `["*"]`.
     - **Items** *(string)*
   - **`excluded_accounts`** *(array)*: A list of account ids and/or account names this statement explicitly does not apply to. Account ids/names can be represented as a regex and string. Default: `[]`.
@@ -170,7 +170,7 @@ configurations for other models used in IAMbic. Cannot contain additional proper
       - *string*
       - *string*
       - *string*
-  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
+  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run. Default: `false`.
   - **`key`** *(string)*
   - **`value`** *(string)*
 

--- a/docs/web/docs/3-reference/3-schemas/aws_iam_role_template.json
+++ b/docs/web/docs/3-reference/3-schemas/aws_iam_role_template.json
@@ -62,7 +62,7 @@
     },
     "deleted": {
       "title": "Deleted",
-      "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran.",
+      "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run.",
       "default": false,
       "type": "boolean"
     },
@@ -342,7 +342,7 @@
         },
         "deleted": {
           "title": "Deleted",
-          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran.",
+          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run.",
           "default": false,
           "type": "boolean"
         },
@@ -448,7 +448,7 @@
         },
         "deleted": {
           "title": "Deleted",
-          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran.",
+          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run.",
           "default": false,
           "type": "boolean"
         },
@@ -719,7 +719,7 @@
         },
         "deleted": {
           "title": "Deleted",
-          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran.",
+          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run.",
           "default": false,
           "type": "boolean"
         },
@@ -762,7 +762,7 @@
         },
         "deleted": {
           "title": "Deleted",
-          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran.",
+          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run.",
           "default": false,
           "type": "boolean"
         },
@@ -845,7 +845,7 @@
         },
         "deleted": {
           "title": "Deleted",
-          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran.",
+          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run.",
           "default": false,
           "type": "boolean"
         },
@@ -1094,7 +1094,7 @@
         },
         "deleted": {
           "title": "Deleted",
-          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran.",
+          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run.",
           "default": false,
           "type": "boolean"
         },

--- a/docs/web/docs/3-reference/3-schemas/aws_iam_role_template.mdx
+++ b/docs/web/docs/3-reference/3-schemas/aws_iam_role_template.mdx
@@ -18,7 +18,7 @@ configurations for other models used in IAMbic.*
     - *string*
     - *string*
     - *string*
-- **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
+- **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run. Default: `false`.
 - **`template_type`** *(string)*: Default: `"NOQ::AWS::IAM::Role"`.
 - **`owner`** *(string)*: Owner of the role.
 - **`iambic_managed`**: Controls the directionality of Iambic changes. Default: `"undefined"`.
@@ -95,7 +95,7 @@ configurations for other models used in IAMbic. Cannot contain additional proper
       - *string*
       - *string*
       - *string*
-  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
+  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run. Default: `false`.
   - **`policy_arn`** *(string)*
   - **`permissions_boundary_type`** *(string)*
 
@@ -133,7 +133,7 @@ configurations for other models used in IAMbic. Cannot contain additional proper
       - *string*
       - *string*
       - *string*
-  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
+  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run. Default: `false`.
   - **`included_accounts`** *(array)*: A list of account ids and/or account names this statement applies to. Account ids/names can be represented as a regex and string. Default: `["*"]`.
     - **Items** *(string)*
   - **`excluded_accounts`** *(array)*: A list of account ids and/or account names this statement explicitly does not apply to. Account ids/names can be represented as a regex and string. Default: `[]`.
@@ -207,7 +207,7 @@ configurations for other models used in IAMbic. Cannot contain additional proper
       - *string*
       - *string*
       - *string*
-  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
+  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run. Default: `false`.
   - **`key`** *(string)*
   - **`value`** *(string)*
 
@@ -220,7 +220,7 @@ configurations for other models used in IAMbic. Cannot contain additional proper
       - *string*
       - *string*
       - *string*
-  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
+  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run. Default: `false`.
   - **`included_accounts`** *(array)*: A list of account ids and/or account names this statement applies to. Account ids/names can be represented as a regex and string. Default: `["*"]`.
     - **Items** *(string)*
   - **`excluded_accounts`** *(array)*: A list of account ids and/or account names this statement explicitly does not apply to. Account ids/names can be represented as a regex and string. Default: `[]`.
@@ -241,7 +241,7 @@ configurations for other models used in IAMbic. Cannot contain additional proper
       - *string*
       - *string*
       - *string*
-  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
+  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run. Default: `false`.
   - **`included_accounts`** *(array)*: A list of account ids and/or account names this statement applies to. Account ids/names can be represented as a regex and string. Default: `["*"]`.
     - **Items** *(string)*
   - **`excluded_accounts`** *(array)*: A list of account ids and/or account names this statement explicitly does not apply to. Account ids/names can be represented as a regex and string. Default: `[]`.
@@ -309,7 +309,7 @@ configurations for other models used in IAMbic. Cannot contain additional proper
       - *string*
       - *string*
       - *string*
-  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
+  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run. Default: `false`.
   - **`users`** *(array)*: List of users who can assume into the role. Default: `[]`.
     - **Items** *(string)*
   - **`groups`** *(array)*: List of groups. Users in one or more of the groups can assume into the role. Default: `[]`.

--- a/docs/web/docs/3-reference/3-schemas/aws_iam_user_template.json
+++ b/docs/web/docs/3-reference/3-schemas/aws_iam_user_template.json
@@ -62,7 +62,7 @@
     },
     "deleted": {
       "title": "Deleted",
-      "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran.",
+      "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run.",
       "default": false,
       "type": "boolean"
     },
@@ -226,7 +226,7 @@
         },
         "deleted": {
           "title": "Deleted",
-          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran.",
+          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run.",
           "default": false,
           "type": "boolean"
         },
@@ -309,7 +309,7 @@
         },
         "deleted": {
           "title": "Deleted",
-          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran.",
+          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run.",
           "default": false,
           "type": "boolean"
         },
@@ -392,7 +392,7 @@
         },
         "deleted": {
           "title": "Deleted",
-          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran.",
+          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run.",
           "default": false,
           "type": "boolean"
         },
@@ -458,7 +458,7 @@
         },
         "deleted": {
           "title": "Deleted",
-          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran.",
+          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run.",
           "default": false,
           "type": "boolean"
         },
@@ -604,7 +604,7 @@
         },
         "deleted": {
           "title": "Deleted",
-          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran.",
+          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run.",
           "default": false,
           "type": "boolean"
         },
@@ -776,7 +776,7 @@
         },
         "deleted": {
           "title": "Deleted",
-          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran.",
+          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run.",
           "default": false,
           "type": "boolean"
         },

--- a/docs/web/docs/3-reference/3-schemas/aws_iam_user_template.mdx
+++ b/docs/web/docs/3-reference/3-schemas/aws_iam_user_template.mdx
@@ -18,7 +18,7 @@ configurations for other models used in IAMbic.*
     - *string*
     - *string*
     - *string*
-- **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
+- **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run. Default: `false`.
 - **`template_type`** *(string)*: Default: `"NOQ::AWS::IAM::User"`.
 - **`owner`** *(string)*
 - **`iambic_managed`**: Controls the directionality of Iambic changes. Default: `"undefined"`.
@@ -65,7 +65,7 @@ configurations for other models used in IAMbic. Cannot contain additional proper
       - *string*
       - *string*
       - *string*
-  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
+  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run. Default: `false`.
   - **`policy_arn`** *(string)*
   - **`permissions_boundary_type`** *(string)*
 
@@ -86,7 +86,7 @@ configurations for other models used in IAMbic. Cannot contain additional proper
       - *string*
       - *string*
       - *string*
-  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
+  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run. Default: `false`.
   - **`key`** *(string)*
   - **`value`** *(string)*
 
@@ -107,7 +107,7 @@ configurations for other models used in IAMbic. Cannot contain additional proper
       - *string*
       - *string*
       - *string*
-  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
+  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run. Default: `false`.
   - **`group_name`** *(string)*
   - **`arn`** *(string)*: ARN of the group. Default: `""`.
   - **`create_date`** *(string)*: Date the group was created. Default: `""`.
@@ -124,7 +124,7 @@ configurations for other models used in IAMbic. Cannot contain additional proper
       - *string*
       - *string*
       - *string*
-  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
+  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run. Default: `false`.
   - **`included_accounts`** *(array)*: A list of account ids and/or account names this statement applies to. Account ids/names can be represented as a regex and string. Default: `["*"]`.
     - **Items** *(string)*
   - **`excluded_accounts`** *(array)*: A list of account ids and/or account names this statement explicitly does not apply to. Account ids/names can be represented as a regex and string. Default: `[]`.
@@ -170,7 +170,7 @@ configurations for other models used in IAMbic. Cannot contain additional proper
       - *string*
       - *string*
       - *string*
-  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
+  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run. Default: `false`.
   - **`included_accounts`** *(array)*: A list of account ids and/or account names this statement applies to. Account ids/names can be represented as a regex and string. Default: `["*"]`.
     - **Items** *(string)*
   - **`excluded_accounts`** *(array)*: A list of account ids and/or account names this statement explicitly does not apply to. Account ids/names can be represented as a regex and string. Default: `[]`.
@@ -220,7 +220,7 @@ configurations for other models used in IAMbic. Cannot contain additional proper
       - *string*
       - *string*
       - *string*
-  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
+  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run. Default: `false`.
   - **`included_accounts`** *(array)*: A list of account ids and/or account names this statement applies to. Account ids/names can be represented as a regex and string. Default: `["*"]`.
     - **Items** *(string)*
   - **`excluded_accounts`** *(array)*: A list of account ids and/or account names this statement explicitly does not apply to. Account ids/names can be represented as a regex and string. Default: `[]`.

--- a/docs/web/docs/3-reference/3-schemas/aws_identity_center_permission_set_template.json
+++ b/docs/web/docs/3-reference/3-schemas/aws_identity_center_permission_set_template.json
@@ -22,7 +22,7 @@
     },
     "deleted": {
       "title": "Deleted",
-      "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran.",
+      "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run.",
       "default": false,
       "type": "boolean"
     },
@@ -188,7 +188,7 @@
         },
         "deleted": {
           "title": "Deleted",
-          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran.",
+          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run.",
           "default": false,
           "type": "boolean"
         },
@@ -231,7 +231,7 @@
         },
         "deleted": {
           "title": "Deleted",
-          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran.",
+          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run.",
           "default": false,
           "type": "boolean"
         },
@@ -332,7 +332,7 @@
         },
         "deleted": {
           "title": "Deleted",
-          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran.",
+          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run.",
           "default": false,
           "type": "boolean"
         },
@@ -504,7 +504,7 @@
         },
         "deleted": {
           "title": "Deleted",
-          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran.",
+          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run.",
           "default": false,
           "type": "boolean"
         },
@@ -547,7 +547,7 @@
         },
         "deleted": {
           "title": "Deleted",
-          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran.",
+          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run.",
           "default": false,
           "type": "boolean"
         },
@@ -625,7 +625,7 @@
         },
         "deleted": {
           "title": "Deleted",
-          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran.",
+          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run.",
           "default": false,
           "type": "boolean"
         },
@@ -745,7 +745,7 @@
         },
         "deleted": {
           "title": "Deleted",
-          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran.",
+          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run.",
           "default": false,
           "type": "boolean"
         },

--- a/docs/web/docs/3-reference/3-schemas/aws_identity_center_permission_set_template.mdx
+++ b/docs/web/docs/3-reference/3-schemas/aws_identity_center_permission_set_template.mdx
@@ -10,7 +10,7 @@ configurations for other models used in IAMbic.*
     - *string*
     - *string*
     - *string*
-- **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
+- **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run. Default: `false`.
 - **`template_type`** *(string)*: Default: `"NOQ::AWS::IdentityCenter::PermissionSet"`.
 - **`owner`** *(string)*: Owner of the permission set.
 - **`iambic_managed`**: Controls the directionality of Iambic changes. Default: `"undefined"`.
@@ -60,7 +60,7 @@ configurations for other models used in IAMbic. Cannot contain additional proper
       - *string*
       - *string*
       - *string*
-  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
+  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run. Default: `false`.
   - **`path`** *(string)*
   - **`name`** *(string)*
 
@@ -73,7 +73,7 @@ configurations for other models used in IAMbic. Cannot contain additional proper
       - *string*
       - *string*
       - *string*
-  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
+  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run. Default: `false`.
   - **`customer_managed_policy_reference`**: Refer to *[#/definitions/CustomerManagedPolicyReference](#definitions/CustomerManagedPolicyReference)*.
   - **`policy_arn`** *(string)*
 
@@ -111,7 +111,7 @@ configurations for other models used in IAMbic. Cannot contain additional proper
       - *string*
       - *string*
       - *string*
-  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
+  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run. Default: `false`.
   - **`included_accounts`** *(array)*: A list of account ids and/or account names this statement applies to. Account ids/names can be represented as a regex and string. Default: `["*"]`.
     - **Items** *(string)*
   - **`excluded_accounts`** *(array)*: A list of account ids and/or account names this statement explicitly does not apply to. Account ids/names can be represented as a regex and string. Default: `[]`.
@@ -161,7 +161,7 @@ configurations for other models used in IAMbic. Cannot contain additional proper
       - *string*
       - *string*
       - *string*
-  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
+  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run. Default: `false`.
   - **`version`** *(string)*
   - **`statement`** *(array)*: List of policy statements.
     - **Items**: Refer to *[#/definitions/PolicyStatement](#definitions/PolicyStatement)*.
@@ -175,7 +175,7 @@ configurations for other models used in IAMbic. Cannot contain additional proper
       - *string*
       - *string*
       - *string*
-  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
+  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run. Default: `false`.
   - **`arn`** *(string)*
 
 <a id="definitions/Tag"></a>
@@ -195,7 +195,7 @@ configurations for other models used in IAMbic. Cannot contain additional proper
       - *string*
       - *string*
       - *string*
-  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
+  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run. Default: `false`.
   - **`key`** *(string)*
   - **`value`** *(string)*
 
@@ -233,7 +233,7 @@ configurations for other models used in IAMbic. Cannot contain additional proper
       - *string*
       - *string*
       - *string*
-  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
+  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run. Default: `false`.
   - **`included_accounts`** *(array)*: A list of account ids and/or account names this statement applies to. Account ids/names can be represented as a regex and string. Default: `["*"]`.
     - **Items** *(string)*
   - **`excluded_accounts`** *(array)*: A list of account ids and/or account names this statement explicitly does not apply to. Account ids/names can be represented as a regex and string. Default: `[]`.

--- a/docs/web/docs/3-reference/3-schemas/azure_active_directory_group_template.json
+++ b/docs/web/docs/3-reference/3-schemas/azure_active_directory_group_template.json
@@ -46,7 +46,7 @@
     },
     "deleted": {
       "title": "Deleted",
-      "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran.",
+      "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run.",
       "default": false,
       "type": "boolean"
     },
@@ -109,7 +109,7 @@
         },
         "deleted": {
           "title": "Deleted",
-          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran.",
+          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run.",
           "default": false,
           "type": "boolean"
         },
@@ -155,7 +155,7 @@
         },
         "deleted": {
           "title": "Deleted",
-          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran.",
+          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run.",
           "default": false,
           "type": "boolean"
         },

--- a/docs/web/docs/3-reference/3-schemas/azure_active_directory_group_template.mdx
+++ b/docs/web/docs/3-reference/3-schemas/azure_active_directory_group_template.mdx
@@ -16,7 +16,7 @@ configurations for other models used in IAMbic.*
     - *string*
     - *string*
     - *string*
-- **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
+- **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run. Default: `false`.
 - **`properties`**: Properties for the Azure AD Group.
   - **All of**
     - : Refer to *[#/definitions/GroupTemplateProperties](#definitions/GroupTemplateProperties)*.
@@ -40,7 +40,7 @@ configurations for other models used in IAMbic. Cannot contain additional proper
       - *string*
       - *string*
       - *string*
-  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
+  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run. Default: `false`.
   - **`id`** *(string)*
   - **`name`** *(string)*
   - **`data_type`**: Refer to *[#/definitions/MemberDataType](#definitions/MemberDataType)*.
@@ -54,7 +54,7 @@ configurations for other models used in IAMbic. Cannot contain additional proper
       - *string*
       - *string*
       - *string*
-  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
+  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run. Default: `false`.
   - **`name`** *(string)*: Name of the group.
   - **`mail_nickname`** *(string)*: Mail nickname of the group.
   - **`group_id`** *(string)*: Unique Group ID for the group. Usually it's {idp-name}-{name}.

--- a/docs/web/docs/3-reference/3-schemas/azure_active_directory_user_template.json
+++ b/docs/web/docs/3-reference/3-schemas/azure_active_directory_user_template.json
@@ -45,7 +45,7 @@
     },
     "deleted": {
       "title": "Deleted",
-      "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran.",
+      "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run.",
       "default": false,
       "type": "boolean"
     },
@@ -109,7 +109,7 @@
         },
         "deleted": {
           "title": "Deleted",
-          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran.",
+          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run.",
           "default": false,
           "type": "boolean"
         },

--- a/docs/web/docs/3-reference/3-schemas/azure_active_directory_user_template.mdx
+++ b/docs/web/docs/3-reference/3-schemas/azure_active_directory_user_template.mdx
@@ -16,7 +16,7 @@ configurations for other models used in IAMbic.*
     - *string*
     - *string*
     - *string*
-- **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
+- **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run. Default: `false`.
 - **`properties`**: Properties for the Azure AD User.
   - **All of**
     - : Refer to *[#/definitions/UserTemplateProperties](#definitions/UserTemplateProperties)*.
@@ -40,7 +40,7 @@ configurations for other models used in IAMbic. Cannot contain additional proper
       - *string*
       - *string*
       - *string*
-  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
+  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run. Default: `false`.
   - **`user_id`** *(string)*: Unique identifier for the user. Default: `""`.
   - **`username`** *(string)*
   - **`display_name`** *(string)*

--- a/docs/web/docs/3-reference/3-schemas/google_workspace_group_template.json
+++ b/docs/web/docs/3-reference/3-schemas/google_workspace_group_template.json
@@ -22,7 +22,7 @@
     },
     "deleted": {
       "title": "Deleted",
-      "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran.",
+      "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run.",
       "default": false,
       "type": "boolean"
     },
@@ -127,7 +127,7 @@
         },
         "deleted": {
           "title": "Deleted",
-          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran.",
+          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run.",
           "default": false,
           "type": "boolean"
         },

--- a/docs/web/docs/3-reference/3-schemas/google_workspace_group_template.mdx
+++ b/docs/web/docs/3-reference/3-schemas/google_workspace_group_template.mdx
@@ -10,7 +10,7 @@ configurations for other models used in IAMbic.*
     - *string*
     - *string*
     - *string*
-- **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
+- **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run. Default: `false`.
 - **`template_type`** *(string)*: Default: `"NOQ::GoogleWorkspace::Group"`.
 - **`owner`** *(string)*: Owner of the group.
 - **`iambic_managed`**: Controls the directionality of Iambic changes. Default: `"undefined"`.
@@ -49,7 +49,7 @@ configurations for other models used in IAMbic. Cannot contain additional proper
       - *string*
       - *string*
       - *string*
-  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
+  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run. Default: `false`.
   - **`email`** *(string)*
   - **`expand`** *(boolean)*: Expand the group into the members of the group. This is useful for nested groups. Default: `false`.
   - **`role`**: Default: `"MEMBER"`.

--- a/docs/web/docs/3-reference/3-schemas/okta_app_template.json
+++ b/docs/web/docs/3-reference/3-schemas/okta_app_template.json
@@ -22,7 +22,7 @@
     },
     "deleted": {
       "title": "Deleted",
-      "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran.",
+      "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run.",
       "default": false,
       "type": "boolean"
     },
@@ -109,7 +109,7 @@
         },
         "deleted": {
           "title": "Deleted",
-          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran.",
+          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run.",
           "default": false,
           "type": "boolean"
         },
@@ -150,7 +150,7 @@
         },
         "deleted": {
           "title": "Deleted",
-          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran.",
+          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run.",
           "default": false,
           "type": "boolean"
         },

--- a/docs/web/docs/3-reference/3-schemas/okta_app_template.mdx
+++ b/docs/web/docs/3-reference/3-schemas/okta_app_template.mdx
@@ -10,7 +10,7 @@ configurations for other models used in IAMbic.*
     - *string*
     - *string*
     - *string*
-- **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
+- **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run. Default: `false`.
 - **`template_type`** *(string)*: Default: `"NOQ::Okta::App"`.
 - **`owner`** *(string)*: Owner of the app.
 - **`iambic_managed`**: Controls the directionality of Iambic changes. Default: `"undefined"`.
@@ -40,7 +40,7 @@ configurations for other models used in IAMbic. Cannot contain additional proper
       - *string*
       - *string*
       - *string*
-  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
+  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run. Default: `false`.
   - **`user`** *(string)*: User assigned to the app.
   - **`group`** *(string)*: Group assigned to the app.
 
@@ -53,7 +53,7 @@ configurations for other models used in IAMbic. Cannot contain additional proper
       - *string*
       - *string*
       - *string*
-  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
+  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run. Default: `false`.
   - **`name`** *(string)*: Name of the app.
   - **`status`**: Status of the app.
     - **All of**

--- a/docs/web/docs/3-reference/3-schemas/okta_group_template.json
+++ b/docs/web/docs/3-reference/3-schemas/okta_group_template.json
@@ -22,7 +22,7 @@
     },
     "deleted": {
       "title": "Deleted",
-      "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran.",
+      "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run.",
       "default": false,
       "type": "boolean"
     },
@@ -115,7 +115,7 @@
         },
         "deleted": {
           "title": "Deleted",
-          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran.",
+          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run.",
           "default": false,
           "type": "boolean"
         },
@@ -213,7 +213,7 @@
         },
         "deleted": {
           "title": "Deleted",
-          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran.",
+          "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run.",
           "default": false,
           "type": "boolean"
         },

--- a/docs/web/docs/3-reference/3-schemas/okta_group_template.mdx
+++ b/docs/web/docs/3-reference/3-schemas/okta_group_template.mdx
@@ -10,7 +10,7 @@ configurations for other models used in IAMbic.*
     - *string*
     - *string*
     - *string*
-- **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
+- **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run. Default: `false`.
 - **`template_type`** *(string)*: Default: `"NOQ::Okta::Group"`.
 - **`owner`** *(string)*: Owner of the group.
 - **`iambic_managed`**: Controls the directionality of Iambic changes. Default: `"undefined"`.
@@ -40,7 +40,7 @@ configurations for other models used in IAMbic. Cannot contain additional proper
       - *string*
       - *string*
       - *string*
-  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
+  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run. Default: `false`.
   - **`username`** *(string)*
   - **`status`**: Status for the group.
     - **All of**
@@ -66,7 +66,7 @@ configurations for other models used in IAMbic. Cannot contain additional proper
       - *string*
       - *string*
       - *string*
-  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
+  - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run. Default: `false`.
   - **`name`** *(string)*: Name of the group.
   - **`group_id`** *(string)*: Unique Group ID for the group. Usually it's {idp-name}-{name}. Default: `""`.
   - **`description`** *(string)*: Description of the group. Default: `""`.

--- a/docs/web/docs/3-reference/3-schemas/okta_user_template.json
+++ b/docs/web/docs/3-reference/3-schemas/okta_user_template.json
@@ -22,7 +22,7 @@
     },
     "deleted": {
       "title": "Deleted",
-      "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran.",
+      "description": "Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run.",
       "default": false,
       "type": "boolean"
     },

--- a/docs/web/docs/3-reference/3-schemas/okta_user_template.mdx
+++ b/docs/web/docs/3-reference/3-schemas/okta_user_template.mdx
@@ -10,7 +10,7 @@ configurations for other models used in IAMbic.*
     - *string*
     - *string*
     - *string*
-- **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
+- **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is run. Default: `false`.
 - **`template_type`** *(string)*: Default: `"NOQ::Okta::User"`.
 - **`owner`** *(string)*
 - **`iambic_managed`**: Controls the directionality of Iambic changes. Default: `"undefined"`.

--- a/iambic/config/wizard.py
+++ b/iambic/config/wizard.py
@@ -295,7 +295,7 @@ def confirm_command_exe(
         raise ValueError(f"Invalid operation: {operation}")
 
     if not questionary.confirm(
-        f"To preserve these changes, {command_type} must be ran to sync your templates.\n"
+        f"To preserve these changes, {command_type} must be run to sync your templates.\n"
         "Proceed?"
     ).unsafe_ask():
         if questionary.confirm(

--- a/iambic/config/wizard.py
+++ b/iambic/config/wizard.py
@@ -780,7 +780,7 @@ class ConfigurationWizard:
         else:
             if requires_sync:
                 if not questionary.confirm(
-                    "Adding this account will require a sync to be ran.\n"
+                    "Adding this account will require a sync to be run.\n"
                     "This is to apply any matching templates to the account if the resource does not already exist.\n"
                     "Then, the account resources will be imported into Iambic.\n"
                     "Proceed?"


### PR DESCRIPTION
## What's changed in the PR?
1. Updated tense of "ran" to "run"
2. Updated grammar on pull request template

## Rationale
Improve the quality of the getting started experience.

## How'd to test?
These are text changes only. They were largely done with find/replace of `is ran` to `is run`. I verified there were no tests expecting the word `ran` anywhere, but did not run the tests.