### PR TITLE
Added Managed Policy ARN to ProposedChange

### DIFF
--- a/iambic/plugins/v0_1_0/aws/iam/role/utils.py
+++ b/iambic/plugins/v0_1_0/aws/iam/role/utils.py
@@ -354,6 +354,7 @@ async def apply_role_managed_policies(
                         resource_type="aws:policy_document",
                         resource_id=policy_arn,
                         attribute="managed_policies",
+                        new_value={"PolicyArn": policy_arn},
                     )
                 ]
                 apply_awaitable = boto_crud_call(
@@ -370,6 +371,7 @@ async def apply_role_managed_policies(
                         resource_type="aws:policy_document",
                         resource_id=policy_arn,
                         attribute="managed_policies",
+                        new_value={"PolicyArn": policy_arn},
                     )
                     for policy_arn in new_managed_policies
                 ]


### PR DESCRIPTION
- Attaching managed policies to roles didn't update the `new_value` of the `ProposedChange`. This has been fixed in this PR

## What changed?
* Adds details regarding changes made to managed policies when they are attached to roles.

## Rationale
* Fixes consistency issue and ensures that managed policy attachments contains the details of
  the attachment to the `ProposedChange`

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [ ] Unit Tests
- [ ] Functional Tests
- [X] Manually Verified
