### PR TITLE
Fixed #405 Skip prompt if SDK can verify settings

### DIFF
--- a/functional_tests/test_wizard.py
+++ b/functional_tests/test_wizard.py
@@ -120,10 +120,6 @@ def test_setup_org_account(iam_spoke_role, temp_templates_directory) -> None:
         tui.sendline("")  # use default
         tui.expect("What would you like to configure in AWS")
         tui.sendline(KEY_DOWN)  # down once to AWS Organizations
-        tui.expect("Is this the case")
-        tui.sendline("")  # use default
-        tui.expect("Proceed")
-        tui.sendline("")  # use default
         tui.expect("AWS Organization ID")
         tui.sendline("")  # use default
         tui.expect("Grant IambicSpokeRole write access")
@@ -177,10 +173,6 @@ def test_setup_org_account_with_stack_creation(
         tui.sendline("")  # use default
         tui.expect("What would you like to configure in AWS")
         tui.sendline(KEY_DOWN)  # down once to AWS Organizations
-        tui.expect("Is this the case")
-        tui.sendline("")  # use default
-        tui.expect("Proceed")
-        tui.sendline("")  # use default
         tui.expect("AWS Organization ID")
         tui.sendline("")  # use default
         tui.expect("Grant IambicSpokeRole write access")

--- a/functional_tests/test_wizard.py
+++ b/functional_tests/test_wizard.py
@@ -68,7 +68,7 @@ def test_setup_single_account(iam_spoke_role, temp_templates_directory) -> None:
         tui.expect("What would you like to configure in AWS")
         tui.sendline(KEY_DOWN * 2)  # down twice to AWS Accounts
         tui.sendline("")  # use default account number
-        tui.expect("Proceed")
+        tui.expect("Provide the ARN of the identity")
         tui.sendline("")  # use default
         tui.expect("What is the name of the AWS Account")
         tui.sendline("hub_account")  # use default


### PR DESCRIPTION
## What changed?
* Skip prompt on org management account and cf_stacksets if we can verify using boto3 sdk

## Rationale
* Reduce setup frictions

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [ ] Unit Tests
- [x] Functional Tests
- [x] Manually Verified

export org admin credentials, run `iambic setup` without an existing iambic_config.yaml