### PR TITLE
Ignore extra fields provided by Azure AD

### DIFF
--- a/iambic/plugins/v0_1_0/azure_ad/group/models.py
+++ b/iambic/plugins/v0_1_0/azure_ad/group/models.py
@@ -8,7 +8,7 @@ from itertools import chain
 from typing import TYPE_CHECKING, Any, List, Optional, Union
 
 from aiohttp import ClientResponseError
-from pydantic import Field
+from pydantic import Extra, Field
 
 from iambic.core.context import ctx
 from iambic.core.logger import log
@@ -198,6 +198,9 @@ class GroupTemplateProperties(ExpiryModel, BaseModel):
         if "mail_nickname" not in data:
             data["mail_nickname"] = data.get("name")
         super().__init__(**data)
+
+    class Config:
+        extra = Extra.ignore
 
     @property
     def resource_type(self) -> str:

--- a/iambic/plugins/v0_1_0/azure_ad/user/models.py
+++ b/iambic/plugins/v0_1_0/azure_ad/user/models.py
@@ -7,7 +7,7 @@ from itertools import chain
 from typing import Optional
 
 from aiohttp import ClientResponseError
-from pydantic import Field
+from pydantic import Extra, Field
 
 from iambic.core.context import ctx
 from iambic.core.logger import log
@@ -75,6 +75,9 @@ class UserTemplateProperties(BaseModel, ExpiryModel):
     user_principal_name: Optional[str] = Field(
         None, description="User principal name of the user", exclude=True
     )
+
+    class Config:
+        extra = Extra.ignore
 
     @property
     def resource_type(self) -> str:


### PR DESCRIPTION
This PR instructs the AD UserTemplateProperties and GroupTemplatesProperties to ignore extra fields that are included, satisfying #423 .

I verified this by creating a custom extension attribute, verifying that the extension attribute replicated the crash, and verified that this resolution resolved the crash and allowed a successful import.