### PR TITLE
Fixed #419 Deleted file should not be removed again

### DIFF
--- a/docs/cep/001-AWS-Managed-Resources-Attributes.md
+++ b/docs/cep/001-AWS-Managed-Resources-Attributes.md
@@ -6,28 +6,28 @@ Introduce attribute to differentiate IAM resources that should not be modified b
 ## Rationale
 IdentityCenter Account Association generates IAM roles that are managed by
 IdentityCenter. Although such IAM roles are included by IAMbic import. If they
-are modified by users, it will diverage from the intend. 
+are modified by users, it will diverage from the intend.
 
 IAM service-link roles are managed by AWS, and cannot be edited. Edit operations
-will generate API error. 
+will generate API error.
 
 By introducing an attribute `cloud_provider_managed_resource`, type `boolean`, the
 IAMbic business logic can introduce special handling for them.
 
 For example, these resources should be marked as `iambic_managed: IMPORT_ONLY`.
 In addition, we can introduce a particular default directory location to store such
-managed_resources. 
+managed_resources.
 
 ## Customer Experience
 For Identity Center permissions set that `n` associated accounts, AWS generates `n`
 corresponding IAM roles. One for each associated account. Currently, they appear
 alongside other regular roles. By default, we can use the `path` information to
-place these roles. 
+place these roles.
 
 A role created due to Identity Center as a path like `/aws-reserved/sso.amazonaws.com/`
-We can place the role in `<relative_directory>/aws-reserved/sso.amazonaws.com`. 
+We can place the role in `<relative_directory>/aws-reserved/sso.amazonaws.com`.
 
-Using `path` information serves as a natural grouping user experience. 
+Using `path` information serves as a natural grouping user experience.
 
 There is concern about the extra number of file bloats. The pillar of IAMbic is to
 maintain source of truth. Those IAM roles are actual artifacts included in the list
@@ -39,21 +39,21 @@ Each IAM resources is represented by a single file is a compromise of
 maintain GitOps workflow in which developer goes through git flow to make changes
 of IAM postures. Git does scale to the size of Microsoft Windows development. In
 performance critical flow, we can later extend with a real DBMS for fast query.
-File can be see as a duality of rows represented inside a DBMS. 
+File can be see as a duality of rows represented inside a DBMS.
 
 ## Alternative
 [Issue #388](https://github.com/noqdev/iambic/issues/388) suggests not even import
 them in the first place. (The import preference will be configurable). I argue that
 breaks the abstraction that IAMbic maintains a catalog that is sufficient to run
 analysis against security posture. Not having such managed resource definition will
-limit posture analysis. The user experience desired is not having them next to the 
-resources that users need to edit. 
+limit posture analysis. The user experience desired is not having them next to the
+resources that users need to edit.
 
 ## Implementation
-* We need to introduce some classification logic likely based on `path`. 
-* Suggest alternative directory location for manageed resources. 
+* We need to introduce some classification logic likely based on `path`.
+* Suggest alternative directory location for manageed resources.
 * (future) flag it's not possible to make changes to managed resources in plan.
 
 ## Compatibility concern
-1. The new attribute should be optional to make existing templates not crash the new 
-version of IAMbic. 
+1. The new attribute should be optional to make existing templates not crash the new
+version of IAMbic.

--- a/iambic/core/models.py
+++ b/iambic/core/models.py
@@ -493,6 +493,11 @@ class BaseTemplate(
         IambicManaged.UNDEFINED,
         description="Controls the directionality of Iambic changes",
     )
+    is_memory_only: Optional[bool] = Field(
+        False,
+        description="if true, it's in-memory only used for clean up operation",
+        hidden_from_schema=True,
+    )
 
     def dict(
         self,
@@ -551,6 +556,9 @@ class BaseTemplate(
 
     def delete(self):
         log.info("Deleting template file", file_path=self.file_path)
+        if self.is_memory_only:
+            log.info("template file is in-memory-only", file_path=self.file_path)
+            return
         try:
             repo = Repo(self.file_path, search_parent_directories=True)
             # why force=True? Expire could have modified the local contents

--- a/test/core/test_git.py
+++ b/test/core/test_git.py
@@ -399,7 +399,13 @@ def test_create_templates_for_deleted_files(mocker):
 
     # Test the create_templates_for_deleted_files function
     with mocker.patch("iambic.core.git.TEMPLATES", mock_templates):
-        result = create_templates_for_deleted_files(deleted_files)
+        result: list[BaseTemplate] = create_templates_for_deleted_files(deleted_files)
 
     # Check if the returned templates are correct
     assert len(result) == 1
+
+    # check returned template is marked as in_memory_only
+    assert result[0].is_memory_only
+
+    # verify delete() won't crash because in-memory template delete is no-op
+    result[0].delete()


### PR DESCRIPTION
We load the deleted file to check for needed resource cleanup. In particular, this case in which deleted file was due to a git mv operation. Because rename would mean the original file path is no longer available, we cannot attempt to git rm or delete the file physically.

## What changed?
* Describe the change in high level terms.

## Rationale
* Explain the rationale behind this change and the approach.

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [x] Unit Tests
- [ ] Functional Tests
- [x] Manually Verified

https://github.com/noqdev/iambic-templates-itest/pull/300