### PR TITLE
Conditionally configure structlog

### DIFF
--- a/iambic/core/logger.py
+++ b/iambic/core/logger.py
@@ -28,22 +28,23 @@ def pretty_log(logger, method_name, event_dict):
 
 
 def configure_logger(logger_name, log_level):
-    structlog.configure(
-        processors=[
-            pretty_log,
-            structlog.processors.add_log_level,
-            structlog.processors.StackInfoRenderer(),
-            structlog.dev.set_exc_info,
-            structlog.processors.TimeStamper("%Y/%m/%d %H:%M:%S", utc=False),
-            structlog.dev.ConsoleRenderer(),
-        ],
-        wrapper_class=structlog.make_filtering_bound_logger(
-            logging.getLevelName(log_level)
-        ),
-        context_class=dict,
-        logger_factory=structlog.PrintLoggerFactory(),
-        cache_logger_on_first_use=False,
-    )
+    if not structlog.is_configured():
+        structlog.configure(
+            processors=[
+                pretty_log,
+                structlog.processors.add_log_level,
+                structlog.processors.StackInfoRenderer(),
+                structlog.dev.set_exc_info,
+                structlog.processors.TimeStamper("%Y/%m/%d %H:%M:%S", utc=False),
+                structlog.dev.ConsoleRenderer(),
+            ],
+            wrapper_class=structlog.make_filtering_bound_logger(
+                logging.getLevelName(log_level)
+            ),
+            context_class=dict,
+            logger_factory=structlog.PrintLoggerFactory(),
+            cache_logger_on_first_use=False,
+        )
     log = structlog.get_logger(logger_name)
 
     if log_level == "DEBUG":


### PR DESCRIPTION
## What changed?
This PR adds a check to determine if structlog has already been configured. If so, IAMbic will not reconfigure it. This is useful when using IAMbic as a library.

## Rationale
* When using IAMbic as a library, we do not want to overrule the calling program's logging configuration. 

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [ ] Unit Tests
- [ ] Functional Tests
- [X] Manually Verified
