### PR TITLE
fix: remove wrong parameters

### DIFF
--- a/iambic/config/wizard.py
+++ b/iambic/config/wizard.py
@@ -916,9 +916,7 @@ class ConfigurationWizard:
                     hub_account_id=account_id,
                     role_arn=role_arn,
                     read_only=read_only,
-                    hub_role_stack_name=hub_role_name,
                     hub_role_name=hub_role_name,
-                    spoke_role_stack_name=spoke_role_name,
                     spoke_role_name=spoke_role_name,
                     tags=tags,
                 )


### PR DESCRIPTION
## What changed?
Arguments removed from `create_spoke_role_stack` at `wizard.py`

## Rationale
Due to the python typing nature, when we refactor some arguments got changed

## How was it tested?

- [ ] Unit Tests
- [ ] Functional Tests
- [x] Manually Verified
