### PR TITLE
Fix #447. Add single account is checking stacksets status when it should not

### DIFF
--- a/functional_tests/test_wizard.py
+++ b/functional_tests/test_wizard.py
@@ -45,6 +45,10 @@ def temp_templates_directory():
     os.chdir(old_cwd)
 
 
+# TODO, we have to add test that targets a newly spin up account without any
+# CF stacksets enable in the organization, preferly even an organizationless account.
+
+
 def test_setup_single_account(iam_spoke_role, temp_templates_directory) -> None:
     log_file = f"{temp_templates_directory}/test_setup_single_aws_account.txt"
     print(f"ui test log file is in {log_file}")


### PR DESCRIPTION
## What changed?
* Add single AWS account should not check CF StackSets status

## Rationale
* has_cf_permissions use to just prompt. However, since we added API checks on organization CF StackSets, it leads single aws account also check against CF StackSets. Single AWS account does not use StackSets. So we actually separate the checks on CF StackSets vs. CF confirmed permissions.

We are not yet actually test against needed CF confirmed permission via API, it's just a simply prompt. Future improvement.

More over, our functional tests does not target a newly minted AWS account. Our current test setup has already enabled CF stacksets in organization. 

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [x] Unit Tests
- [ ] Functional Tests
- [x] Manually Verified
