### PR TITLE
Fix #463 Id policy support

### DIFF
--- a/iambic/plugins/v0_1_0/aws/iam/policy/models.py
+++ b/iambic/plugins/v0_1_0/aws/iam/policy/models.py
@@ -201,6 +201,10 @@ class PolicyDocument(AccessModel, ExpiryModel):
         None,
         description="List of policy statements",
     )
+    id: Optional[str] = Field(
+        None,
+        description="The Id element specifies an optional identifier for the policy. The ID is used differently in different services.",
+    )
 
     @property
     def resource_type(self):

--- a/iambic/plugins/v0_1_0/aws/iam/role/template_generation.py
+++ b/iambic/plugins/v0_1_0/aws/iam/role/template_generation.py
@@ -438,14 +438,14 @@ async def create_templated_role(  # noqa: C901
         )
     except Exception as e:
         log_params = {
-            "role_name": f"{role_name}",
-            "role_template_params": f"{role_template_params}",
+            "role_name": role_name,
+            "role_template_params": role_template_params,
         }
         log.error(
             "Not able to create_or_update_template",
             **log_params,
         )
-        raise e from None
+        raise e
 
 
 async def collect_aws_roles(

--- a/iambic/plugins/v0_1_0/aws/iam/role/template_generation.py
+++ b/iambic/plugins/v0_1_0/aws/iam/role/template_generation.py
@@ -426,15 +426,26 @@ async def create_templated_role(  # noqa: C901
         role_template_params.get("included_accounts"),
         role_path=path,
     )
-    return create_or_update_template(
-        file_path,
-        existing_template_map,
-        role_name,
-        AwsIamRoleTemplate,
-        role_template_params,
-        RoleProperties(**role_template_properties),
-        list(aws_account_map.values()),
-    )
+    try:
+        return create_or_update_template(
+            file_path,
+            existing_template_map,
+            role_name,
+            AwsIamRoleTemplate,
+            role_template_params,
+            RoleProperties(**role_template_properties),
+            list(aws_account_map.values()),
+        )
+    except Exception as e:
+        log_params = {
+            "role_name": f"{role_name}",
+            "role_template_params": f"{role_template_params}",
+        }
+        log.error(
+            "Not able to create_or_update_template",
+            **log_params,
+        )
+        raise e from None
 
 
 async def collect_aws_roles(

--- a/test/plugins/v0_1_0/aws/iam/role/test_models.py
+++ b/test/plugins/v0_1_0/aws/iam/role/test_models.py
@@ -796,3 +796,42 @@ def test_mixed_type_description_merges():
     new_properties = RoleProperties(role_name="foo", description=new_description)
     merged_model = merge_model(new_properties, existing_properties, [])
     assert merged_model.description[0].description == "foo"
+
+
+def test_role_policy_id():
+    role_properties_kwargs = {
+        "role_name": "bar",
+        "inline_policies": [
+            {
+                "policy_name": "hello",
+                "included_accounts": ["*"],
+                "id": "uuid-4",
+                "statement": {
+                    "effect": "Deny",
+                    "action": ["s3:GetObject"],
+                    "resource": "*",
+                },
+            },
+        ],
+    }
+    role_properties = RoleProperties(**role_properties_kwargs)
+    assert role_properties
+
+
+def test_role_no_policy_id():
+    role_properties_kwargs = {
+        "role_name": "bar",
+        "inline_policies": [
+            {
+                "policy_name": "hello",
+                "included_accounts": ["*"],
+                "statement": {
+                    "effect": "Deny",
+                    "action": ["s3:GetObject"],
+                    "resource": "*",
+                },
+            },
+        ],
+    }
+    role_properties = RoleProperties(**role_properties_kwargs)
+    assert role_properties

--- a/test/plugins/v0_1_0/aws/iam/role/test_utils.py
+++ b/test/plugins/v0_1_0/aws/iam/role/test_utils.py
@@ -46,6 +46,7 @@ EXAMPLE_INLINE_POLICY_NAME = "example_inline_policy_name"
 EXAMPLE_INLINE_POLICY_DOCUMENT = """
 {
    "Version":"2012-10-17",
+   "Id": "cd3ad3d9-2776-4ef1-a904-4c229d1642ee",
    "Statement":[
       {
          "Effect":"Allow",


### PR DESCRIPTION
## What changed?
*Support optional Id in policy document

## Rationale
* It's a supported grammar in AWS: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_grammar.html

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [x] Unit Tests
- [ ] Functional Tests
- [ ] Manually Verified
