### PR TITLE
Included empty tags dict when decribing role without tags

### DIFF
--- a/iambic/plugins/v0_1_0/aws/iam/role/utils.py
+++ b/iambic/plugins/v0_1_0/aws/iam/role/utils.py
@@ -114,6 +114,10 @@ async def get_role(role_name: str, iam_client, include_policies: bool = True) ->
             current_role["InlinePolicies"] = await get_role_inline_policies(
                 role_name, iam_client, as_dict=False
             )
+
+        if not current_role.get("Tags"):
+            current_role["Tags"] = []
+
     except iam_client.exceptions.NoSuchEntityException:
         current_role = {}
 

--- a/test/plugins/v0_1_0/aws/iam/role/test_utils.py
+++ b/test/plugins/v0_1_0/aws/iam/role/test_utils.py
@@ -174,6 +174,14 @@ async def test_get_role_managed_policies(mock_iam_client):
 async def test_get_role(mock_iam_client):
     role = await get_role(EXAMPLE_ROLE_NAME, mock_iam_client)
     assert role["RoleName"] == EXAMPLE_ROLE_NAME
+    assert role["Tags"] == [{"Key": EXAMPLE_TAG_KEY, "Value": EXAMPLE_TAG_VALUE}]
+
+    # Remove the tags from the role and check that this is able to return the Tag dict as empty
+    mock_iam_client.untag_role(RoleName=EXAMPLE_ROLE_NAME, TagKeys=[EXAMPLE_TAG_KEY])
+
+    # Describe again:
+    role = await get_role(EXAMPLE_ROLE_NAME, mock_iam_client)
+    assert role["Tags"] == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- Ensures consistency between current role value and new role value

## What changed?
* Ensures that when `get_role` is called, it will always include a Tags dictionary

## Rationale
* Maintain consistency between the new and current role configuration

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [X] Unit Tests
- [ ] Functional Tests
- [X] Manually Verified
