### PR TITLE
EN-2120: remove account's id and name from variables, if empty exclude it

### DIFF
--- a/iambic/plugins/v0_1_0/aws/models.py
+++ b/iambic/plugins/v0_1_0/aws/models.py
@@ -479,6 +479,17 @@ class AWSAccount(ProviderChild, BaseAWSAccountAndOrgModel):
             exclude_defaults=exclude_defaults,
             exclude_none=exclude_none,
         )
+
+        if "variables" in resp:
+            resp["variables"] = [
+                i
+                for i in resp.get("variables", [])
+                if i.get("key") not in ["account_id", "account_name"]
+            ]
+
+            if resp["variables"] == []:
+                resp.pop("variables")
+
         return sort_dict(
             resp,
             [


### PR DESCRIPTION
## What changed?
Exclude account_name and account_id from variables

## Rationale
These keys are written in other level, so it is redundant.

## How was it tested?
- [ ] Unit Tests
- [ ] Functional Tests
- [x] Manually Verified: clean repo execute setup
