### PR TITLE
Import Rule Support

### DIFF
--- a/docs/web/docs/3-reference/12-aws_import_rules.mdx
+++ b/docs/web/docs/3-reference/12-aws_import_rules.mdx
@@ -1,0 +1,130 @@
+---
+title: AWS Import Rules
+---
+
+## Introduction and Motivation
+
+IAMbic's import rules are a convenient way to control how IAMbic handles specific resources in your AWS environment.
+There could be situations where you would want to tell IAMbic to:
+
+- Completely IGNORE resources that are created and managed by certain systems or services such as AWS Identity Center (SSO).
+
+- Set role templates to import_only if they are managed by another infrastructure-as-code (IaC) tool, such as Terraform. This allows you to import and track
+these resources within IAMbic without allowing users to change them through an IAMbic GitOps flow.
+
+## Example configuration
+
+You can configure IAMbic's import rules in the `aws.import_rules` configuration in the IAMbic's YAML configuration file.
+Here is an example of how you might set up some import rules:
+
+```yaml
+aws:
+  import_rules:
+    - match_template_types:
+        - "NOQ::AWS::IAM::Role"
+      match_tags:
+        - key: "terraform"
+          value: "managed"
+      action: "set_import_only"
+    - match_template_types:
+        - "NOQ::AWS::IdentityCenter::PermissionSet"
+      action: "ignore"
+```
+
+In this example, the first rule tells IAMbic to set IAM Role templates (that are tagged with "terraform: managed") to import_only.
+The second rule tells IAMbic to ignore all Permission Sets.
+
+## Rule Processing Logic
+
+Import rules are processed using an `AND` logic within a rule and `OR` logic across different rules.
+
+This means that:
+
+- Within a single rule, all conditions (match_template_types, match_tags, etc.) must be met for the rule to apply.
+- Across different rules, if a resource matches any rule, the corresponding action will be taken, with ignore taking priority.
+
+For example, if a resource matches the conditions of two rules, one with an action of ignore and the other with set_import_only,
+the resource will be ignored by IAMbic.
+
+## Supported Resource Types
+
+The supported AWS resource types for the import rules in IAMbic are:
+
+- IAM Roles
+- IAM Users
+- IAM Groups
+- IAM Managed Policies
+- AWS Identity Center (SSO) Permission Sets
+
+## Examples of Rules
+
+Here are some specific examples of import rules you might set:
+
+1. Ignoring Specific Template Types:
+
+```yaml
+aws:
+  import_rules:
+    - match_template_types:
+        - "NOQ::AWS::IAM::Role"
+      action: "ignore"
+```
+
+2. Ignoring Specific Template Types if a Tag Matches:
+
+```yaml
+aws:
+  import_rules:
+    - match_template_types: ["NOQ::AWS::IAM::Role"]
+      match_tags:
+        - key: "Environment"
+          value: "Production"
+      action: "ignore"
+```
+
+3. Ignoring All Supported Templates with a Specific Tag Key, Regardless of Tag Value
+
+```yaml
+aws:
+  import_rules:
+    - match_tags:
+        - key: "terraform"
+      action: "ignore"
+```
+
+4. Ignoring All Supported Templates with a Specific Tag Key and Value:
+
+```yaml
+aws:
+  import_rules:
+    - match_tags:
+        - key: "ManagedBy"
+          value: "CDK"
+      action: "ignore"
+```
+
+5. Ignoring All Supported Templates with a Specific Identifier Starting with a String:
+
+```yaml
+aws:
+  import_rules:
+    - match_names:
+        - "AWSReservedSSO_*"
+      action: "ignore"
+```
+
+6. Ignoring IAM Role Templates with Certain Paths
+
+```yaml
+aws:
+  import_rules:
+    - match_paths:
+        - "/service-role/*"
+        - "/aws-service-role/*"
+      action: "ignore"
+```
+
+In these examples, the "ignore" action tells IAMbic not to manage these resources at all,
+while the "set_import_only" action tells IAMbic to import these resources for tracking but not manage them.
+
+The `match_template_types`, `match_tags`, `match_names`, and `match_paths` conditions allow you to specify the resources to which these actions apply.

--- a/iambic/core/template_generation.py
+++ b/iambic/core/template_generation.py
@@ -976,6 +976,10 @@ def merge_model(  # noqa: C901
         value_as_list = isinstance(new_value, list)
         existing_value = getattr(existing_model, key)
         if key in iambic_fields:
+            if key == "iambic_managed":
+                iambic_managed: IambicManaged = getattr(existing_model, key)
+                if iambic_managed.value == "undefined":
+                    setattr(merged_model, key, new_value)
             # not something we want to merge because
             # this is metadata only, not in the cloud-side
             continue

--- a/iambic/plugins/v0_1_0/aws/utils.py
+++ b/iambic/plugins/v0_1_0/aws/utils.py
@@ -32,10 +32,10 @@ async def process_import_rules(
         # Match by tag
         if rule.match_tags:
             for tag in rule.match_tags:
-                for role_tag in tags:
-                    if is_regex_match(tag.key, role_tag.get("key")) and (
+                for resource_tag in tags:
+                    if is_regex_match(tag.key, resource_tag.get("key")) and (
                         tag.value is None
-                        or is_regex_match(tag.value, role_tag.get("value"))
+                        or is_regex_match(tag.value, resource_tag.get("value"))
                     ):
                         tag_match = True
                         break

--- a/iambic/plugins/v0_1_0/aws/utils.py
+++ b/iambic/plugins/v0_1_0/aws/utils.py
@@ -3,17 +3,73 @@ from __future__ import annotations
 import asyncio
 import re
 from enum import Enum
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import boto3
 from botocore.exceptions import ClientError, NoCredentialsError
 
 from iambic.core.iambic_enum import IambicManaged
 from iambic.core.logger import log
-from iambic.core.utils import aio_wrapper
+from iambic.core.utils import aio_wrapper, is_regex_match
 
 if TYPE_CHECKING:
-    from iambic.plugins.v0_1_0.aws.iambic_plugin import AWSConfig
+    from iambic.plugins.v0_1_0.aws.iambic_plugin import AWSConfig, ImportAction
+
+
+async def process_import_rules(
+    config: AWSConfig,
+    template_type: str,
+    identifier: str,
+    tags: list[dict[str, str]],
+    resource_dict: dict[str, Any],
+) -> list[ImportAction]:
+    actions = []
+
+    for rule in config.import_rules:
+        # Initialize match indicators
+        tag_match = name_match = path_match = template_type_match = False
+
+        # Match by tag
+        if rule.match_tags:
+            for tag in rule.match_tags:
+                for role_tag in tags:
+                    if is_regex_match(tag.key, role_tag.get("key")) and (
+                        tag.value is None
+                        or is_regex_match(tag.value, role_tag.get("value"))
+                    ):
+                        tag_match = True
+                        break
+
+        # Match by name/identifier
+        if rule.match_names:
+            for pattern in rule.match_names:
+                if is_regex_match(pattern, identifier):
+                    name_match = True
+                    break
+
+        # Match by path
+        if rule.match_paths:
+            for pattern in rule.match_paths:
+                if is_regex_match(pattern, resource_dict.get("path", "")):
+                    path_match = True
+                    break
+
+        # Match by template type
+        if rule.match_template_types:
+            for pattern in rule.match_template_types:
+                if is_regex_match(pattern, template_type):
+                    template_type_match = True
+                    break
+
+        # Add action to the list if all conditions specified in the rule are satisfied
+        if (
+            (not rule.match_tags or tag_match)
+            and (not rule.match_names or name_match)
+            and (not rule.match_paths or path_match)
+            and (not rule.match_template_types or template_type_match)
+        ):
+            actions.append(rule.action)
+    return actions
 
 
 def calculate_import_preference(existing_template):

--- a/test/plugins/v0_1_0/aws/test_utils.py
+++ b/test/plugins/v0_1_0/aws/test_utils.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from unittest.mock import Mock
+
 import pytest
-from mock import Mock
 
 
 @pytest.mark.parametrize(

--- a/test/plugins/v0_1_0/aws/test_utils.py
+++ b/test/plugins/v0_1_0/aws/test_utils.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 import pytest
-
-from iambic.plugins.v0_1_0.aws.utils import get_identity_arn
+from mock import Mock
 
 
 @pytest.mark.parametrize(
@@ -38,5 +37,98 @@ from iambic.plugins.v0_1_0.aws.utils import get_identity_arn
     ],
 )
 def test_get_identity_arn(caller_identity, expected_arn):
+    from iambic.plugins.v0_1_0.aws.utils import get_identity_arn
+
     arn = get_identity_arn(caller_identity)
     assert arn == expected_arn
+
+
+@pytest.mark.asyncio
+async def test_process_import_rules():
+    from iambic.plugins.v0_1_0.aws.iambic_plugin import (
+        ImportAction,
+        ImportRule,
+        ImportRuleTag,
+    )
+    from iambic.plugins.v0_1_0.aws.utils import process_import_rules
+
+    # Setup
+    template_type = "NOQ::AWS::IAM::Role"
+    identifier = "AWSServiceRoleForCloudFormationStackSetsOrgMember"
+    tags = [{"key": "tagkey", "value": "tagvalue"}]
+    resource_dict = {
+        "path": "/aws-service-role/member.org.stacksets.cloudformation.amazonaws.com/",
+        "role_name": "AWSServiceRoleForCloudFormationStackSetsOrgMember",
+    }
+
+    test_rules = [
+        {
+            "rules": [
+                ImportRule(
+                    match_tags=[ImportRuleTag(key="terraform")],
+                    action=ImportAction.set_import_only,
+                ),
+            ],
+            "result": [],
+        },
+        {
+            "rules": [
+                ImportRule(
+                    match_tags=[ImportRuleTag(key="tagkey", value="tagvalue")],
+                    action=ImportAction.set_import_only,
+                )
+            ],
+            "result": [ImportAction.set_import_only],
+        },
+        {
+            "rules": [
+                ImportRule(match_names=["AWSReservedSSO*"], action=ImportAction.ignore)
+            ],
+            "result": [],
+        },
+        {
+            "rules": [
+                ImportRule(match_names=["AWSServiceRole*"], action=ImportAction.ignore)
+            ],
+            "result": [ImportAction.ignore],
+        },
+        {
+            "rules": [
+                ImportRule(
+                    match_paths=["/service-role/*", "/aws-service-role/*"],
+                    action=ImportAction.ignore,
+                )
+            ],
+            "result": [ImportAction.ignore],
+        },
+        {
+            "rules": [
+                ImportRule(
+                    match_tags=[{"key": "ManagedBy", "value": "CDK"}],
+                    action=ImportAction.ignore,
+                )
+            ],
+            "result": [],
+        },
+        {
+            "rules": [
+                ImportRule(
+                    match_template_types=["NOQ::AWS::IAM::Role"],
+                    match_tags=[ImportRuleTag(key="tagkey", value="tagvalue")],
+                    action=ImportAction.set_import_only,
+                )
+            ],
+            "result": [ImportAction.set_import_only],
+        },
+    ]
+    for test_rule in test_rules:
+        config_mock = Mock()
+        config_mock.import_rules = test_rule["rules"]
+
+        # Call function
+        result = await process_import_rules(
+            config_mock, template_type, identifier, tags, resource_dict
+        )
+
+        # Verify result
+        assert result == test_rule["result"]


### PR DESCRIPTION
## What changed?
* This PR adds support for AWS Import Rules, with documentation. IAMbic will obey import rules to either ignore resources with certain attributes, or to flag them as `import_only`.

## Rationale
Rationale is to support ignoring AWS Managed Resources (#388), and #421. This will allow users to import terraform or AWS CDK managed resources in an `import_only` mode, or just ignore them altogether to avoid polluting their iambic-templates repository.

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [X] Unit Tests
- [ ] Functional Tests
- [X] Manually Verified
