### PR TITLE
Handle commented out list element

### DIFF
--- a/iambic/core/models.py
+++ b/iambic/core/models.py
@@ -77,7 +77,7 @@ class IambicPydanticBaseModel(PydanticBaseModel):
         set(), description="metadata for iambic", exclude=True, hidden_from_schema=True
     )
     metadata_commented_dict: dict = Field(
-        {}, description="yaml inline comments", hidden_from_schema=True
+        {}, description="yaml comments", hidden_from_schema=True
     )
 
     def __init__(self, *args, **kwargs):

--- a/iambic/core/utils.py
+++ b/iambic/core/utils.py
@@ -335,6 +335,8 @@ def sort_dict(original, prioritize=None):
 
 
 def transform_comments(yaml_dict):
+    from ruamel.yaml import CommentedMap
+
     comment_dict = {}
     yaml_dict["metadata_commented_dict"] = comment_dict
     for key, comment in yaml_dict.ca.items.items():
@@ -354,6 +356,8 @@ def transform_comments(yaml_dict):
     for key, value in yaml_dict.items():
         if isinstance(value, list) and len(value) > 0 and isinstance(value[0], dict):
             yaml_dict[key] = [transform_comments(n) for n in value]
+        elif isinstance(value, CommentedMap):
+            yaml_dict[key] = transform_comments(value)
     return yaml_dict
 
 

--- a/iambic/core/utils.py
+++ b/iambic/core/utils.py
@@ -408,6 +408,12 @@ def create_commented_map(_dict: dict):
             if maybe_comment[2]:
                 # post value comment
                 commented_map.yaml_add_eol_comment(key=key, comment=maybe_comment[2])
+                if maybe_comment[2][0] == "\n":
+                    # patch silly raumel behavior: when comment is `\n  # line 1`,
+                    # current implementation adds another `# ` before the \n
+                    commented_map.ca._items[key][2]._value = maybe_comment[
+                        2
+                    ]  # brittle to raumel implementation
             if maybe_comment[3]:
                 # pre value comment
                 pre_value_comment = maybe_comment[3]

--- a/iambic/core/utils.py
+++ b/iambic/core/utils.py
@@ -351,6 +351,9 @@ def transform_comments(yaml_dict):
             yaml_dict[key] = [transform_comments(n) for n in value]
         elif isinstance(value, dict):
             yaml_dict[key] = transform_comments(value)
+    for key, value in yaml_dict.items():
+        if isinstance(value, list) and len(value) > 0 and isinstance(value[0], dict):
+            yaml_dict[key] = [transform_comments(n) for n in value]
     return yaml_dict
 
 

--- a/iambic/plugins/v0_1_0/aws/iam/group/utils.py
+++ b/iambic/plugins/v0_1_0/aws/iam/group/utils.py
@@ -249,6 +249,7 @@ async def apply_group_inline_policies(
                 policy_document,
                 ignore_order=True,
                 report_repetition=True,
+                exclude_regex_paths=["metadata_commented_dict"],
             )
 
             # DeepDiff will return type changes as actual type functions and not strings,

--- a/iambic/plugins/v0_1_0/aws/iam/policy/utils.py
+++ b/iambic/plugins/v0_1_0/aws/iam/policy/utils.py
@@ -168,6 +168,7 @@ async def apply_update_managed_policy(
         template_policy_document,
         ignore_order=True,
         report_repetition=True,
+        exclude_regex_paths=["metadata_commented_dict"],
     )
     # DeepDiff will return type changes as actual type functions and not strings,
     # and this will cause json serialization to fail later on when we process

--- a/iambic/plugins/v0_1_0/aws/iam/role/utils.py
+++ b/iambic/plugins/v0_1_0/aws/iam/role/utils.py
@@ -275,6 +275,7 @@ async def update_assume_role_policy(
             template_policy_document,
             report_repetition=True,
             ignore_order=True,
+            exclude_regex_paths=["metadata_commented_dict"],
         )
 
         # DeepDiff will return type changes as actual type functions and not strings,
@@ -565,6 +566,7 @@ async def apply_role_inline_policies(
                 policy_document,
                 ignore_order=True,
                 report_repetition=True,
+                exclude_regex_paths=["metadata_commented_dict"],
             )
 
             # DeepDiff will return type changes as actual type functions and not strings,

--- a/iambic/plugins/v0_1_0/aws/iam/user/utils.py
+++ b/iambic/plugins/v0_1_0/aws/iam/user/utils.py
@@ -463,6 +463,7 @@ async def apply_user_inline_policies(
                 policy_document,
                 ignore_order=True,
                 report_repetition=True,
+                exclude_regex_paths=["metadata_commented_dict"],
             )
 
             # DeepDiff will return type changes as actual type functions and not strings,

--- a/iambic/plugins/v0_1_0/aws/identity_center/permission_set/utils.py
+++ b/iambic/plugins/v0_1_0/aws/identity_center/permission_set/utils.py
@@ -608,6 +608,7 @@ async def apply_permission_set_inline_policy(
             template_inline_policy,
             report_repetition=True,
             ignore_order=True,
+            exclude_regex_paths=["metadata_commented_dict"],
         )
 
     if template_inline_policy and (not existing_inline_policy or bool(policy_drift)):
@@ -690,6 +691,7 @@ async def apply_permission_set_permission_boundary(
             template_permission_boundary,
             report_repetition=True,
             ignore_order=True,
+            exclude_regex_paths=["metadata_commented_dict"],
         )
 
     if template_permission_boundary and (

--- a/iambic/plugins/v0_1_0/aws/organizations/scp/utils.py
+++ b/iambic/plugins/v0_1_0/aws/organizations/scp/utils.py
@@ -307,6 +307,7 @@ async def apply_update_policy(
         new_value,
         report_repetition=True,
         ignore_order=True,
+        exclude_regex_paths=["metadata_commented_dict"],
     )
 
     if diff == {}:

--- a/test/core/test_utils.py
+++ b/test/core/test_utils.py
@@ -101,6 +101,20 @@ forrest:
     assert "# comment line 1" in as_yaml
 
 
+def test_commented_out_list_element_yaml():
+    MULTILINE_YAML = """
+forrest:
+  - name: simple_tree # COMMENT
+  # - name: commented_out_tree
+    """
+    yaml_dict = yaml.load(MULTILINE_YAML)
+    yaml_dict = transform_comments(yaml_dict)
+    commented_model = ForrestModel(**yaml_dict)
+    commented_map = create_commented_map(commented_model.dict())
+    as_yaml = yaml.dump(commented_map)
+    assert "commented_out_tree" in as_yaml
+
+
 class TestGlobalRetryController(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self):
         self.wait_time = 1

--- a/test/core/test_utils.py
+++ b/test/core/test_utils.py
@@ -160,6 +160,21 @@ def test_after_key_pre_key_commented_yaml():
     assert MULTILINE_YAML == as_yaml
 
 
+# be careful with this test, as the check is format sensitive
+def test_after_value_newline_commented_yaml_2():
+    MULTILINE_YAML = """tree:
+  # pre-key-comment
+  name: simple_tree
+  # LINE 1
+"""
+    yaml_dict = yaml.load(MULTILINE_YAML)
+    yaml_dict = transform_comments(yaml_dict)
+    commented_model = TreeContainer(**yaml_dict)
+    commented_map = create_commented_map(commented_model.dict())
+    as_yaml = yaml.dump(commented_map)
+    assert MULTILINE_YAML == as_yaml
+
+
 def test_inner_comment():
     MULTILINE_YAML = """
   tree:

--- a/test/core/test_utils.py
+++ b/test/core/test_utils.py
@@ -67,6 +67,10 @@ class TreeModel(BaseModel):
     name: str
 
 
+class TreeContainer(BaseModel):
+    tree: TreeModel
+
+
 class ForrestModel(BaseModel):
     forrest: List[TreeModel]
 
@@ -80,6 +84,19 @@ def test_commented_yaml():
     yaml_dict = yaml.load(TEST_COMMENTED_YAML)
     yaml_dict = transform_comments(yaml_dict)
     commented_model = ForrestModel(**yaml_dict)
+    commented_map = create_commented_map(commented_model.dict())
+    as_yaml = yaml.dump(commented_map)
+    assert "COMMENT" in as_yaml
+
+
+def test_inner_comment():
+    MULTILINE_YAML = """
+  tree:
+    name: simple_tree # COMMENT
+    """
+    yaml_dict = yaml.load(MULTILINE_YAML)
+    yaml_dict = transform_comments(yaml_dict)
+    commented_model = TreeContainer(**yaml_dict)
     commented_map = create_commented_map(commented_model.dict())
     as_yaml = yaml.dump(commented_map)
     assert "COMMENT" in as_yaml

--- a/test/core/test_utils.py
+++ b/test/core/test_utils.py
@@ -80,6 +80,32 @@ TEST_COMMENTED_YAML = """forrest:  # forrest-comment
 """
 
 
+# be careful with this test, as the check is format sensitive
+def test_file_header_commented_yaml():
+    MULTILINE_YAML = """# HEADER LINE 1
+# HEADER LINE 2
+name: simple_tree
+"""
+    yaml_dict = yaml.load(MULTILINE_YAML)
+    yaml_dict = transform_comments(yaml_dict)
+    commented_model = TreeModel(**yaml_dict)
+    commented_map = create_commented_map(commented_model.dict())
+    as_yaml = yaml.dump(commented_map)
+    assert MULTILINE_YAML == as_yaml
+
+
+# be careful with this test, as the check is format sensitive
+def test_no_file_header_commented_yaml():
+    MULTILINE_YAML = """name: simple_tree
+"""
+    yaml_dict = yaml.load(MULTILINE_YAML)
+    yaml_dict = transform_comments(yaml_dict)
+    commented_model = TreeModel(**yaml_dict)
+    commented_map = create_commented_map(commented_model.dict())
+    as_yaml = yaml.dump(commented_map)
+    assert MULTILINE_YAML == as_yaml
+
+
 def test_commented_yaml():
     yaml_dict = yaml.load(TEST_COMMENTED_YAML)
     yaml_dict = transform_comments(yaml_dict)
@@ -87,6 +113,51 @@ def test_commented_yaml():
     commented_map = create_commented_map(commented_model.dict())
     as_yaml = yaml.dump(commented_map)
     assert "COMMENT" in as_yaml
+
+
+# be careful with this test, as the check is format sensitive
+def test_file_footer_commented_yaml():
+    MULTILINE_YAML = """name: simple_tree  # LINE 1
+# LINE 2
+"""
+    yaml_dict = yaml.load(MULTILINE_YAML)
+    yaml_dict = transform_comments(yaml_dict)
+    commented_model = TreeModel(**yaml_dict)
+    commented_map = create_commented_map(commented_model.dict())
+    as_yaml = yaml.dump(commented_map)
+    assert MULTILINE_YAML == as_yaml
+
+
+# be careful with this test, as the check is format sensitive
+# this test case is commented out because raumel actually cannot write
+# out such pre-value-comments.
+# def test_after_key_pre_value_commented_yaml():
+#     MULTILINE_YAML = """name:
+#   # pre-value-comment
+#   simple_tree  # LINE 1
+# # LINE 2
+# """
+#     yaml_dict = yaml.load(MULTILINE_YAML)
+#     yaml_dict = transform_comments(yaml_dict)
+#     commented_model = TreeModel(**yaml_dict)
+#     commented_map = create_commented_map(commented_model.dict())
+#     as_yaml = yaml.dump(commented_map)
+#     assert MULTILINE_YAML == as_yaml
+
+
+# be careful with this test, as the check is format sensitive
+def test_after_key_pre_key_commented_yaml():
+    MULTILINE_YAML = """tree:
+  # pre-key-comment
+  name: simple_tree  # LINE 1
+# LINE 2
+"""
+    yaml_dict = yaml.load(MULTILINE_YAML)
+    yaml_dict = transform_comments(yaml_dict)
+    commented_model = TreeContainer(**yaml_dict)
+    commented_map = create_commented_map(commented_model.dict())
+    as_yaml = yaml.dump(commented_map)
+    assert MULTILINE_YAML == as_yaml
 
 
 def test_inner_comment():


### PR DESCRIPTION
## What changed?
* Handle commented out list element

## Rationale
*  a commented out is not stored in commented_yaml_dict.ca.items. instead, it's store inside the previous element inside a commented_sequence. (value)
* note: this change does not attempt to address multi-line comment. multi-line comment implement today already squash it from multiline to single line. when we figure out how to preserve multiline comment, it will not impact this change.

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [x] Unit Tests
- [ ] Functional Tests
- [ ] Manually Verified
