### PR TITLE
Implement #357 for sts:SetSourceIdentity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 ## 0.4.1 (Target Date May 1st 2023)
 
 PERMISSION CHANGES:
-* IambicHubRole added SQS read/write access to queue named `IAMbicChangeDetectionQueue` to support IAM resource detection. [#355]
+* IambicHubRole added SQS read/write access to queue named `IAMbicChangeDetectionQueue` to support IAM resource detection. #355
+* IambicHubRole added sts:SetSourceIdentity to `IambicSpokeRole` to be compatible with Idp that enforce SetSourceIdentityForwarding
+
+ENHANCEMENTS:
+* Be compatible with Idp that enforces sts:SetSourceIdentity [reference](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_control-access_monitor.html)
 
 BUG FIXES:
-* IAM resource detect mechanism cannot remove SQS message that is already been processed in `IAMbicChangeDetectionQueue` [#355]
+* IAM resource detect mechanism cannot remove SQS message that is already been processed in `IAMbicChangeDetectionQueue` #355
+
 
 ## 0.3.0 (April 21, 2023)
 

--- a/docs/web/docs/3-reference/6-aws_hub_and_spoke_roles.mdx
+++ b/docs/web/docs/3-reference/6-aws_hub_and_spoke_roles.mdx
@@ -34,9 +34,10 @@ for more details.
       "Effect": "Allow",
       "Action": [
         "sts:AssumeRole",
-        "sts:TagSession"
+        "sts:TagSession",
+        "sts:SetSourceIdentity"
       ],
-      "Resource": "*"
+      "Resource": "arn:aws:iam::*:role/IambicSpokeRole*"
     }
   ]
 }

--- a/iambic/plugins/v0_1_0/aws/cloud_formation/templates/IambicHubRole.yml
+++ b/iambic/plugins/v0_1_0/aws/cloud_formation/templates/IambicHubRole.yml
@@ -29,6 +29,7 @@ Resources:
               Action:
                 - sts:AssumeRole
                 - sts:TagSession
+                - sts:SetSourceIdentity
               Principal:
                 AWS: !Ref AssumeAsArn
           -
@@ -44,6 +45,7 @@ Resources:
               - Effect: Allow
                 Action:
                   - sts:assumerole
+                  - sts:SetSourceIdentity
                 Resource:
                   - !Sub 'arn:aws:iam::*:role/${SpokeRoleName}*'
         - PolicyName: list_spoke_account_info

--- a/iambic/plugins/v0_1_0/aws/cloud_formation/templates/IambicSpokeRole.yml
+++ b/iambic/plugins/v0_1_0/aws/cloud_formation/templates/IambicSpokeRole.yml
@@ -22,6 +22,7 @@ Resources:
             Action:
               - sts:AssumeRole
               - sts:TagSession
+              - sts:SetSourceIdentity
             Principal:
               AWS: !Ref HubRoleArn
       Policies:

--- a/iambic/plugins/v0_1_0/aws/cloud_formation/templates/IambicSpokeRoleReadOnly.yml
+++ b/iambic/plugins/v0_1_0/aws/cloud_formation/templates/IambicSpokeRoleReadOnly.yml
@@ -22,6 +22,7 @@ Resources:
             Action:
               - sts:AssumeRole
               - sts:TagSession
+              - sts:SetSourceIdentity
             Principal:
               AWS: !Ref HubRoleArn
       Policies:


### PR DESCRIPTION
## What changed?
Add `sts:SetSourceIdentity` compatibility during `iambic setup`

## Rationale
* Enterprise that has Idp enforce sts:setSourceIdentity will fail to complete the chain because `IambicHubRole` does not include `sts:SetSourceIdentity` in both identity policy and role trust policy.

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [ ] Unit Tests
- [ ] Functional Tests
- [x] Manually Verified

Verified using the iambic_testing_org. Since we don't have the okta infra setup for sts:SetSourceIdentity. I simulate it using aws cli

1. assume a role with SetSourceIdentity
```
aws sts assume-role --role-arn arn:aws:iam::REDACTED_ACCOUNT_ID:role/IambicHubRole --role-session-name "REDACTED_EMAIL" --source-identity "REDACTED_EMAIL"
```
2. run iambic setup to bootstrap the IambicHubRole and IambicSpokeRole. Observe if iambic setup completes. 