### PR TITLE
BUG-2097 fix read only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 
 # Change Log
 
+## 0.6.1 (Target Date May 3rd, 2023)
+
+ENHANCEMENTS:
+
+* Additional clarity in the wizard as it relates to AWS cloudformation changes.  
+
+BUG FIXES:
+
+* AWS read only spoke role is now working as designed
+* Fixes to text being truncated in the wizard on smaller terminal windows.
+
+THANKS:
+
+* [rjulian](https://github.com/rjulian) for reporting [#377](https://github.com/noqdev/iambic/pull/377).
+
 ## 0.5.1 (Target Date May 2nd, 2023)
 
 PERMISSION CHANGES:

--- a/iambic/plugins/v0_1_0/aws/cloud_formation/templates/IambicSpokeRoleReadOnly.yml
+++ b/iambic/plugins/v0_1_0/aws/cloud_formation/templates/IambicSpokeRoleReadOnly.yml
@@ -7,7 +7,7 @@ Parameters:
   HubRoleArn:
     Type: String
 Resources:
-  IambicSpokeRoleReadOnly:
+  IambicSpokeRole:
     Type: 'AWS::IAM::Role'
     Properties:
       RoleName: !Ref SpokeRoleName

--- a/iambic/plugins/v0_1_0/aws/cloud_formation/utils.py
+++ b/iambic/plugins/v0_1_0/aws/cloud_formation/utils.py
@@ -402,7 +402,7 @@ async def create_hub_role_stack(
         **additional_kwargs,
     )
     if stack_created:
-        return await create_spoke_role_stack(cf_client, hub_account_id, role_arn, spoke_role_read_only)
+        return await create_spoke_role_stack(cf_client, hub_account_id, role_arn)
 
     return stack_created
 

--- a/iambic/plugins/v0_1_0/aws/handlers.py
+++ b/iambic/plugins/v0_1_0/aws/handlers.py
@@ -165,6 +165,10 @@ async def apply_iam_templates(
     :param templates: The list of templates to apply.
     :param remote_worker: The remote worker to use for applying templates.
     """
+    if config.spoke_role_is_read_only:
+        log.critical("Unable to apply resources when spoke_role_is_read_only is True")
+        return []
+
     await generate_permission_set_map(config.accounts, templates)
 
     template_changes: list[TemplateChangeDetails] = []

--- a/iambic/plugins/v0_1_0/aws/models.py
+++ b/iambic/plugins/v0_1_0/aws/models.py
@@ -55,11 +55,8 @@ def get_hub_role_arn(account_id: str) -> str:
     return f"arn:aws:iam::{account_id}:role/{IAMBIC_HUB_ROLE_NAME}"
 
 
-def get_spoke_role_arn(account_id: str, read_only=False) -> str:
-    spoke_role_postfix = "ReadOnly" if read_only else ""
-    return (
-        f"arn:aws:iam::{account_id}:role/{IAMBIC_SPOKE_ROLE_NAME}{spoke_role_postfix}"
-    )
+def get_spoke_role_arn(account_id: str) -> str:
+    return f"arn:aws:iam::{account_id}:role/{IAMBIC_SPOKE_ROLE_NAME}"
 
 
 @yaml_object(yaml)
@@ -589,7 +586,7 @@ class AWSOrganization(BaseAWSAccountAndOrgModel):
     )
     spoke_role_is_read_only: bool = Field(
         False,
-        description="if true, the spoke role name is IambicSpokeRoleReadOnly",
+        description="if true, the spoke role will be limited to read-only permissions",
     )
 
     async def _create_org_account_instance(
@@ -625,9 +622,7 @@ class AWSOrganization(BaseAWSAccountAndOrgModel):
             variables=account["variables"],
             identity_center_details=identity_center_details,
             iambic_managed=account_rule.iambic_managed,
-            spoke_role_arn=get_spoke_role_arn(
-                account_id, read_only=self.spoke_role_is_read_only
-            ),
+            spoke_role_arn=get_spoke_role_arn(account_id),
             hub_session_info=dict(boto3_session=session),
             default_region=region_name,
             boto3_session_map={},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "iambic-core"
 packages = [
     { include="iambic", from="." },
 ]
-version = "0.5.3"
+version = "0.6.0"
 license = "Apache-2.0"
 description = "The python package used to generate, parse, and execute noqform yaml templates."
 authors = ["Noq Software <hello@noq.dev>"]

--- a/test/plugins/v0_1_0/aws/identity_center/permission_set/test_models.py
+++ b/test/plugins/v0_1_0/aws/identity_center/permission_set/test_models.py
@@ -98,13 +98,29 @@ def test_description_validation_with_empty_string():
 
 
 def test_permission_boundary_with_customer_managed_policy_ref_with_default_path():
-    properties = PermissionSetProperties(name="foo", description="A", permissions_boundary={"customer_managed_policy_reference": {"name": "foo"}})
+    properties = PermissionSetProperties(
+        name="foo",
+        description="A",
+        permissions_boundary={"customer_managed_policy_reference": {"name": "foo"}},
+    )
     assert properties.permissions_boundary.customer_managed_policy_reference.path == "/"
 
 
 def test_permission_boundary_with_customer_managed_policy_ref_with_custom_path():
-    properties = PermissionSetProperties(name="foo", description="A", permissions_boundary={"customer_managed_policy_reference": {"name": "foo", "path": "/engineering/"}})
-    assert properties.permissions_boundary.customer_managed_policy_reference.path == "/engineering/"
+    properties = PermissionSetProperties(
+        name="foo",
+        description="A",
+        permissions_boundary={
+            "customer_managed_policy_reference": {
+                "name": "foo",
+                "path": "/engineering/",
+            }
+        },
+    )
+    assert (
+        properties.permissions_boundary.customer_managed_policy_reference.path
+        == "/engineering/"
+    )
 
 
 def test_description_validation_with_valid_string():


### PR DESCRIPTION
## What changed?
* AWS read only now working as designed
* Fixed text formatting in the wizard on smaller terminal windows

## Additional notes
The reason for moving larger prompts from questionary to click.echo is due to the issues questionary has with large strings. Text is frequently truncated and if you resize the terminal the text will occasionally be duplicated. The strings in click.echo are prefixed with a new line for readability. It creates a visual grouping of the click text with the questionary prompt. We could consider moving away from questionary in the future but this solves the problem until then.

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [x] Unit Tests
- [x] Functional Tests
- [x] Created read only aws org in the wizard w/ small terminal
- [x] Created read only aws account in the wizard w/ small terminal
