### PR TITLE
Prep for 0.5.0 Version Bump

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "iambic-core"
 packages = [
     { include="iambic", from="." },
 ]
-version = "0.4.5"
+version = "0.5.0"
 license = "Apache-2.0"
 description = "The python package used to generate, parse, and execute noqform yaml templates."
 authors = ["Noq Software <hello@noq.dev>"]


### PR DESCRIPTION
## What changed?
Prep for 0.5.1 PyPI release

## Rationale
* `AwsIdentityCenterPermissionSetTemplate` has a document schema changed, so we decide to bump the version.

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [x] Unit Tests
- [x] Functional Tests
- [ ] Manually Verified
