### PR TITLE
Fix change detection setup for isolated runs

### DIFF
--- a/docs/web/docs/2-how_to_guides/1-AWS/2-convert-aws-json-to-iambic-yaml.mdx
+++ b/docs/web/docs/2-how_to_guides/1-AWS/2-convert-aws-json-to-iambic-yaml.mdx
@@ -1,3 +1,47 @@
 ---
 title: Converting IAM Policy Syntax to IAMbic YAML
 ---
+
+IAMbic provides a Policy Converter that allows you to convert AWS IAM Policies to IAMbic-compatible YAML and vice versa.
+This tool is available both as a command-line interface (CLI) using `iambic convert` and a web tool at
+[https://www.iambic.org/tools/policy-converter](https://www.iambic.org/tools/policy-converter).
+
+## How to use
+
+### CLI
+
+#### Convert AWS IAM Policies to IAMbic-compatible YAML
+
+1. Open your terminal.
+2. Run the command `iambic convert`. This will open your default text editor.
+3. Paste the AWS IAM policy JSON that you want to convert into the editor.
+4. Save and close the editor.
+5. The converted IAMbic-compatible YAML will be printed in the terminal.
+
+#### Convert IAMbic-compatible YAML to AWS IAM Policies
+
+1. Open your terminal.
+2. Run the command `iambic convert`. This will open your default text editor.
+3. Paste the IAMbic-compatible YAML that you want to convert into the editor.
+4. Save and close the editor.
+5. The converted AWS IAM policy JSON will be printed in the terminal.
+
+### Web Tool
+
+#### Convert AWS IAM Policies to IAMbic-compatible YAML
+
+1. Navigate to [https://www.iambic.org/tools/policy-converter](https://www.iambic.org/tools/policy-converter) in your web browser.
+2. Paste the AWS IAM policy JSON into the editor labeled "JSON".
+3. The converted IAMbic-compatible YAML will automatically appear in the "IAMbic-compatible YAML" editor.
+
+#### Convert IAMbic-compatible YAML to AWS IAM Policies
+
+1. Navigate to [https://www.iambic.org/tools/policy-converter](https://www.iambic.org/tools/policy-converter) in your web browser.
+2. Paste the IAMbic-compatible YAML into the editor labeled "IAMbic-compatible YAML".
+3. The converted AWS IAM policy JSON will automatically appear in the "JSON" editor.
+
+## Using IAM Policy Simulator or AWS Policy Generator
+
+You can directly paste IAM policies from the [IAM Policy Simulator](https://policysim.aws.amazon.com/) or
+ [AWS Policy Generator](https://awspolicygen.s3.amazonaws.com/policygen.html) into the IAMbic Policy Converter
+ to convert them. Simply follow the steps above for converting AWS IAM Policies to IAMbic-compatible YAML or vice versa.

--- a/iambic/config/wizard.py
+++ b/iambic/config/wizard.py
@@ -1833,6 +1833,7 @@ class ConfigurationWizard:
         return hub_role_name, spoke_role_name, tags
 
     def configuration_wizard_change_detection_setup(self, aws_org: AWSOrganization):
+        self.setup_aws_configuration()
         click.echo(
             "\nTo setup change detection for iambic it requires creating CloudFormation stacks "
             "and a CloudFormation stack set.\n"
@@ -1841,6 +1842,12 @@ class ConfigurationWizard:
             "If you have already manually deployed the templates, answer yes to proceed.\n"
             "IAMbic will validate that your stacks have been deployed successfully and will not attempt to replace them."
         )
+        unparse_tags = questionary.text(
+            "Add Tags (leave blank or `team=ops_team, cost_center=engineering`): ",
+            default="",
+            validate=validate_aws_cf_input_tags,
+        ).ask()
+        tags = aws_cf_parse_key_value_string(unparse_tags)
         if not questionary.confirm("Proceed?").unsafe_ask():
             return
 
@@ -1859,6 +1866,7 @@ class ConfigurationWizard:
                 aws_org.org_id,
                 aws_org.org_account_id,
                 self.cf_role_arn,
+                tags=tags,
             )
         )
         if not successfully_created:

--- a/iambic/config/wizard.py
+++ b/iambic/config/wizard.py
@@ -58,6 +58,7 @@ from iambic.plugins.v0_1_0.aws.iam.role.models import (
 from iambic.plugins.v0_1_0.aws.iambic_plugin import AWSConfig
 from iambic.plugins.v0_1_0.aws.models import (
     ARN_RE,
+    IAMBIC_CHANGE_DETECTION_SUFFIX,
     IAMBIC_HUB_ROLE_NAME,
     IAMBIC_SPOKE_ROLE_NAME,
     AWSAccount,
@@ -1874,7 +1875,7 @@ class ConfigurationWizard:
 
         role_name = IAMBIC_SPOKE_ROLE_NAME
         hub_account_id = self.hub_account_id
-        sqs_arn = f"arn:aws:sqs:{self.aws_default_region}:{hub_account_id}:IAMbicChangeDetectionQueue"
+        sqs_arn = f"arn:aws:sqs:{self.aws_default_region}:{hub_account_id}:IAMbicChangeDetectionQueue{IAMBIC_CHANGE_DETECTION_SUFFIX}"
 
         if not self.existing_role_template_map:
             log.info("Loading AWS role templates...")

--- a/iambic/plugins/v0_1_0/aws/cloud_formation/templates/IdentityRuleDestination.yml
+++ b/iambic/plugins/v0_1_0/aws/cloud_formation/templates/IdentityRuleDestination.yml
@@ -6,15 +6,19 @@ Parameters:
   OrgID:
     Type: String
     Description: AWS Organization ID.
+  Suffix:
+    Type: String
+    Description: Suffix to append to the name of the EventBridge Bus and SQS Queue.
+    Default: ""
 Resources:
   IAMbicEventBus:
     Type: 'AWS::Events::EventBus'
     Properties:
-      Name: 'IAMbicChangeDetectionEventBus'
+      Name: !Sub 'IAMbicChangeDetectionEventBus${Suffix}'
   IAMbicEventBusPolicy:
     Type: 'AWS::Events::EventBusPolicy'
     Properties:
-      StatementId: 'IAMbicEventBusPolicy'
+      StatementId: !Sub 'IAMbicEventBusPolicy${Suffix}'
       EventBusName: !Ref IAMbicEventBus
       Statement:
         Effect: "Allow"
@@ -29,7 +33,7 @@ Resources:
   IAMbicEventRule:
     Type: 'AWS::Events::Rule'
     Properties:
-      Name: IAMbicChangeDetectionRule
+      Name: !Sub 'IAMbicChangeDetectionRule${Suffix}'
       Description: 'Captures changes when an Identity is created/Updated/deleted.'
       EventBusName: !Ref IAMbicEventBus
       EventPattern:
@@ -39,6 +43,7 @@ Resources:
           eventSource:
             - iam.amazonaws.com
             - sso.amazonaws.com
+            - organizations.amazonaws.com
           eventName:
             - prefix: Create
             - prefix: Update
@@ -60,7 +65,7 @@ Resources:
   IAMbicChangeDetectionQueue:
     Type: 'AWS::SQS::Queue'
     Properties:
-      QueueName: IAMbicChangeDetectionQueue
+      QueueName: !Sub 'IAMbicChangeDetectionQueue${Suffix}'
       MessageRetentionPeriod: 604800
   IAMbicChangeDetectionQueueSQSPolicy:
     Type: AWS::SQS::QueuePolicy

--- a/iambic/plugins/v0_1_0/aws/cloud_formation/templates/IdentityRuleForwarder.yml
+++ b/iambic/plugins/v0_1_0/aws/cloud_formation/templates/IdentityRuleForwarder.yml
@@ -5,11 +5,15 @@ Description: >-
 Parameters:
   TargetEventBusArn:
     Type: String
+  Suffix:
+    Type: String
+    Description: Suffix to append to the name of the role, rule, and other resources
+    Default: ""
 Resources:
   IAMbicEventForwardingRole:
     Type: 'AWS::IAM::Role'
     Properties:
-      RoleName: 'IAMbicEventForwardingRole'
+      RoleName: !Sub 'IAMbicEventForwardingRole${Suffix}'
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -31,7 +35,7 @@ Resources:
   IAMbicEventForwardingRule:
     Type: 'AWS::Events::Rule'
     Properties:
-      Name: IAMbicEventForwardingRule
+      Name: !Sub 'IAMbicEventForwardingRule${Suffix}'
       Description: 'Captures IAM and SSO events and forwards the events to the IAMbicEventBus for processing.'
       EventBusName: default
       EventPattern:
@@ -41,6 +45,7 @@ Resources:
           eventSource:
             - iam.amazonaws.com
             - sso.amazonaws.com
+            - organizations.amazonaws.com
           eventName:
             - prefix: Create
             - prefix: Update

--- a/iambic/plugins/v0_1_0/aws/models.py
+++ b/iambic/plugins/v0_1_0/aws/models.py
@@ -49,6 +49,7 @@ ARN_RE = r"(^arn:([^:]*):([^:]*):([^:]*):(|\*|[\d]{12}|cloudfront|aws|{{var.acco
 
 IAMBIC_HUB_ROLE_NAME = os.getenv("IAMBIC_HUB_ROLE_NAME", "IambicHubRole")
 IAMBIC_SPOKE_ROLE_NAME = os.getenv("IAMBIC_SPOKE_ROLE_NAME", "IambicSpokeRole")
+IAMBIC_CHANGE_DETECTION_SUFFIX = os.getenv("IAMBIC_CHANGE_DETECTION_SUFFIX", "")
 
 
 def get_hub_role_arn(account_id: str, role_name=None) -> str:


### PR DESCRIPTION
This PR fixes #407. When we set up change detection, we are assuming that the AWS configuration has already been loaded in. This was only the case if you ran the change detection setup immediately after setting up your AWS hub/spoke accounts. We fixed this by calling `self.setup_aws_configuration()`.

This PR also adds tag support for change detection stack/stack sets, and adds `iambic convert` details to the docs.