### PR TITLE
EN-2148 Skip a key from new_model if old_model already mark it as metadata

### DIFF
--- a/iambic/core/template_generation.py
+++ b/iambic/core/template_generation.py
@@ -975,7 +975,11 @@ def merge_model(  # noqa: C901
         new_value = getattr(new_model, key)
         value_as_list = isinstance(new_value, list)
         existing_value = getattr(existing_model, key)
-        if isinstance(existing_value, list):
+        if key in iambic_fields:
+            # not something we want to merge because
+            # this is metadata only, not in the cloud-side
+            continue
+        elif isinstance(existing_value, list):
             if len(existing_value) > 0:
                 inner_element = existing_value[0]
 


### PR DESCRIPTION
## What changed?
* During merge model, if a field is already marked as metadata, skip.

## Rationale
* During deep model merging, we did not check if a field is marked as metadata early enough. For IAM role model, access rules is marked as metadata.

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [x] Unit Tests
- [ ] Functional Tests
- [ ] Manually Verified
