### PR TITLE
Implemented #390 Tags support on IAMbic hub and spoke role creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,28 @@
 
 # Change Log
 
-## 0.6.1 (Target Date May 3rd, 2023)
+## 0.7.1 (May 9th, 2023)
 
 ENHANCEMENTS:
 
-* Additional clarity in the wizard as it relates to AWS cloudformation changes.  
+* Tag support on CloudFormation stack. These tags will propagate to IambicHubRole and
+IambicSpokeRole created. Wizard will prompt the user to either enter blank or
+in `key1=value1` format. To add multiple tags, use `key1=value1, key2=value2` format.
+
+BUG FIXES:
+
+* Fixes in wizard when user does not grant Iambic write access.
+* Fixes in wizard when setting up an individual AWS account instead of AWS Organization.
+
+THANKS:
+
+* `noq@phad.me`, `perpil` in [NoqCommunity](https://noqcommunity.slack.com/archives/C02P9E8BDK6/p1683275443604049) proposing tags support during IAMbic setup.
+
+## 0.6.1 (May 3rd, 2023)
+
+ENHANCEMENTS:
+
+* Additional clarity in the wizard as it relates to AWS cloudformation changes.
 * Added the ability to check the IAMbic version from the CLI.
 
 BUG FIXES:
@@ -17,7 +34,7 @@ THANKS:
 
 * [rjulian](https://github.com/rjulian) for reporting [#377](https://github.com/noqdev/iambic/pull/377).
 
-## 0.5.1 (Target Date May 2nd, 2023)
+## 0.5.1 (May 2nd, 2023)
 
 PERMISSION CHANGES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ BUG FIXES:
 
 THANKS:
 
-* `noq@phad.me`, `perpil` in [NoqCommunity](https://noqcommunity.slack.com/archives/C02P9E8BDK6/p1683275443604049) proposing tags support during IAMbic setup.
+* `Phil H.`, `David B.` in [NoqCommunity](https://noqcommunity.slack.com/archives/C02P9E8BDK6/p1683275443604049) proposing tags support during IAMbic setup.
 
 ## 0.6.1 (May 3rd, 2023)
 

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ functional_wizard_test:
 .PHONY: functional_test
 functional_test:
 	pytest --cov-report html --cov iambic --cov-report lcov:cov_functional_tests.lcov --cov-report xml:cov_functional_tests.xml --cov-report html:cov_functional_tests.html  functional_tests --ignore functional_tests/test_github_cicd.py --ignore functional_tests/test_config_discovery.py -s -n auto --dist loadscope --reruns 3 --reruns-delay 5 -r aR --durations=20
-	pytest --cov-report html --cov iambic --cov-report lcov:cov_functional_tests_config_discovery.lcov --cov-report xml:cov_functional_tests_config_discovery.xml --cov-report html:cov_functional_tests_config_discovery.html  functional_tests/test_config_discovery.py functional_tests/test_wizard.py -s --durations=20
+	pytest --cov-report html --cov iambic --cov-report lcov:cov_functional_tests_config_discovery.lcov --cov-report xml:cov_functional_tests_config_discovery.xml --cov-report html:cov_functional_tests_config_discovery.html  functional_tests/test_config_discovery.py -s --durations=20
 # 	pytest --cov-report html --cov iambic functional_tests -s
 # 	pytest --cov-report html --cov iambic functional_tests/aws/role/test_create_template.py -s
 # 	pytest --cov-report html --cov iambic functional_tests/aws/managed_policy/test_template_expiration.py -s

--- a/Makefile
+++ b/Makefile
@@ -60,10 +60,14 @@ push_manifest:
 test:
 	python -m pytest -c pytest.ini
 
+.PHONY: functional_wizard_test
+functional_wizard_test:
+	pytest --cov-report html --cov iambic --cov-report lcov:cov_functional_tests_wizard.lcov --cov-report xml:cov_functional_tests_wizard.xml --cov-report html:cov_functional_tests_wizard.html  functional_tests/test_wizard.py -s --durations=20
+
 .PHONY: functional_test
 functional_test:
 	pytest --cov-report html --cov iambic --cov-report lcov:cov_functional_tests.lcov --cov-report xml:cov_functional_tests.xml --cov-report html:cov_functional_tests.html  functional_tests --ignore functional_tests/test_github_cicd.py --ignore functional_tests/test_config_discovery.py -s -n auto --dist loadscope --reruns 3 --reruns-delay 5 -r aR --durations=20
-	pytest --cov-report html --cov iambic --cov-report lcov:cov_functional_tests_config_discovery.lcov --cov-report xml:cov_functional_tests_config_discovery.xml --cov-report html:cov_functional_tests_config_discovery.html  functional_tests/test_config_discovery.py -s --durations=20
+	pytest --cov-report html --cov iambic --cov-report lcov:cov_functional_tests_config_discovery.lcov --cov-report xml:cov_functional_tests_config_discovery.xml --cov-report html:cov_functional_tests_config_discovery.html  functional_tests/test_config_discovery.py functional_tests/test_wizard.py -s --durations=20
 # 	pytest --cov-report html --cov iambic functional_tests -s
 # 	pytest --cov-report html --cov iambic functional_tests/aws/role/test_create_template.py -s
 # 	pytest --cov-report html --cov iambic functional_tests/aws/managed_policy/test_template_expiration.py -s

--- a/functional_tests/test_wizard.py
+++ b/functional_tests/test_wizard.py
@@ -1,21 +1,50 @@
 import os
 import tempfile
 
+import boto3
 import pexpect
+import pytest
 
 KEY_UP = "\x1b[A"
 KEY_DOWN = "\x1b[B"
 
 
-def test_setup_single_account() -> None:
+@pytest.fixture
+def iam_spoke_role():
+    # assumption, we already have an IambicHubRole access
+    # we will then assume into IambicFunctionalTestWizardRole
+    # to simulate bootstrapping Iambic
+    sts_client = boto3.client("sts")
+    response = sts_client.get_caller_identity()
+    iambic_spoke_role_arn = response["Arn"]
+    iambic_spoke_role_arn = iambic_spoke_role_arn[0 : iambic_spoke_role_arn.rindex("/")]
+    iambic_spoke_role_arn = iambic_spoke_role_arn.replace("assumed-role", "role")
+    iambic_spoke_role_arn = iambic_spoke_role_arn.replace(
+        "IambicHubRole", "IambicFunctionalTestWizardRole"
+    )
+    print(iambic_spoke_role_arn)
+
+    response = sts_client.assume_role(
+        RoleArn=iambic_spoke_role_arn, RoleSessionName="functional_test"
+    )
+    assert "Credentials" in response
+    yield response
+
+
+def test_setup_single_account(iam_spoke_role) -> None:
     temp_templates_directory = tempfile.mkdtemp(
         prefix="iambic_test_temp_templates_directory"
     )
     log_file = f"{temp_templates_directory}/test_setup_single_aws_account.txt"
     print(f"ui test log file is in {log_file}")
+    spawn_env = dict(os.environ)
+    spawn_env["PROMPT_TOOLKIT_NO_CPR"] = "1"
+    spawn_env["AWS_ACCESS_KEY_ID"] = iam_spoke_role["Credentials"]["AccessKeyId"]
+    spawn_env["AWS_SECRET_ACCESS_KEY"] = iam_spoke_role["Credentials"][
+        "SecretAccessKey"
+    ]
+    spawn_env["AWS_SESSION_TOKEN"] = iam_spoke_role["Credentials"]["SessionToken"]
     with open(log_file, "wb") as fout:
-        spawn_env = dict(os.environ)
-        spawn_env["PROMPT_TOOLKIT_NO_CPR"] = "1"
         tui = pexpect.spawn(
             "iambic setup",
             timeout=5,
@@ -49,3 +78,56 @@ def test_setup_single_account() -> None:
         tui.expect("Proceed")
         tui.sendline("\r")  # use default
         tui.expect("What would you like to do", timeout=120)
+
+
+def test_setup_org_account(iam_spoke_role) -> None:
+    temp_templates_directory = tempfile.mkdtemp(
+        prefix="iambic_test_temp_templates_directory"
+    )
+    log_file = f"{temp_templates_directory}/test_setup_org_account.txt"
+    print(f"ui test log file is in {log_file}")
+    spawn_env = dict(os.environ)
+    spawn_env["PROMPT_TOOLKIT_NO_CPR"] = "1"
+    spawn_env["AWS_ACCESS_KEY_ID"] = iam_spoke_role["Credentials"]["AccessKeyId"]
+    spawn_env["AWS_SECRET_ACCESS_KEY"] = iam_spoke_role["Credentials"][
+        "SecretAccessKey"
+    ]
+    spawn_env["AWS_SESSION_TOKEN"] = iam_spoke_role["Credentials"]["SessionToken"]
+    with open(log_file, "wb") as fout:
+        tui = pexpect.spawn(
+            "iambic setup",
+            timeout=5,
+            env=spawn_env,
+            logfile=fout,
+            cwd=temp_templates_directory,
+        )
+        tui.expect("What would you like to configure")
+        tui.sendline("\r")  # use default AWS
+        tui.expect("What region should IAMbic use")
+        tui.sendline("\r")  # use default us-east-1
+        tui.expect("Which Account ID should we use to deploy the IAMbic hub role")
+        tui.sendline("\r")  # use default account number
+        tui.expect("Would you like to use this identity")
+        tui.sendline("\r")  # use default Y
+        tui.expect("What would you like to configure in AWS")
+        tui.sendline(KEY_DOWN)  # down once to AWS Organizations
+        tui.sendline("\r")  # use default account number
+        tui.expect("Proceed")
+        tui.sendline("Y")  # use default Y
+        tui.expect("AWS Organization ID")
+        tui.sendline("\r")  # use default
+        tui.expect("Grant IambicSpokeRole write access")
+        tui.sendline("Y\r")  # use default Y
+        tui.expect("Identity ARN")
+        tui.sendline("\r")  # use default
+        tui.expect("Role ARN")
+        tui.sendline("\r")  # use default
+        tui.expect("Add Tags")
+        tui.sendline("\r\n")  # use default
+        tui.expect("Would you like to setup Identity Center")
+        tui.sendline("\r")  # use default
+        tui.expect("Keep these settings")
+        tui.sendline("\r")  # use default
+        tui.expect("Add the org accounts to the config and import the org")
+        tui.sendline("\r")  # use default
+        tui.expect("What would you like to configure", timeout=600)

--- a/functional_tests/test_wizard.py
+++ b/functional_tests/test_wizard.py
@@ -1,0 +1,51 @@
+import os
+import tempfile
+
+import pexpect
+
+KEY_UP = "\x1b[A"
+KEY_DOWN = "\x1b[B"
+
+
+def test_setup_single_account() -> None:
+    temp_templates_directory = tempfile.mkdtemp(
+        prefix="iambic_test_temp_templates_directory"
+    )
+    log_file = f"{temp_templates_directory}/test_setup_single_aws_account.txt"
+    print(f"ui test log file is in {log_file}")
+    with open(log_file, "wb") as fout:
+        spawn_env = dict(os.environ)
+        spawn_env["PROMPT_TOOLKIT_NO_CPR"] = "1"
+        tui = pexpect.spawn(
+            "iambic setup",
+            timeout=5,
+            env=spawn_env,
+            logfile=fout,
+            cwd=temp_templates_directory,
+        )
+        tui.expect("What would you like to configure")
+        tui.sendline("\r")  # use default AWS
+        tui.expect("What region should IAMbic use")
+        tui.sendline("\r")  # use default us-east-1
+        tui.expect("Which Account ID should we use to deploy the IAMbic hub role")
+        tui.sendline("\r")  # use default account number
+        tui.expect("Would you like to use this identity")
+        tui.sendline("\r")  # use default Y
+        tui.expect("What would you like to configure in AWS")
+        tui.sendline(KEY_DOWN * 2)  # down twice to AWS Accounts
+        tui.sendline("\r")  # use default account number
+        tui.expect("Proceed")
+        tui.sendline("Y")  # use default Y
+        tui.expect("What is the name of the AWS Account")
+        tui.sendline("hub_account\r")  # use default Y
+        tui.expect("Grant IambicSpokeRole write access")
+        tui.sendline("Y\r")  # use default Y
+        tui.expect("Proceed")
+        tui.sendline("\r")  # use default
+        tui.expect("Role ARN")
+        tui.sendline("\r")  # use default
+        tui.expect("Add Tags")
+        tui.sendline("\r\n")  # use default
+        tui.expect("Proceed")
+        tui.sendline("\r")  # use default
+        tui.expect("What would you like to do", timeout=120)

--- a/functional_tests/test_wizard.py
+++ b/functional_tests/test_wizard.py
@@ -1,5 +1,7 @@
 import os
+import random
 import tempfile
+import time
 
 import boto3
 import pexpect
@@ -22,7 +24,6 @@ def iam_spoke_role():
     iambic_spoke_role_arn = iambic_spoke_role_arn.replace(
         "IambicHubRole", "IambicFunctionalTestWizardRole"
     )
-    print(iambic_spoke_role_arn)
 
     response = sts_client.assume_role(
         RoleArn=iambic_spoke_role_arn, RoleSessionName="functional_test"
@@ -53,30 +54,30 @@ def test_setup_single_account(iam_spoke_role) -> None:
             cwd=temp_templates_directory,
         )
         tui.expect("What would you like to configure")
-        tui.sendline("\r")  # use default AWS
+        tui.sendline("")  # use default AWS
         tui.expect("What region should IAMbic use")
-        tui.sendline("\r")  # use default us-east-1
+        tui.sendline("")  # use default us-east-1
         tui.expect("Which Account ID should we use to deploy the IAMbic hub role")
-        tui.sendline("\r")  # use default account number
+        tui.sendline("")  # use default account number
         tui.expect("Would you like to use this identity")
-        tui.sendline("\r")  # use default Y
+        tui.sendline("")  # use default
         tui.expect("What would you like to configure in AWS")
         tui.sendline(KEY_DOWN * 2)  # down twice to AWS Accounts
-        tui.sendline("\r")  # use default account number
+        tui.sendline("")  # use default account number
         tui.expect("Proceed")
-        tui.sendline("Y")  # use default Y
+        tui.sendline("")  # use default
         tui.expect("What is the name of the AWS Account")
-        tui.sendline("hub_account\r")  # use default Y
+        tui.sendline("hub_account")  # use default
         tui.expect("Grant IambicSpokeRole write access")
-        tui.sendline("Y\r")  # use default Y
+        tui.sendline("")  # use default
         tui.expect("Proceed")
-        tui.sendline("\r")  # use default
+        tui.sendline("")  # use default
         tui.expect("Role ARN")
-        tui.sendline("\r")  # use default
+        tui.sendline("")  # use default
         tui.expect("Add Tags")
-        tui.sendline("\r\n")  # use default
+        tui.sendline("\n")  # use default
         tui.expect("Proceed")
-        tui.sendline("\r")  # use default
+        tui.sendline("")  # use default
         tui.expect("What would you like to do", timeout=120)
 
 
@@ -102,32 +103,149 @@ def test_setup_org_account(iam_spoke_role) -> None:
             cwd=temp_templates_directory,
         )
         tui.expect("What would you like to configure")
-        tui.sendline("\r")  # use default AWS
+        tui.sendline("")  # use default AWS
         tui.expect("What region should IAMbic use")
-        tui.sendline("\r")  # use default us-east-1
+        tui.sendline("")  # use default us-east-1
         tui.expect("Which Account ID should we use to deploy the IAMbic hub role")
-        tui.sendline("\r")  # use default account number
+        tui.sendline("")  # use default account number
         tui.expect("Would you like to use this identity")
-        tui.sendline("\r")  # use default Y
+        tui.sendline("")  # use default
         tui.expect("What would you like to configure in AWS")
         tui.sendline(KEY_DOWN)  # down once to AWS Organizations
-        tui.sendline("\r")  # use default account number
+        tui.sendline("")  # use default account number
         tui.expect("Proceed")
-        tui.sendline("Y")  # use default Y
+        tui.sendline("")  # use default
         tui.expect("AWS Organization ID")
-        tui.sendline("\r")  # use default
+        tui.sendline("")  # use default
         tui.expect("Grant IambicSpokeRole write access")
-        tui.sendline("Y\r")  # use default Y
+        tui.sendline("")  # use default
         tui.expect("Identity ARN")
-        tui.sendline("\r")  # use default
+        tui.sendline("")  # use default
         tui.expect("Role ARN")
-        tui.sendline("\r")  # use default
+        tui.sendline("")  # use default
         tui.expect("Add Tags")
-        tui.sendline("\r\n")  # use default
+        tui.sendline("\n")  # use default
         tui.expect("Would you like to setup Identity Center")
-        tui.sendline("\r")  # use default
+        tui.sendline("")  # use default
         tui.expect("Keep these settings")
-        tui.sendline("\r")  # use default
+        tui.sendline("")  # use default
         tui.expect("Add the org accounts to the config and import the org")
-        tui.sendline("\r")  # use default
+        tui.sendline("")  # use default
         tui.expect("What would you like to configure", timeout=600)
+
+
+def test_setup_org_account_with_stack_creation(iam_spoke_role) -> None:
+    random_int = random.randint(0, 10000)
+    unique_suffix = f"FuncTest{random_int}"
+    iambic_hub_role_name = f"IambicHubRole{unique_suffix}"
+    iambic_spoke_role_name = f"IambicSpokeRole{unique_suffix}"
+    iambic_control_plane_region = "us-east-1"
+
+    # stackset creation is slow. this test is known to be slow
+    temp_templates_directory = tempfile.mkdtemp(
+        prefix="iambic_test_temp_templates_directory"
+    )
+    log_file = f"{temp_templates_directory}/test_setup_org_account.txt"
+    print(f"ui test log file is in {log_file}")
+    spawn_env = dict(os.environ)
+    spawn_env["PROMPT_TOOLKIT_NO_CPR"] = "1"
+    spawn_env["AWS_ACCESS_KEY_ID"] = iam_spoke_role["Credentials"]["AccessKeyId"]
+    spawn_env["AWS_SECRET_ACCESS_KEY"] = iam_spoke_role["Credentials"][
+        "SecretAccessKey"
+    ]
+    spawn_env["AWS_SESSION_TOKEN"] = iam_spoke_role["Credentials"]["SessionToken"]
+    with open(log_file, "wb") as fout:
+        tui = pexpect.spawn(
+            "iambic setup --more-options",
+            timeout=5,
+            env=spawn_env,
+            logfile=fout,
+            cwd=temp_templates_directory,
+        )
+        tui.expect("What would you like to configure")
+        tui.sendline("")  # use default AWS
+        tui.expect("What region should IAMbic use")
+        tui.sendline("")  # use default us-east-1
+        tui.expect("Which Account ID should we use to deploy the IAMbic hub role")
+        tui.sendline("")  # use default account number
+        tui.expect("Would you like to use this identity")
+        tui.sendline("")  # use default
+        tui.expect("What would you like to configure in AWS")
+        tui.sendline(KEY_DOWN)  # down once to AWS Organizations
+        tui.expect("Is this the case")
+        tui.sendline("")  # use default
+        tui.expect("Proceed")
+        tui.sendline("")  # use default
+        tui.expect("AWS Organization ID")
+        tui.sendline("")  # use default
+        tui.expect("Grant IambicSpokeRole write access")
+        tui.sendline("")  # use default
+        tui.expect("Identity ARN")
+        tui.sendline("")  # use default
+        tui.expect("Role ARN")
+        tui.sendline("")  # use default
+        tui.expect("Proceed")
+        tui.sendline("")  # use default
+        tui.expect("Iambic Hub Role Name")
+        tui.sendline(iambic_hub_role_name)
+        tui.expect("Iambic Spoke Role Name")
+        tui.sendline(iambic_spoke_role_name)
+        tui.expect("Add Tags")
+        tui.sendline("team=engineering")  # use default
+        tui.expect(
+            "Would you like to setup Identity Center", timeout=600
+        )  # stack set takes time
+        tui.sendline("")  # use default
+        tui.expect("Keep these settings")
+        tui.sendline("")  # use default
+        tui.expect("Add the org accounts to the config and import the org")
+        tui.sendline("")  # use default
+        tui.expect("What would you like to configure", timeout=600)
+
+    # find out organization root
+    org_client = boto3.client(
+        "organizations",
+        aws_access_key_id=iam_spoke_role["Credentials"]["AccessKeyId"],
+        aws_secret_access_key=iam_spoke_role["Credentials"]["SecretAccessKey"],
+        aws_session_token=iam_spoke_role["Credentials"]["SessionToken"],
+        region_name=iambic_control_plane_region,
+    )
+    org_response = org_client.list_roots()
+    org_root_id = org_response["Roots"][0]["Id"]
+
+    # clean up cf resources
+    cf_client = boto3.client(
+        "cloudformation",
+        aws_access_key_id=iam_spoke_role["Credentials"]["AccessKeyId"],
+        aws_secret_access_key=iam_spoke_role["Credentials"]["SecretAccessKey"],
+        aws_session_token=iam_spoke_role["Credentials"]["SessionToken"],
+        region_name=iambic_control_plane_region,
+    )
+    _ = cf_client.delete_stack(
+        StackName=iambic_hub_role_name,
+    )
+    _ = cf_client.delete_stack(
+        StackName=iambic_spoke_role_name,
+    )
+
+    _ = cf_client.delete_stack_instances(
+        StackSetName=iambic_spoke_role_name,
+        DeploymentTargets={
+            "OrganizationalUnitIds": [
+                org_root_id,
+            ],
+            "AccountFilterType": "NONE",
+        },
+        Regions=[
+            "us-east-1",
+        ],
+        OperationPreferences={
+            "RegionConcurrencyType": "PARALLEL",
+            "FailureTolerancePercentage": 100,
+            "MaxConcurrentPercentage": 100,
+        },
+        RetainStacks=False,
+    )
+    # takes time to delete
+    time.sleep(10)
+    _ = cf_client.delete_stack_set(StackSetName=iambic_spoke_role_name)

--- a/functional_tests/test_wizard.py
+++ b/functional_tests/test_wizard.py
@@ -112,7 +112,8 @@ def test_setup_org_account(iam_spoke_role) -> None:
         tui.sendline("")  # use default
         tui.expect("What would you like to configure in AWS")
         tui.sendline(KEY_DOWN)  # down once to AWS Organizations
-        tui.sendline("")  # use default account number
+        tui.expect("Is this the case")
+        tui.sendline("")  # use default
         tui.expect("Proceed")
         tui.sendline("")  # use default
         tui.expect("AWS Organization ID")
@@ -122,6 +123,8 @@ def test_setup_org_account(iam_spoke_role) -> None:
         tui.expect("Identity ARN")
         tui.sendline("")  # use default
         tui.expect("Role ARN")
+        tui.sendline("")  # use default
+        tui.expect("Proceed")
         tui.sendline("")  # use default
         tui.expect("Add Tags")
         tui.sendline("\n")  # use default

--- a/iambic/config/utils.py
+++ b/iambic/config/utils.py
@@ -11,6 +11,9 @@ if TYPE_CHECKING:
     from iambic.config.dynamic_config import Config
 
 
+CF_INVALID_TAGS_MSG = "Format has to be either blank or `key1=value1"
+
+
 async def resolve_config_template_path(repo_dir: str) -> pathlib.Path:
     config_template_file_path = await gather_templates(repo_dir, "Core::Config")
     if len(config_template_file_path) == 0:
@@ -49,3 +52,36 @@ def check_and_update_resource_limit(config: Config):
                 current_ulimit=soft_limit,
                 desired_ulimit=minimum_ulimit,
             )
+
+
+def aws_cf_parse_key_value_string(key_value_string):
+    # This function is here because we don't have an abstraction for plugin to customize wizard setup
+    # raw_key_value_string is a list of key value pairs separated by comma.
+    # Examples: "k1=v1,k2='v  2',k3,k4"
+    # https://github.com/aws/aws-cli/blob/96e5992ea216d7d951585c5050de589061f4e8fe/awscli/customizations/emr/emrutils.py#L28
+    key_value_list = []
+    if key_value_string:
+        raw_key_value_list = key_value_string.split(",")
+        for kv in raw_key_value_list:
+            kv = kv.strip()
+            if kv.find("=") == -1:
+                key, value = kv, ""
+            else:
+                key, value = kv.split("=", 1)
+            if len(key) < 1:
+                raise ValueError("key must have at least one character")
+            key_value_list.append({"Key": key, "Value": value})
+        return key_value_list
+    else:
+        return None
+
+
+def validate_aws_cf_input_tags(s):
+    # This function is here because we don't have an abstraction for plugin to customize wizard setup
+    try:
+        tags = aws_cf_parse_key_value_string(s)
+        if len(s) > 0 and len(tags) == 0:
+            return CF_INVALID_TAGS_MSG
+        return True
+    except Exception:
+        return CF_INVALID_TAGS_MSG

--- a/iambic/config/wizard.py
+++ b/iambic/config/wizard.py
@@ -117,7 +117,6 @@ def clear_stdin_buffer():
     """
     # Warning: This appears to work fine in a real terminal,
     # but not VSCode's Debug Terminal
-
     r, _, _ = select.select([sys.stdin], [], [], 0)
     while r:
         # If there is input waiting, read and discard it.
@@ -1815,14 +1814,18 @@ class ConfigurationWizard:
         hub_role_name = IAMBIC_HUB_ROLE_NAME
         spoke_role_name = IAMBIC_SPOKE_ROLE_NAME
         if self._is_more_options:
-            hub_role_name = questionary.text(
-                "Assign Iambic Hub Role Name: ",
-                default=IAMBIC_HUB_ROLE_NAME,
+            input_hub_role_name = questionary.text(
+                "(Optional) Iambic Hub Role Name: ",
+                default="",
             ).unsafe_ask()
-            spoke_role_name = questionary.text(
-                "Assign Iambic Spoke Role Name: ",
-                default=IAMBIC_SPOKE_ROLE_NAME,
+            input_spoke_role_name = questionary.text(
+                "(Optional) Iambic Spoke Role Name: ",
+                default="",
             ).unsafe_ask()
+            if input_hub_role_name:
+                hub_role_name = input_hub_role_name
+            if input_spoke_role_name:
+                spoke_role_name = input_spoke_role_name
         unparse_tags = questionary.text(
             "Add Tags (leave blank or `team=ops_team, cost_center=engineering`): ",
             default="",

--- a/iambic/config/wizard.py
+++ b/iambic/config/wizard.py
@@ -340,7 +340,7 @@ def confirm_command_exe(
 
 
 class ConfigurationWizard:
-    def __init__(self, repo_dir: str):
+    def __init__(self, repo_dir: str, is_more_options: bool = False):
         # TODO: Handle the case where the config file exists but is not valid
         self.existing_role_template_map = {}
         self.aws_account_map = {}
@@ -351,6 +351,7 @@ class ConfigurationWizard:
         self.caller_identity = {}
         self.profile_name = ""
         self._default_region = None
+        self._is_more_options = is_more_options
 
         asyncio.run(self.set_config_details())
         check_and_update_resource_limit(self.config)
@@ -884,14 +885,17 @@ class ConfigurationWizard:
         elif not is_hub_account:
             profile_name = None
 
-        hub_role_name = questionary.text(
-            "Assign Iambic Hub Role Name: ",
-            default=IAMBIC_HUB_ROLE_NAME,
-        ).unsafe_ask()
-        spoke_role_name = questionary.text(
-            "Assign Iambic Spoke Role Name: ",
-            default=IAMBIC_SPOKE_ROLE_NAME,
-        ).unsafe_ask()
+        hub_role_name = IAMBIC_HUB_ROLE_NAME
+        spoke_role_name = IAMBIC_SPOKE_ROLE_NAME
+        if self._is_more_options:
+            hub_role_name = questionary.text(
+                "Assign Iambic Hub Role Name: ",
+                default=IAMBIC_HUB_ROLE_NAME,
+            ).unsafe_ask()
+            spoke_role_name = questionary.text(
+                "Assign Iambic Spoke Role Name: ",
+                default=IAMBIC_SPOKE_ROLE_NAME,
+            ).unsafe_ask()
         unparse_tags = questionary.text(
             "Add Tags (leave blank or `team=ops_team, cost_center=engineering`): ",
             default="",
@@ -1200,14 +1204,17 @@ class ConfigurationWizard:
             log.info("Unable to add the AWS Org without creating the required roles.")
             return
 
-        hub_role_name = questionary.text(
-            "Assign Iambic Hub Role Name: ",
-            default=IAMBIC_HUB_ROLE_NAME,
-        ).unsafe_ask()
-        spoke_role_name = questionary.text(
-            "Assign Iambic Spoke Role Name: ",
-            default=IAMBIC_SPOKE_ROLE_NAME,
-        ).unsafe_ask()
+        hub_role_name = IAMBIC_HUB_ROLE_NAME
+        spoke_role_name = IAMBIC_SPOKE_ROLE_NAME
+        if self._is_more_options:
+            hub_role_name = questionary.text(
+                "Assign Iambic Hub Role Name: ",
+                default=IAMBIC_HUB_ROLE_NAME,
+            ).unsafe_ask()
+            spoke_role_name = questionary.text(
+                "Assign Iambic Spoke Role Name: ",
+                default=IAMBIC_SPOKE_ROLE_NAME,
+            ).unsafe_ask()
         unparse_tags = questionary.text(
             "Add Tags (leave blank or `team=ops_team, cost_center=engineering`): ",
             default="",

--- a/iambic/config/wizard.py
+++ b/iambic/config/wizard.py
@@ -806,6 +806,7 @@ class ConfigurationWizard:
                 > self.config.aws.min_accounts_required_for_wildcard_included_accounts
             )
         )
+        assume_as_arn = self.assume_as_arn
 
         if is_hub_account:
             account_id = self.hub_account_id
@@ -827,6 +828,8 @@ class ConfigurationWizard:
                     "Unable to add the AWS Account without creating the required roles."
                 )
                 return
+
+            role_arn = set_aws_role_arn(account_id)
 
         else:
             if requires_sync:
@@ -858,7 +861,6 @@ class ConfigurationWizard:
                 "What region should IAMbic use?", self.aws_default_region
             )
             role_arn = set_aws_role_arn(account_id)
-            assume_as_arn = self.assume_as_arn
 
             click.echo(
                 "\nIAMbic requires Hub and Spoke roles to be created which is deployed using CloudFormation.\n"

--- a/iambic/main.py
+++ b/iambic/main.py
@@ -461,9 +461,17 @@ def init_plugins_cmd(repo_dir: str):
     default=os.getenv("IAMBIC_REPO_DIR"),
     help="The repo directory. Example: ~/iambic-templates",
 )
-def setup(repo_dir: str):
+@click.option(
+    "--more-options",
+    "is_more_options",
+    is_flag=True,
+    hidden=True,
+    default=False,
+    help="If enabled, wizard will ask more questions",
+)
+def setup(repo_dir: str, is_more_options: bool):
     ctx.command = Command.APPLY
-    ConfigurationWizard(repo_dir).run()
+    ConfigurationWizard(repo_dir, is_more_options=is_more_options).run()
 
 
 if __name__ == "__main__":

--- a/iambic/plugins/v0_1_0/aws/cloud_formation/utils.py
+++ b/iambic/plugins/v0_1_0/aws/cloud_formation/utils.py
@@ -483,16 +483,3 @@ async def create_iambic_role_stacks(
         )
 
     return hub_role_created
-
-
-def parse_pair(s) -> dict:
-    key, value = s.rstrip().split("=")
-    return {"Key": key, "Value": value}
-
-
-def parse_tags(s) -> list[dict]:
-    if not s:
-        return None
-    else:
-        pairs = s.split(",")
-        return [parse_pair(p) for p in pairs]

--- a/iambic/plugins/v0_1_0/aws/cloud_formation/utils.py
+++ b/iambic/plugins/v0_1_0/aws/cloud_formation/utils.py
@@ -322,22 +322,33 @@ async def create_spoke_role_stack_set(
     org_client,
     hub_account_id: str,
     read_only=False,
+    stack_set_name=IAMBIC_SPOKE_ROLE_NAME,
+    hub_role_name=IAMBIC_HUB_ROLE_NAME,
+    spoke_role_name=IAMBIC_SPOKE_ROLE_NAME,
+    tags=None,
 ) -> bool:
     region = cf_client.meta.region_name
     org_roots = await legacy_paginated_search(
         org_client.list_roots, response_key="Roots"
     )
 
+    kwargs = {}
+
+    if tags:
+        kwargs["Tags"] = tags
+
     return await create_stack_set(
         cf_client,
-        stack_set_name="IambicSpokeRole",
+        stack_set_name=stack_set_name,
         template_body=get_iambic_spoke_role_template_body(read_only=read_only),
         parameters=[
             {
                 "ParameterKey": "HubRoleArn",
-                "ParameterValue": get_hub_role_arn(hub_account_id),
+                "ParameterValue": get_hub_role_arn(
+                    hub_account_id, role_name=hub_role_name
+                ),
             },
-            {"ParameterKey": "SpokeRoleName", "ParameterValue": IAMBIC_SPOKE_ROLE_NAME},
+            {"ParameterKey": "SpokeRoleName", "ParameterValue": spoke_role_name},
         ],
         deployment_targets={
             "OrganizationalUnitIds": [root["Id"] for root in org_roots],
@@ -350,6 +361,7 @@ async def create_spoke_role_stack_set(
             "FailureToleranceCount": 10,
         },
         Capabilities=["CAPABILITY_NAMED_IAM"],
+        **kwargs,
     )
 
 
@@ -358,20 +370,28 @@ async def create_spoke_role_stack(
     hub_account_id: str,
     role_arn: str = None,
     read_only=False,
+    stack_name=IAMBIC_SPOKE_ROLE_NAME,
+    hub_role_name=IAMBIC_HUB_ROLE_NAME,
+    spoke_role_name=IAMBIC_SPOKE_ROLE_NAME,
+    tags=None,
 ) -> bool:
     additional_kwargs = {"RoleARN": role_arn} if role_arn else {}
+    if tags:
+        additional_kwargs["Tags"] = tags
     return await create_stack(
         cf_client,
-        stack_name="IambicSpokeRole",
+        stack_name=stack_name,
         template_body=get_iambic_spoke_role_template_body(read_only=read_only),
         parameters=[
             {
                 "ParameterKey": "HubRoleArn",
-                "ParameterValue": get_hub_role_arn(hub_account_id),
+                "ParameterValue": get_hub_role_arn(
+                    hub_account_id, role_name=hub_role_name
+                ),
             },
             {
                 "ParameterKey": "SpokeRoleName",
-                "ParameterValue": IAMBIC_SPOKE_ROLE_NAME,
+                "ParameterValue": spoke_role_name,
             },
         ],
         Capabilities=["CAPABILITY_NAMED_IAM"],
@@ -384,17 +404,24 @@ async def create_hub_role_stack(
     hub_account_id: str,
     assume_as_arn: str,
     role_arn: str = None,
+    stack_name=IAMBIC_HUB_ROLE_NAME,
+    hub_role_name=IAMBIC_HUB_ROLE_NAME,
+    spoke_role_name=IAMBIC_SPOKE_ROLE_NAME,
+    tags=None,
 ) -> bool:
     additional_kwargs = {"RoleARN": role_arn} if role_arn else {}
+    if tags:
+        additional_kwargs["Tags"] = tags
+
     stack_created = await create_stack(
         cf_client,
-        stack_name="IambicHubRole",
+        stack_name=stack_name,
         template_body=get_iambic_hub_role_template_body(),
         parameters=[
-            {"ParameterKey": "HubRoleName", "ParameterValue": IAMBIC_HUB_ROLE_NAME},
+            {"ParameterKey": "HubRoleName", "ParameterValue": hub_role_name},
             {
                 "ParameterKey": "SpokeRoleName",
-                "ParameterValue": IAMBIC_SPOKE_ROLE_NAME,
+                "ParameterValue": spoke_role_name,
             },
             {"ParameterKey": "AssumeAsArn", "ParameterValue": assume_as_arn},
         ],
@@ -402,7 +429,14 @@ async def create_hub_role_stack(
         **additional_kwargs,
     )
     if stack_created:
-        return await create_spoke_role_stack(cf_client, hub_account_id, role_arn)
+        return await create_spoke_role_stack(
+            cf_client,
+            hub_account_id,
+            role_arn,
+            stack_name=spoke_role_name,
+            hub_role_name=hub_role_name,
+            spoke_role_name=spoke_role_name,
+        )
 
     return stack_created
 
@@ -414,12 +448,21 @@ async def create_iambic_role_stacks(
     role_arn: str = None,
     org_client=None,
     read_only=False,
+    hub_role_stack_name=IAMBIC_HUB_ROLE_NAME,
+    hub_role_name=IAMBIC_HUB_ROLE_NAME,
+    spoke_role_stack_name=IAMBIC_SPOKE_ROLE_NAME,
+    spoke_role_name=IAMBIC_SPOKE_ROLE_NAME,
+    tags=None,
 ) -> bool:
     hub_role_created = await create_hub_role_stack(
         cf_client,
         hub_account_id,
         assume_as_arn,
         role_arn,
+        stack_name=hub_role_stack_name,
+        hub_role_name=hub_role_name,
+        spoke_role_name=spoke_role_name,
+        tags=tags,
     )
     region = cf_client.meta.region_name
     if hub_role_created and org_client:
@@ -429,7 +472,27 @@ async def create_iambic_role_stacks(
             f"https://{region}.console.aws.amazon.com/cloudformation/home?region={region}#/stacksets/IambicSpokeRole/stacks\n"
         )
         return await create_spoke_role_stack_set(
-            cf_client, org_client, hub_account_id, read_only=read_only
+            cf_client,
+            org_client,
+            hub_account_id,
+            read_only=read_only,
+            stack_set_name=spoke_role_stack_name,
+            hub_role_name=hub_role_name,
+            spoke_role_name=spoke_role_name,
+            tags=tags,
         )
 
     return hub_role_created
+
+
+def parse_pair(s) -> dict:
+    key, value = s.rstrip().split("=")
+    return {"Key": key, "Value": value}
+
+
+def parse_tags(s) -> list[dict]:
+    if not s:
+        return None
+    else:
+        pairs = s.split(",")
+        return [parse_pair(p) for p in pairs]

--- a/iambic/plugins/v0_1_0/aws/cloud_formation/utils.py
+++ b/iambic/plugins/v0_1_0/aws/cloud_formation/utils.py
@@ -469,7 +469,7 @@ async def create_iambic_role_stacks(
         log.info(
             f"WARNING: Do not exit; creating stack instances.\n"
             f"You can check the progress here:\n"
-            f"https://{region}.console.aws.amazon.com/cloudformation/home?region={region}#/stacksets/IambicSpokeRole/stacks\n"
+            f"https://{region}.console.aws.amazon.com/cloudformation/home?region={region}#/stacksets/{spoke_role_name}/stacks\n"
         )
         return await create_spoke_role_stack_set(
             cf_client,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "iambic-core"
 packages = [
     { include="iambic", from="." },
 ]
-version = "0.6.2"
+version = "0.7.0"
 license = "Apache-2.0"
 description = "The python package used to generate, parse, and execute noqform yaml templates."
 authors = ["Noq Software <hello@noq.dev>"]


### PR DESCRIPTION
## What changed?
* Tags support on cloudformation stack and stack sets creation. The tags propagate to resources created by stack and stack sets.
* Support custom name for IambicHubRole
* Support custom name for IambicSpokeRole

## Rationale
* Rather than plumbing specific tag support on just IAM roles. It seems more convention to attach tags on the stack and stack sets, and let cloudformation to propagate tags down to any resources created.
* Support custom name for IambicHubRole and IambicSpokeRole helps a lot during development and testing because I don't have to blow away existing installation. (so there is no role creation conflict)

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [ ] Unit Tests
- [x] Functional Tests
- [x] Manually Verified

Run iambic setup, and iambic import