### PR TITLE
Implement GitHub App interaction error protocol

### DIFF
--- a/docs/cep/000-cep-template.md
+++ b/docs/cep/000-cep-template.md
@@ -1,0 +1,19 @@
+# CEP xxx - Code Enhancement Proposal Title
+
+## Summary
+Short summary about a code enhancement proposal
+
+## Rationale
+Why is this new enhancement needed?
+
+## Customer Experience
+How does the customer interact with this enhancement?
+
+## Alternative
+Is there alternative considered?
+
+## Implementation
+What's needed on the implementation?
+
+## Compatibility concern
+Is there any compatibility concern?

--- a/docs/cep/002-GitHub-App-Interactions-Protocol.md
+++ b/docs/cep/002-GitHub-App-Interactions-Protocol.md
@@ -1,0 +1,78 @@
+# CEP 002 - GitHub App Interactions Protocol
+
+## Summary
+
+Outlines how a different GitHub app can interact with the IAMbic
+GitHub App integration
+
+## Rationale
+
+IAMbic GitHub App is responsible for continuous integration and continuous
+delivery. By itself, it's meant to be an assistant for human developers.
+It automatically plans changes in the pull requests and made comments back
+to pull requests. Pull requests authors and reviewers decide when to apply
+the changes.
+
+If a different GitHub App (hereby known as GA2) needs to interact with the pull request flow, it
+needs additional information beyond what GitHub pull request provides. For
+example, GA2 is a enterprise application that opens a pull request on iambic templates repository, we need
+a mechanism to approve the pull request without a developer interacting with GitHub.
+
+GitHub Pull Requests prohibits pull request author to approve its own requests.
+We need to extend IAMBic GitHub App to submit pull request review with "Approve Event".
+In addition, the authenticity and authorization needs to be established between
+IAMbic GitHub app and GA2 because most environments need to control changes
+within their IAMbic templates to be in compliance.
+
+## Customer Experience
+Customer that depends on GA2 typically don't use GitHub interface. We need to support
+GA2 to drive the pull request forward without customer interacting directly with GitHub.
+
+GA2 can rely on a separate set of user experience outside of GitHub.
+
+## Alternative
+Is there alternative considered?
+
+## Implementation
+
+### approve
+
+GA2 submits a signed comment in the following format.
+
+```
+iambic approve
+<free form>
+<!--signed_payload_in_jwt_format-->
+```
+
+`signed_payload_in_jwt_format` is a json payload with the following require attributes
+in ES256 algorithm.
+
+```json
+{
+    "repo": "example.com/iambic-templates",
+    "pr": 1,
+    "signee": [
+        "user1@example.org",
+        "user2@example.org",
+    ],
+}
+```
+
+### errors
+
+If `iambic apply` fails, it contains a footer in the comment body payload as
+
+```
+free form error data
+<!--iambic/apply/error-->
+```
+
+Currently, we have not yet signed the footer. It's possible to cause denial of service
+error to GA2 if malicious identity makes comment with the same footer and GA2
+reacts to such footer unconditionally.
+
+A possible improvement is to establish signature verification from IAMbic GitHub App to GA2.
+
+## Compatibility concern
+As of 2023-06-22, there is no compatibility concern.

--- a/iambic/plugins/v0_1_0/github/github.py
+++ b/iambic/plugins/v0_1_0/github/github.py
@@ -30,6 +30,7 @@ from iambic.core.models import ExecutionMessage, TemplateChangeDetails
 from iambic.core.utils import decode_with_reference_time, yaml
 from iambic.main import run_apply, run_detect, run_expire, run_git_apply, run_git_plan
 from iambic.plugins.v0_1_0.github.iambic_plugin import GithubConfig
+from iambic.plugins.v0_1_0.github.utils import IAMBIC_APPLY_ERROR_METADATA
 
 iambic_app = __import__("iambic.lambda.app", globals(), locals(), [], 0)
 lambda_run_handler = getattr(iambic_app, "lambda").app.run_handler
@@ -419,7 +420,7 @@ def handle_iambic_git_apply(
         captured_traceback = traceback.format_exc()
         log.error("fault", exception=captured_traceback)
         pull_request.create_issue_comment(
-            "exception during apply is {0} \n ```{1}```".format(
+            f"exception during apply is {0} \n ```{1}```\n{IAMBIC_APPLY_ERROR_METADATA}".format(
                 pull_request.mergeable_state, captured_traceback
             )
         )

--- a/iambic/plugins/v0_1_0/github/utils.py
+++ b/iambic/plugins/v0_1_0/github/utils.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+IAMBIC_APPLY_ERROR_METADATA = "<!--iambic/apply/error-->"
+
+
+def is_iambic_apply_error(body: str):
+    footer = body.split("\n")[-1]
+    return IAMBIC_APPLY_ERROR_METADATA in footer

--- a/test/plugins/v0_1_0/github/test_utils.py
+++ b/test/plugins/v0_1_0/github/test_utils.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from iambic.plugins.v0_1_0.github.utils import (
+    IAMBIC_APPLY_ERROR_METADATA,
+    is_iambic_apply_error,
+)
+
+
+def test_is_iambic_apply_error():
+    expected_result = is_iambic_apply_error(f"xyz\n{IAMBIC_APPLY_ERROR_METADATA}")
+    assert expected_result
+
+
+def test_is_not_iambic_apply_error():
+    expected_result = is_iambic_apply_error("xyz\n")
+    assert not expected_result


### PR DESCRIPTION
## What changed?
* Add error metadata during `iambic apply` errors

## Rationale
* Another GitHub App that wants to know if `iambic apply` fail

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [x] Unit Tests
- [ ] Functional Tests
- [ ] Manually Verified
