### PR TITLE
Fixed #372 in which permission boundary works with managed_policy_arn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,18 @@
-## 0.4.1 (Target Date May 1st, 2023)
+## 0.5.1 (Target Date May 15th, 2023)
+
+BREAKING CHANGES:
+* `AwsIdentityCenterPermissionSetTemplate` schema has changed. In particular, `permission_boundary.policy_arn` has become `permission_boundary.managed_policy_arn`. This is due PermissionSet API distinguishes attached
+permission_boundary either owned by AWS or owned by Customer. To align with AWS API response, we have decided
+to follow the AWS naming convention. The old name `permission_boundary.policy_arn` never quite work correctly
+in `AwsIdentityCenterPermissionSetTemplate`. We decide to go with the breaking change route.
+
+BUG FIXES:
+* Fixed import of `AwsIdentityCenterPermissionSetTemplate` in which permission boundary is set to `managed_policy_arn`
+
+THANKS:
+* [perpil](https://github.com/perpil) for reporting [#372](https://github.com/noqdev/iambic/issues/372).
+
+## 0.4.1 (May 1st, 2023)
 
 PERMISSION CHANGES:
 * IambicHubRole added SQS read/write access to queue named `IAMbicChangeDetectionQueue` to support IAM resource detection. [#355](https://github.com/noqdev/iambic/pull/355)

--- a/docs/web/docs/1-getting_started/3-aws.mdx
+++ b/docs/web/docs/1-getting_started/3-aws.mdx
@@ -443,7 +443,7 @@ properties:
   managed_policies:
     - arn: arn:aws:iam::aws:policy/job-function/ViewOnlyAccess
   permissions_boundary:
-    policy_arn: arn:aws:iam::aws:policy/AWSDirectConnectReadOnlyAccess
+    managed_policy_arn: arn:aws:iam::aws:policy/AWSDirectConnectReadOnlyAccess
   session_duration: PT1H
 ```
 
@@ -525,7 +525,7 @@ properties:
   managed_policies:
     - arn: arn:aws:iam::aws:policy/job-function/ViewOnlyAccess
   permissions_boundary:
-    policy_arn: arn:aws:iam::aws:policy/AWSDirectConnectReadOnlyAccess
+    managed_policy_arn: arn:aws:iam::aws:policy/AWSDirectConnectReadOnlyAccess
   session_duration: PT1H
 ```
 

--- a/functional_tests/aws/permission_set/test_update_template.py
+++ b/functional_tests/aws/permission_set/test_update_template.py
@@ -4,6 +4,7 @@ import asyncio
 import datetime
 from unittest import IsolatedAsyncioTestCase
 
+import pytest
 from functional_tests.aws.permission_set.utils import generate_permission_set_template
 from functional_tests.conftest import IAMBIC_TEST_DETAILS
 
@@ -12,6 +13,7 @@ from iambic.core.context import ctx
 from iambic.core.models import ProposedChangeType
 from iambic.output.text import screen_render_resource_changes
 from iambic.plugins.v0_1_0.aws.identity_center.permission_set.models import (
+    PermissionBoundary,
     PermissionSetAccess,
 )
 from iambic.plugins.v0_1_0.aws.identity_center.permission_set.utils import (
@@ -152,3 +154,80 @@ class UpdatePermissionSetTestCase(IsolatedAsyncioTestCase):
             IAMBIC_TEST_DETAILS.identity_center_account.identity_center_details.org_account_map,
         )
         assert len(cloud_access_rules) == 0
+
+    async def test_update_permission_boundary(self):
+        assert self.template.properties.permissions_boundary is None
+        self.template.properties.permissions_boundary = PermissionBoundary(
+            managed_policy_arn="arn:aws:iam::aws:policy/ReadOnlyAccess"
+        )
+        changes = await self.template.apply(IAMBIC_TEST_DETAILS.config.aws)
+        assert (
+            changes.proposed_changes[0].proposed_changes[0].change_type
+            == ProposedChangeType.ATTACH
+        )
+        assert changes.exceptions_seen in [None, []]
+
+        identity_center_client = await IAMBIC_TEST_DETAILS.identity_center_account.get_boto3_client(
+            "sso-admin",
+            region_name=IAMBIC_TEST_DETAILS.identity_center_account.identity_center_details.region_name,
+        )
+        sso_admin_instance_arn = (
+            IAMBIC_TEST_DETAILS.identity_center_account.identity_center_details.instance_arn
+        )
+        permission_set_arn = IAMBIC_TEST_DETAILS.identity_center_account.identity_center_details.permission_set_map[
+            self.template.identifier
+        ][
+            "PermissionSetArn"
+        ]
+        response = identity_center_client.get_permissions_boundary_for_permission_set(
+            InstanceArn=sso_admin_instance_arn,
+            PermissionSetArn=permission_set_arn,
+        )
+
+        self.assertEqual(
+            self.template.properties.permissions_boundary.managed_policy_arn,
+            response["PermissionsBoundary"]["ManagedPolicyArn"],
+        )
+
+        # base_deny is already setup in the functional test org
+        self.template.properties.permissions_boundary = PermissionBoundary(
+            customer_managed_policy_reference={"name": "base_deny", "path": "/"}
+        )
+        changes = await self.template.apply(IAMBIC_TEST_DETAILS.config.aws)
+        assert (
+            changes.proposed_changes[0].proposed_changes[0].change_type
+            == ProposedChangeType.UPDATE
+        )
+        assert changes.exceptions_seen in [None, []]
+
+        response = identity_center_client.get_permissions_boundary_for_permission_set(
+            InstanceArn=sso_admin_instance_arn,
+            PermissionSetArn=permission_set_arn,
+        )
+
+        self.assertEqual(
+            self.template.properties.permissions_boundary.customer_managed_policy_reference.name,
+            response["PermissionsBoundary"]["CustomerManagedPolicyReference"]["Name"],
+        )
+
+        self.assertEqual(
+            self.template.properties.permissions_boundary.customer_managed_policy_reference.path,
+            response["PermissionsBoundary"]["CustomerManagedPolicyReference"]["Path"],
+        )
+
+        self.template.properties.permissions_boundary = None
+        changes = await self.template.apply(IAMBIC_TEST_DETAILS.config.aws)
+        assert (
+            changes.proposed_changes[0].proposed_changes[0].change_type
+            == ProposedChangeType.DETACH
+        )
+        assert changes.exceptions_seen in [None, []]
+
+        with pytest.raises(
+            Exception, match="PermissionsBoundary not present in permission set"
+        ):
+            # it's a funky AWS API design, it rather send non-200 response
+            _ = identity_center_client.get_permissions_boundary_for_permission_set(
+                InstanceArn=sso_admin_instance_arn,
+                PermissionSetArn=permission_set_arn,
+            )

--- a/functional_tests/plugins/v0_1_0/github/test_github_app.py.backup
+++ b/functional_tests/plugins/v0_1_0/github/test_github_app.py.backup
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+
+# The below profile only works if you have your own cloud resources and matching aws profile
+TERRAFORM_AWS_PROFILE = (
+    "iambic_test_org_spoke_account_1/iambic_test_org_spoke_account_1_admin"
+)
+
+
+@pytest.fixture
+def generate_templates_fixture():
+    # to override the conftest version to speed up testing
+    pass
+
+
+@pytest.fixture
+def deploy_lambda():
+    # subprocess.run("make -f Makefile.itest auth_to_ecr", shell=True, check=True)
+    # subprocess.run(
+    #     "make -f Makefile.itest build_docker_itest", shell=True, check=True
+    # )
+    # subprocess.run(
+    #     "make -f Makefile.itest upload_docker_itest", shell=True, check=True
+    # )
+
+    # terraform workspace new branch-123
+    # terraform apply
+    # terraform destroy
+    # terraform workspace select default
+    # terraform workspace delete branch-123
+
+    branch = "branch-456"
+
+    setup_string = f"cd deployment/github_app_test && terraform workspace new {branch} && terraform apply -var aws_profile={TERRAFORM_AWS_PROFILE} -auto-approve"
+    # print(setup_string)
+    subprocess.run(setup_string, shell=True, check=True)
+
+    show_output_string = f"cd deployment/github_app_test && terraform workspace select {branch} && terraform output -json"
+    terraform_output_string = subprocess.check_output(show_output_string, shell=True)
+    terraform_output = json.loads(terraform_output_string)
+
+    yield terraform_output["function_url"]["value"]
+
+    destroy_string = f"cd deployment/github_app_test && terraform workspace select {branch} && terraform destroy -var aws_profile={TERRAFORM_AWS_PROFILE} -auto-approve"
+    subprocess.run(destroy_string, shell=True, check=True)
+
+    destroy_workspace_string = f"cd deployment/github_app_test && terraform workspace select default && terraform workspace delete {branch}"
+    subprocess.run(destroy_workspace_string, shell=True, check=True)
+
+    return 1
+
+
+def test_bootstrap(deploy_lambda):
+    print(deploy_lambda)
+    assert deploy_lambda is not None

--- a/iambic/plugins/v0_1_0/aws/identity_center/permission_set/models.py
+++ b/iambic/plugins/v0_1_0/aws/identity_center/permission_set/models.py
@@ -104,7 +104,7 @@ class ManagedPolicyArn(BaseModel, ExpiryModel):
 
 class PermissionBoundary(BaseModel, ExpiryModel):
     customer_managed_policy_reference: Optional[CustomerManagedPolicyReference]
-    policy_arn: Optional[str]
+    managed_policy_arn: Optional[str]
 
     @property
     def resource_type(self):
@@ -112,7 +112,7 @@ class PermissionBoundary(BaseModel, ExpiryModel):
 
     @property
     def resource_id(self):
-        return self.customer_managed_policy_reference.name or self.policy_arn
+        return self.customer_managed_policy_reference.name or self.managed_policy_arn
 
 
 class SessionDuration(BaseModel):
@@ -742,9 +742,7 @@ class AwsIdentityCenterPermissionSetTemplate(
 
         return account_change_details
 
-    async def apply(
-        self, config: AWSConfig  # noqa: C901
-    ) -> TemplateChangeDetails:
+    async def apply(self, config: AWSConfig) -> TemplateChangeDetails:  # noqa: C901
         tasks = []
         template_changes = TemplateChangeDetails(
             resource_id=self.resource_id,

--- a/iambic/plugins/v0_1_0/aws/identity_center/permission_set/utils.py
+++ b/iambic/plugins/v0_1_0/aws/identity_center/permission_set/utils.py
@@ -711,7 +711,7 @@ async def apply_permission_set_permission_boundary(
         else:
             response.append(
                 ProposedChange(
-                    change_type=ProposedChangeType.CREATE,
+                    change_type=ProposedChangeType.ATTACH,
                     resource_type="aws:identity_center:permission_set",
                     resource_id=permission_set_arn,
                     attribute="permissions_boundary",
@@ -735,7 +735,7 @@ async def apply_permission_set_permission_boundary(
         log_str = "Removing PermissionsBoundary discovered."
         response.append(
             ProposedChange(
-                change_type=ProposedChangeType.DELETE,
+                change_type=ProposedChangeType.DETACH,
                 resource_type="aws:identity_center:permission_set",
                 resource_id=permission_set_arn,
                 attribute="permissions_boundary",


### PR DESCRIPTION
## What changed?
* permission_boundary.policy_arn has become permission_boundary.managed_policy_arn
* Added functional test
* Modified the action of permission boundary to ATTACH and DETACH
* fixed pyflake8 error

## Rationale
previously this [changeset](https://github.com/noqdev/iambic/commit/d33889041b13464fcba20f63a7c30074b573ede6#diff-f4d5cb969c2690c7e494665e79318181b3cec7d97e6aa3b3e27f10f341de7e47) renamed identity_center:permission_boundary from managed_policy_arn to policy_arn in an attempt to be consistent in document schema. however, since AWS is wild inconsistent, it actually use managed_policy_arn in its boto3 response ,so unless we do adapter code (in and out), this has been broken since then. now, since this has been broken since so long, i recommend not fight the AWS inconsistency. why? for people that is referencing both our docs and AWS docs, if we force the concept of renaming the response (aside from Camcel Case to snake case), it's not super predictable. i recommend we use the original managed_policy_arn.

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [ ] Unit Tests
- [x] Functional Tests
- [x] Manually Verified

manual verification import permission set with managed_policy_arn. 

the newly added functional test exercise managed_policy_arn attachment, customer_managed_policy_reference, and permission_boundary detachment.  