### PR TITLE
Fix/expand bot interaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 
 # Change Log
 
+## 0.9.8 (Jun 20, 2023)
+
+ENHANCEMENTS:
+
+* Explicit allow list GitHub bots interactions (iambic approve, iambic apply)  [#470](https://github.com/noqdev/iambic/pull/470)
+
 ## 0.9.6 (Jun 15, 2023)
 
 BUG FIXES:

--- a/iambic/plugins/v0_1_0/github/github_app.py
+++ b/iambic/plugins/v0_1_0/github/github_app.py
@@ -45,6 +45,12 @@ from iambic.plugins.v0_1_0.github.github import (
 # This is due to lambda reusing the already running container
 
 
+# We typically ignore bot interactions; however, there are scenarios
+# in which we want other installed GitHub App to interact with the
+# integrations, we allow list such situations explicitly.
+ALLOWED_BOT_INTERACTIONS = ["iambic approve" "iambic apply"]
+
+
 def format_github_url(repository_url: str, github_token: str) -> str:
     parse_result = urlparse(repository_url)
     return parse_result._replace(
@@ -237,7 +243,7 @@ def handle_issue_comment(
         return HandleIssueCommentReturnCode.NO_MATCHING_BODY
 
     if comment_user_login.endswith("[bot]"):
-        if command_lookup != "iambic approve":
+        if command_lookup not in ALLOWED_BOT_INTERACTIONS:
             # return early unless it's the approve attempt
             # the approve handler require to walk the full config
             # to determine.

--- a/iambic/plugins/v0_1_0/github/github_app.py
+++ b/iambic/plugins/v0_1_0/github/github_app.py
@@ -48,7 +48,7 @@ from iambic.plugins.v0_1_0.github.github import (
 # We typically ignore bot interactions; however, there are scenarios
 # in which we want other installed GitHub App to interact with the
 # integrations, we allow list such situations explicitly.
-ALLOWED_BOT_INTERACTIONS = ["iambic approve" "iambic apply"]
+ALLOWED_BOT_INTERACTIONS = ["iambic approve", "iambic apply"]
 
 
 def format_github_url(repository_url: str, github_token: str) -> str:


### PR DESCRIPTION
## What changed?
* Allow "iambic approve" and "iambic apply" issued by bots through processing

## Rationale
* We previously only allow list "iambic approve" issued by bots. Change to an explicit allow list to allow "apply" command by bots. 

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] Manually Verified
