### PR TITLE
Prototype template file location based on path attribute

### DIFF
--- a/iambic/plugins/v0_1_0/aws/iam/group/template_generation.py
+++ b/iambic/plugins/v0_1_0/aws/iam/group/template_generation.py
@@ -59,6 +59,7 @@ def get_templated_group_file_path(
     group_dir: str,
     group_name: str,
     included_accounts: list[str],
+    group_path: str = None,
 ) -> str:
     if included_accounts is not None and len(included_accounts) > 1:
         separator = "multi_account"
@@ -76,7 +77,21 @@ def get_templated_group_file_path(
         .replace(".", "_")
         .lower()
     )
-    return str(os.path.join(group_dir, separator, f"{file_name}.yaml"))
+
+    # using path components from path attribute
+    if group_path:
+        group_path_components = group_path.split("/")
+        # get rid of empty component
+        group_path_components = [
+            component for component in group_path_components if component
+        ]
+
+    # stitch desired location together
+    os_paths = [group_dir, separator]
+    os_paths.extend(group_path_components)
+    os_paths.append(f"{file_name}.yaml")
+
+    return str(os.path.join(*os_paths))
 
 
 async def generate_account_group_resource_files(
@@ -303,6 +318,7 @@ async def create_templated_group(  # noqa: C901
         group_dir,
         group_name,
         group_template_params.get("included_accounts"),
+        group_path=path,
     )
     return create_or_update_template(
         file_path,

--- a/iambic/plugins/v0_1_0/aws/iam/policy/template_generation.py
+++ b/iambic/plugins/v0_1_0/aws/iam/policy/template_generation.py
@@ -58,6 +58,7 @@ def get_templated_managed_policy_file_path(
     policy_name: str,
     included_accounts: list[str],
     account_map: dict[str, AWSAccount],
+    managed_policy_path: str = None,
 ):
     if len(included_accounts) > 1:
         separator = "multi_account"
@@ -74,7 +75,21 @@ def get_templated_managed_policy_file_path(
         .replace(".", "_")
         .lower()
     )
-    return str(os.path.join(managed_policy_dir, separator, f"{file_name}.yaml"))
+
+    # using path components from path attribute
+    if managed_policy_path:
+        managed_policy_path_components = managed_policy_path.split("/")
+        # get rid of empty component
+        managed_policy_path_components = [
+            component for component in managed_policy_path_components if component
+        ]
+
+    # stitch desired location together
+    os_paths = [managed_policy_dir, separator]
+    os_paths.extend(managed_policy_path_components)
+    os_paths.append(f"{file_name}.yaml")
+
+    return str(os.path.join(*os_paths))
 
 
 async def generate_account_managed_policy_resource_files(
@@ -290,6 +305,7 @@ async def create_templated_managed_policy(  # noqa: C901
         managed_policy_name,
         template_params.get("included_accounts"),
         aws_account_map,
+        managed_policy_path=path,
     )
     return create_or_update_template(
         file_path,

--- a/iambic/plugins/v0_1_0/aws/iam/role/template_generation.py
+++ b/iambic/plugins/v0_1_0/aws/iam/role/template_generation.py
@@ -61,6 +61,7 @@ def get_templated_role_file_path(
     role_dir: str,
     role_name: str,
     included_accounts: list[str],
+    role_path: str = None,
 ) -> str:
     if included_accounts is not None and len(included_accounts) > 1:
         separator = "multi_account"
@@ -78,7 +79,21 @@ def get_templated_role_file_path(
         .replace(".", "_")
         .lower()
     )
-    return str(os.path.join(role_dir, separator, f"{file_name}.yaml"))
+
+    # using path components from path attribute
+    if role_path:
+        role_path_components = role_path.split("/")
+        # get rid of empty component
+        role_path_components = [
+            component for component in role_path_components if component
+        ]
+
+    # stitch desired location together
+    os_paths = [role_dir, separator]
+    os_paths.extend(role_path_components)
+    os_paths.append(f"{file_name}.yaml")
+
+    return str(os.path.join(*os_paths))
 
 
 async def generate_account_role_resource_files(
@@ -409,6 +424,7 @@ async def create_templated_role(  # noqa: C901
         role_dir,
         role_name,
         role_template_params.get("included_accounts"),
+        role_path=path,
     )
     return create_or_update_template(
         file_path,

--- a/iambic/plugins/v0_1_0/aws/iam/user/template_generation.py
+++ b/iambic/plugins/v0_1_0/aws/iam/user/template_generation.py
@@ -61,6 +61,7 @@ def get_templated_user_file_path(
     user_dir: str,
     user_name: str,
     included_accounts: list[str],
+    user_path: str = None,
 ) -> str:
     if included_accounts is not None and len(included_accounts) > 1:
         separator = "multi_account"
@@ -78,7 +79,21 @@ def get_templated_user_file_path(
         .replace(".", "_")
         .lower()
     )
-    return str(os.path.join(user_dir, separator, f"{file_name}.yaml"))
+
+    # using path components from path attribute
+    if user_path:
+        user_path_components = user_path.split("/")
+        # get rid of empty component
+        user_path_components = [
+            component for component in user_path_components if component
+        ]
+
+    # stitch desired location together
+    os_paths = [user_dir, separator]
+    os_paths.extend(user_path_components)
+    os_paths.append(f"{file_name}.yaml")
+
+    return str(os.path.join(*os_paths))
 
 
 async def generate_account_user_resource_files(
@@ -387,6 +402,7 @@ async def create_templated_user(  # noqa: C901
         user_dir,
         user_name,
         user_template_params.get("included_accounts"),
+        user_path=path,
     )
     return create_or_update_template(
         file_path,


### PR DESCRIPTION
## What changed?
* If AWS resources have "path" attribute, use it generate template path based on the path components

For example: a role generated by the IdentityCenter will be placed in 

resources/aws/iam/role/iambic_test_org_account/aws-reserved/sso.amazonaws.com/awsreservedsso_administratoraccess_4819c5786e143dd5.yaml

* This change imports roles, policies, user, group

This is an example change: https://github.com/noqdev/iambic-templates-examples/pull/11/files

## Rationale
* AWS managed resources leverage "path" attribute to group things they don't want AWS customer to edit. (such as service-linked roles, or roles created by IdentityCenter.

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [ ] Unit Tests
- [ ] Functional Tests
- [x] Manually Verified

Run iambic import in a fresh repo and examine the location the template is placed at.