### PR TITLE
Fix #397 Handle legacy statement dictinoary schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 
 # Change Log
 
+## 0.7.3 (May 10th, 2023)
+
+BUG FIXES:
+
+* AWS plugin now supports legacy policy document schema. (This is an undocumented
+schema in which statement can be a single statement not wrapped inside an array.
+New policy editor will always use the array syntax; however, there are old policies
+that have the legacy syntax. IAMbic should handle it gracefully without crashing.)
+
+THANKS:
+
+* `Shreyas D` reported the issue [#397](https://github.com/noqdev/iambic/pull/397)
+
+
 ## 0.7.1 (May 9th, 2023)
 
 ENHANCEMENTS:

--- a/iambic/plugins/v0_1_0/aws/iam/policy/models.py
+++ b/iambic/plugins/v0_1_0/aws/iam/policy/models.py
@@ -181,7 +181,7 @@ class PolicyStatement(AccessModel, ExpiryModel):
 
 class AssumeRolePolicyDocument(AccessModel):
     version: str = "2008-10-17"
-    statement: Optional[List[PolicyStatement]] = None
+    statement: Optional[Union[List[PolicyStatement], PolicyStatement]] = None
 
     @property
     def resource_type(self) -> str:
@@ -197,7 +197,7 @@ class PolicyDocument(AccessModel, ExpiryModel):
         description="The name of the policy.",
     )
     version: Optional[str]
-    statement: Optional[List[PolicyStatement]] = Field(
+    statement: Optional[Union[List[PolicyStatement], PolicyStatement]] = Field(
         None,
         description="List of policy statements",
     )
@@ -213,7 +213,7 @@ class PolicyDocument(AccessModel, ExpiryModel):
 
 class ManagedPolicyDocument(AccessModel):
     version: Optional[str] = None
-    statement: Optional[List[PolicyStatement]] = Field(
+    statement: Optional[Union[List[PolicyStatement], PolicyStatement]] = Field(
         None,
         description="List of policy statements",
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "iambic-core"
 packages = [
     { include="iambic", from="." },
 ]
-version = "0.7.3"
+version = "0.7.2"
 license = "Apache-2.0"
 description = "The python package used to generate, parse, and execute noqform yaml templates."
 authors = ["Noq Software <hello@noq.dev>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "iambic-core"
 packages = [
     { include="iambic", from="." },
 ]
-version = "0.7.2"
+version = "0.7.3"
 license = "Apache-2.0"
 description = "The python package used to generate, parse, and execute noqform yaml templates."
 authors = ["Noq Software <hello@noq.dev>"]

--- a/test/plugins/v0_1_0/aws/iam/policy/test_utils.py
+++ b/test/plugins/v0_1_0/aws/iam/policy/test_utils.py
@@ -33,6 +33,16 @@ EXAMPLE_POLICY_DOCUMENT = """
    ]
 }
 """
+EXAMPLE_LEGACY_POLICY_DOCUMENT = """
+{
+   "Version":"2012-10-17",
+   "Statement": {
+        "Effect":"Allow",
+        "Action":"acm:ListCertificates",
+        "Resource":"*"
+    }
+}
+"""
 EXAMPLE_TAG_KEY = "test_key"
 EXAMPLE_TAG_VALUE = "test_value"
 EXAMPLE_POLICY_ARN = "arn:aws:iam::123456789012:policy/example_managed_policy_name"
@@ -116,6 +126,21 @@ async def test_delete_managed_policy(mock_iam_client):
 @pytest.mark.asyncio
 async def test_apply_update_managed_policy(mock_iam_client):
     template_policy_document = json.loads(EXAMPLE_POLICY_DOCUMENT)
+    existing_policy_document = []
+    log_params = {}
+    proposed_changes = await apply_update_managed_policy(
+        mock_iam_client,
+        EXAMPLE_POLICY_ARN,
+        template_policy_document,
+        existing_policy_document,
+        log_params,
+    )
+    assert proposed_changes[0].change_type == ProposedChangeType.UPDATE
+
+
+@pytest.mark.asyncio
+async def test_apply_update_managed_policy_using_legacy_syntax(mock_iam_client):
+    template_policy_document = json.loads(EXAMPLE_LEGACY_POLICY_DOCUMENT)
     existing_policy_document = []
     log_params = {}
     proposed_changes = await apply_update_managed_policy(


### PR DESCRIPTION
## What changed?
* Policy Statement legacy schema allows dictionary (single statement) besides the list of statements

## Rationale
* Since single statement policy document schema is valid in AWS, we have to support it.

The official grammar document did not even mention this oddities: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_grammar.html

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [x] Unit Tests
- [ ] Functional Tests
- [x] Manually Verified

Manual testing:

Change an existing managed policy to use the legacy syntax. then run iambic import.