### PR TITLE
Fix regression in which wizard ignores AWS credentials from environment variables

### DIFF
--- a/iambic/config/wizard.py
+++ b/iambic/config/wizard.py
@@ -1000,9 +1000,6 @@ class ConfigurationWizard:
             if getattr(self, "boto3_session", None) is None:
                 # need bootstrapping
                 self.boto3_session = boto3.Session(region_name=self.aws_default_region)
-
-            if getattr(self, "boto3_session", None) is None:
-                # need bootstrapping
                 self.autodetected_org_settings = {}
 
             default_caller_identity = self.boto3_session.client(

--- a/iambic/config/wizard.py
+++ b/iambic/config/wizard.py
@@ -999,10 +999,10 @@ class ConfigurationWizard:
         try:
             if getattr(self, "boto3_session", None) is None:
                 # need bootstrapping
-                # FIXME
                 self.boto3_session = boto3.Session(region_name=self.aws_default_region)
 
             if getattr(self, "boto3_session", None) is None:
+                # need bootstrapping
                 self.autodetected_org_settings = {}
 
             default_caller_identity = self.boto3_session.client(

--- a/iambic/config/wizard.py
+++ b/iambic/config/wizard.py
@@ -551,11 +551,11 @@ class ConfigurationWizard:
 
         return profile_name if profile_name != "None" else None
 
-    def set_boto3_session(self):
+    def set_boto3_session(self, allow_none=False):
         self._has_cf_permissions = True
         while True:
             try:
-                profile_name = self.set_aws_profile_name()
+                profile_name = self.set_aws_profile_name(allow_none=allow_none)
                 self.boto3_session = boto3.Session(
                     profile_name=profile_name, region_name=self.aws_default_region
                 )
@@ -997,6 +997,14 @@ class ConfigurationWizard:
             self.hub_account_id = None
 
         try:
+            if getattr(self, "boto3_session", None) is None:
+                # need bootstrapping
+                # FIXME
+                self.boto3_session = boto3.Session(region_name=self.aws_default_region)
+
+            if getattr(self, "boto3_session", None) is None:
+                self.autodetected_org_settings = {}
+
             default_caller_identity = self.boto3_session.client(
                 "sts", region_name=self.aws_default_region
             ).get_caller_identity()
@@ -1034,6 +1042,14 @@ class ConfigurationWizard:
                 f"Would you like to use this identity?"
             ).ask():
                 self.caller_identity = default_caller_identity
+                # If we are going to use the default_caller_identity,
+                # we need to set teh autodetected_org_settings to
+                with contextlib.suppress(
+                    ClientError, NoCredentialsError, FileNotFoundError
+                ):
+                    self.autodetected_org_settings = self.boto3_session.client(
+                        "organizations"
+                    ).describe_organization()["Organization"]
             else:
                 self.set_boto3_session()
         else:


### PR DESCRIPTION
## What changed?
* Fix regression in which wizard ignores AWS credentials from environment variables

## Rationale
* In the previous wizard update, AWS wizard flow no longer respect credentials set in environment variables

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [ ] Unit Tests
- [ ] Functional Tests
- [x] Manually Verified

* Due to existing function asks for manual input, I've not figured out a pattern to write test yet.

Manual test flow:

1. set aws credentials in your env, such that `aws sts get-caller-identity` returns the identity you want to use for the wizard flow
2. run `iambic setup` (note, we are assuming no local iambic_config.yaml in the current directory)

verify the prompt matches

```
(env) stevenmoy@steven-noqdev-mbp iambic % iambic setup         
2023/05/02 17:44:10 [info     ] Setting config metadata...
2023/05/02 17:44:10 [info     ] Plugins loaded successfully...
? What would you like to configure? AWS
? What region should IAMbic use? us-east-1
? To get started with the IAMbic setup wizard, you'll need an AWS account.
This is where IAMbic will deploy its main role. If you have an AWS Organization, that account will be your hub account.
Review to-be-created IAMbic roles at https://docs.iambic.org/reference/aws_hub_and_spoke_roles
Which Account ID should we use to deploy the IAMbic hub role? 580605962305
? IAMbic detected you are using arn:aws:iam::580605962305:role/iambic_test_org_account_admin for AWS access.
This identity will require the ability to createCloudFormation stacks, stack sets, and stack set instances.
Would you like to use this identity? Yes
2023/05/02 17:44:15 [info     ] Scanning for upstream changes to config attributes.
2023/05/02 17:44:15 [info     ] Finished scanning for upstream changes to config attributes.
2023/05/02 17:44:15 [info     ] Config successfully written    
  config_location=/Users/stevenmoy/noqdev/iambic/iambic_config.yaml
? What would you like to configure in AWS?
We recommend configuring IAMbic with AWS Organizations, but you may also manually configure accounts. AWS Organizations
? If you would like to use AWS Organizations, the IAMbic hub account you configured must be the same AWS account as your AWS Organization.
Is this the case? Yes
? This requires that you have the ability to create CloudFormation stacks, stack sets, and stack set instances.
If you are using an AWS Organization, be sure that trusted access is enabled.
You can check this using the AWS Console:
  https://us-east-1.console.aws.amazon.com/organizations/v2/home/services/CloudFormation%20StackSets
Proceed? Yes
? What is the AWS Organization ID? It can be found here https://us-east-1.console.aws.amazon.com/organizations/v2/home/accounts o-8t0mt0ybdd
? Create required Hub and Spoke roles via CloudFormation?
The templates that will be used can be found here:
  https://github.com/noqdev/iambic/tree/main/iambic/plugins/v0_1_0/aws/cloud_formation/templates Yes
? Grant IambicSpokeRole write access to IAM and IdentityCenter?
If set to 'no', this will limit IAMbic's capabilities to import-only. Yes
? Provide a user or role ARN that will be able to access the hub role. Note: Access to this identity is required to use IAMbic locally. arn:aws:iam::580605962305:role/iambic_test_org_account_admin
? (Optional) Provide a role arn that CloudFormation will assume to create the stack(s) or hit enter to use your current access.

```