### PR TITLE
Update Docker `alias` to allow AWS SSO + additional clarity

### DIFF
--- a/docs/web/docs/3-reference/1-installation/1_install_iambic_via_docker.mdx
+++ b/docs/web/docs/3-reference/1-installation/1_install_iambic_via_docker.mdx
@@ -47,11 +47,11 @@ Depending on where your cloud credentials are stored, you may have to mount the 
 We recommend that you add the following to your ~/.bashrc or ~/.bash_profile:
 
 ```bash
-echo 'alias iambic="docker run -it -u $(id -u):$(id -g) -v ${HOME}/.aws:/app/.aws -e AWS_CONFIG_FILE=/app/.aws/config -e AWS_SHARED_CREDENTIALS_FILE=/app/.aws/credentials -e "AWS_PROFILE=${AWS_PROFILE}" -v <local_dir\>:/templates:Z public.ecr.aws/iambic/iambic:latest <command>"' >> ~/.bashrc
+echo 'alias iambic="docker run -it -u $(id -u):$(id -g) -v ${HOME}/.aws:/app/.aws:ro -e AWS_CONFIG_FILE=/app/.aws/config -e AWS_SHARED_CREDENTIALS_FILE=/app/.aws/credentials -e AWS_PROFILE -e HOME=/app -v <iambic-templates>:/templates:Z public.ecr.aws/iambic/iambic:latest"' >> ~/.bashrc
 ```
 
 ```zsh
-echo 'alias iambic="docker run -it -u $(id -u):$(id -g) -v ${HOME}/.aws:/app/.aws -e AWS_CONFIG_FILE=/app/.aws/config -e AWS_SHARED_CREDENTIALS_FILE=/app/.aws/credentials -e "AWS_PROFILE=${AWS_PROFILE}" -v <local_dir\>:/templates:Z public.ecr.aws/iambic/iambic:latest <command>"' >> ~/.zshrc
+echo 'alias iambic="docker run -it -u $(id -u):$(id -g) -v ${HOME}/.aws:/app/.aws:ro -e AWS_CONFIG_FILE=/app/.aws/config -e AWS_SHARED_CREDENTIALS_FILE=/app/.aws/credentials -e AWS_PROFILE -e HOME=/app -v <iambic-templates>:/templates:Z public.ecr.aws/iambic/iambic:latest"' >> ~/.zshrc
 ```
 
 That way you can just execute iambic seamlessly as an application within your system:


### PR DESCRIPTION
## What changed?
* Updated the `alias` in the documentation

## Rationale
* `-e HOME` was required in order to make AWS SDK figure out where the `.aws/sso/cache` folder lives
* `-e AWS_PROFILE` was changed to pick up the current profile when running `iambic` as an alias
* `<local_dir\>` was changed for clarity
* `-v ${HOME}/.aws:/app/.aws:ro` was changed since write access to this directory should not be required

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [ ] Unit Tests
- [ ] Functional Tests
- [X] Manually Verified
