### PR TITLE
EN-2150 Implement "iambic approve"

### DIFF
--- a/iambic/plugins/v0_1_0/github/github.py
+++ b/iambic/plugins/v0_1_0/github/github.py
@@ -564,7 +564,7 @@ def handle_iambic_approve(
             and comment_user_login == allowed_bot_approver
         ):
             pull_request.create_review(
-                event="APPROVE", body="react to `approve` from `comment_user_login`"
+                event="APPROVE", body=f"react to `approve` from `{comment_user_login}`"
             )
             return HandleIssueCommentReturnCode.APPROVED
         else:

--- a/iambic/plugins/v0_1_0/github/github_app.py
+++ b/iambic/plugins/v0_1_0/github/github_app.py
@@ -226,10 +226,13 @@ def handle_issue_comment(
     log_params = {"COMMENT_DISPATCH_MAP_KEYS": COMMENT_DISPATCH_MAP.keys()}
     log.info("COMMENT_DISPATCH_MAP keys", **log_params)
 
-    command_lookup = " ".join(comment_body.split(" ")[0:2])
+    command_lookup = comment_body.split("\n")[0].strip()
 
     if command_lookup not in COMMENT_DISPATCH_MAP:
-        log_params = {"comment_body": comment_body}
+        log_params = {
+            "command_lookup": command_lookup,
+            "comment_body": comment_body,
+        }
         log.error("handle_issue_comment: no op", **log_params)
         return HandleIssueCommentReturnCode.NO_MATCHING_BODY
 

--- a/iambic/plugins/v0_1_0/github/github_app.py
+++ b/iambic/plugins/v0_1_0/github/github_app.py
@@ -225,13 +225,16 @@ def handle_issue_comment(
     comment_user_login = webhook_payload["comment"]["user"]["login"]
     log_params = {"COMMENT_DISPATCH_MAP_KEYS": COMMENT_DISPATCH_MAP.keys()}
     log.info("COMMENT_DISPATCH_MAP keys", **log_params)
-    if comment_body not in COMMENT_DISPATCH_MAP:
+
+    command_lookup = " ".join(comment_body.split(" ")[0:2])
+
+    if command_lookup not in COMMENT_DISPATCH_MAP:
         log_params = {"comment_body": comment_body}
         log.error("handle_issue_comment: no op", **log_params)
         return HandleIssueCommentReturnCode.NO_MATCHING_BODY
 
     if comment_user_login.endswith("[bot]"):
-        if comment_body != "iambic approve":
+        if command_lookup != "iambic approve":
             # return early unless it's the approve attempt
             # the approve handler require to walk the full config
             # to determine.
@@ -253,7 +256,7 @@ def handle_issue_comment(
     log_params = {"pull_request_branch_name": pull_request_branch_name}
     log.info("PR remote branch name", **log_params)
 
-    comment_func: Callable = COMMENT_DISPATCH_MAP[comment_body]
+    comment_func: Callable = COMMENT_DISPATCH_MAP[command_lookup]
     return comment_func(
         None,
         github_client,
@@ -265,6 +268,7 @@ def handle_issue_comment(
         repo_url,
         proposed_changes_path=getattr(iambic_app, "lambda").app.PLAN_OUTPUT_PATH,
         comment_user_login=comment_user_login,
+        comment=comment_body,
     )
 
 

--- a/iambic/plugins/v0_1_0/github/iambic_plugin.py
+++ b/iambic/plugins/v0_1_0/github/iambic_plugin.py
@@ -6,6 +6,8 @@ from iambic.core.iambic_plugin import ProviderPlugin
 from iambic.plugins.v0_1_0 import PLUGIN_VERSION
 from iambic.plugins.v0_1_0.github.handlers import import_github_resources, load
 
+DEFAULT_ALLOWED_BOT_APPROVER = None
+
 
 class GithubConfig(BaseModel):
     commit_message_user_name: str = Field(
@@ -29,6 +31,10 @@ class GithubConfig(BaseModel):
     commit_message_for_git_apply: str = Field(
         default="Replace relative time with absolute time",
         description="Commit message to use during changes through git-apply",
+    )
+    allowed_bot_approver: str = Field(
+        default=DEFAULT_ALLOWED_BOT_APPROVER,
+        description="Default login for allowed bot approver",
     )
 
 

--- a/iambic/plugins/v0_1_0/github/iambic_plugin.py
+++ b/iambic/plugins/v0_1_0/github/iambic_plugin.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Optional
+
 from pydantic import BaseModel, Field
 
 from iambic.core.iambic_plugin import ProviderPlugin
@@ -7,6 +9,17 @@ from iambic.plugins.v0_1_0 import PLUGIN_VERSION
 from iambic.plugins.v0_1_0.github.handlers import import_github_resources, load
 
 DEFAULT_ALLOWED_BOT_APPROVER = None
+
+
+class GithubBotApprover(BaseModel):
+    login: str = Field(
+        ...,
+        description="login for allowed bot approver",
+    )
+    ed25519_pub_key: str = Field(
+        ...,
+        description="Ed25519 Pub Key for allowed bot approver",
+    )
 
 
 class GithubConfig(BaseModel):
@@ -32,9 +45,9 @@ class GithubConfig(BaseModel):
         default="Replace relative time with absolute time",
         description="Commit message to use during changes through git-apply",
     )
-    allowed_bot_approver: str = Field(
-        default=DEFAULT_ALLOWED_BOT_APPROVER,
-        description="Default login for allowed bot approver",
+    allowed_bot_approvers: Optional[list[GithubBotApprover]] = Field(
+        default=[],
+        description="list of allowed bot approver",
     )
 
 

--- a/iambic/plugins/v0_1_0/github/iambic_plugin.py
+++ b/iambic/plugins/v0_1_0/github/iambic_plugin.py
@@ -16,9 +16,9 @@ class GithubBotApprover(BaseModel):
         ...,
         description="login for allowed bot approver",
     )
-    ed25519_pub_key: str = Field(
+    es256_pub_key: str = Field(
         ...,
-        description="Ed25519 Pub Key for allowed bot approver",
+        description="ES256 Pub Key for allowed bot approver",
     )
 
 

--- a/test/plugins/v0_1_0/github/test_github.py
+++ b/test/plugins/v0_1_0/github/test_github.py
@@ -458,9 +458,9 @@ def test_run_handler():
             "event": {
                 "comment": {
                     "body": "iambic git-apply",
-                },
-                "user": {
-                    "login": "fake-commenter",
+                    "user": {
+                        "login": "fake-commenter",
+                    },
                 },
                 "issue": {"number": 4},
                 "repository": {

--- a/test/plugins/v0_1_0/github/test_github.py
+++ b/test/plugins/v0_1_0/github/test_github.py
@@ -459,6 +459,9 @@ def test_run_handler():
                 "comment": {
                     "body": "iambic git-apply",
                 },
+                "user": {
+                    "login": "fake-commenter",
+                },
                 "issue": {"number": 4},
                 "repository": {
                     "clone_url": "https://github.com/exampleorg/iambic-templates.git"


### PR DESCRIPTION
## What changed?
* Implement `iambic approve` comment reaction for GitHub

## Rationale
* Allow specific bot approver to approve a pull request.

Security consideration:
1. How do we lock down if iambic-integrations[bot] approve ability. By default, without using Noq SaaS, the allowed_bot_approver is None, we will not allow `iambic approve` command. 
2. We go by commenter's GitHub login to compare with config's GitHub.allowed_bot_approver to see if we should allow to mark the review as approve. If not, a complaint will be posted back to PR comment.
3. `iambic approve` has to load the main branch to check the value of config's GitHub.allowed_bot_approver to avoid developer abusing the PR to change that value in the template repo. Alternate is to set it in the lambda deployment environment variable. I think we prefer to configure template repo. That's the reason, we always checkout the main branch when we have to handle the `iambic approve` command.
4. Can someone pretend to be the configured login value? this value is set by GitHub webhook event and also the event is signed, I don't think its configurable. login per GitHub's spec should be unique. 

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [x] Unit Tests
- [ ] Functional Tests
- [x] Manually Verified

See https://github.com/noqdev/iambic-templates-itest/pull/305 for the `iambic approve` response in PR comments.