### PR TITLE
Ensure we're setting variables for AWS accounts added during Setup Wizard

### DIFF
--- a/iambic/config/wizard.py
+++ b/iambic/config/wizard.py
@@ -663,7 +663,6 @@ class ConfigurationWizard:
             command=Command.IMPORT,
             provider_type="aws",
         )
-        self.config.aws = asyncio.run(aws_load(self.config.aws))
         await import_aws_resources(
             exe_message,
             self.config.aws,
@@ -704,8 +703,6 @@ class ConfigurationWizard:
     async def sync_config_aws_org(self, run_config_discovery: bool = True):
         if not self.config.aws:
             self.config.aws = AWSConfig()
-
-        self.config.aws = await aws_load(self.config.aws)
 
         self.aws_account_map = {}
         current_command = ctx.command

--- a/iambic/config/wizard.py
+++ b/iambic/config/wizard.py
@@ -663,6 +663,7 @@ class ConfigurationWizard:
             command=Command.IMPORT,
             provider_type="aws",
         )
+        self.config.aws = asyncio.run(aws_load(self.config.aws))
         await import_aws_resources(
             exe_message,
             self.config.aws,
@@ -703,6 +704,8 @@ class ConfigurationWizard:
     async def sync_config_aws_org(self, run_config_discovery: bool = True):
         if not self.config.aws:
             self.config.aws = AWSConfig()
+
+        self.config.aws = await aws_load(self.config.aws)
 
         self.aws_account_map = {}
         current_command = ctx.command

--- a/iambic/plugins/v0_1_0/aws/handlers.py
+++ b/iambic/plugins/v0_1_0/aws/handlers.py
@@ -755,13 +755,13 @@ async def discover_new_aws_accounts(
     for org_accounts in orgs_accounts:
         for account in org_accounts:
             if config_account_idx_map.get(account.account_id) is None:
-                config.accounts.append(account)
-                config.accounts[-1].variables.extend(
+                account.variables.extend(
                     [
                         Variable(key="account_id", value=account.account_id),
                         Variable(key="account_name", value=account.account_name),
                     ]
                 )
+                config.accounts.append(account)
                 log.warning(
                     "New AWS account discovered. Adding account to config.",
                     account_id=account.account_id,

--- a/iambic/plugins/v0_1_0/aws/handlers.py
+++ b/iambic/plugins/v0_1_0/aws/handlers.py
@@ -756,6 +756,12 @@ async def discover_new_aws_accounts(
         for account in org_accounts:
             if config_account_idx_map.get(account.account_id) is None:
                 config.accounts.append(account)
+                config.accounts[-1].variables.extend(
+                    [
+                        Variable(key="account_id", value=account.account_id),
+                        Variable(key="account_name", value=account.account_name),
+                    ]
+                )
                 log.warning(
                     "New AWS account discovered. Adding account to config.",
                     account_id=account.account_id,

--- a/iambic/plugins/v0_1_0/aws/models.py
+++ b/iambic/plugins/v0_1_0/aws/models.py
@@ -284,7 +284,7 @@ class AWSAccount(ProviderChild, BaseAWSAccountAndOrgModel):
         Partition.AWS,
         description="The AWS partition the account is in. Options are aws, aws-us-gov, and aws-cn",
     )
-    variables: Optional[List[Variable]] = Field(
+    variables: list[Variable] = Field(
         [],
         description="A list of variables to be used when creating templates",
     )

--- a/iambic/plugins/v0_1_0/google_workspace/iambic_plugin.py
+++ b/iambic/plugins/v0_1_0/google_workspace/iambic_plugin.py
@@ -44,7 +44,7 @@ class GoogleProject(BaseModel):
     token_uri: str
     auth_provider_x509_cert_url: str
     client_x509_cert_url: str
-    variables: Optional[list[Variable]] = Field(
+    variables: list[Variable] = Field(
         [],
         description="A list of variables to be used when creating templates",
     )


### PR DESCRIPTION
This PR ensures that AWS Account ID and Account Name variable substitution works for the AWS resource import that occurs after the setup wizard. Thank you @datfinesoul  for reporting the issue.