### PR TITLE
Add 'notes' core template attribute

### DIFF
--- a/iambic/core/models.py
+++ b/iambic/core/models.py
@@ -37,6 +37,7 @@ from pydantic.fields import ModelField
 from iambic.core.iambic_enum import Command, ExecutionStatus, IambicManaged
 from iambic.core.logger import log
 from iambic.core.utils import (
+    LiteralScalarString,
     apply_to_provider,
     create_commented_map,
     get_writable_directory,
@@ -210,6 +211,7 @@ class BaseModel(IambicPydanticBaseModel):
             "included_orgs",
             "excluded_orgs",
             "owner",
+            "notes",
             "template_type",
             "file_path",
             "metadata_iambic_fields",
@@ -490,6 +492,7 @@ class BaseTemplate(
     template_type: str
     file_path: Union[str, Path] = Field(..., hidden_from_schema=True)
     owner: Optional[str]
+    notes: Optional[str]
     iambic_managed: Optional[IambicManaged] = Field(
         IambicManaged.UNDEFINED,
         description="Controls the directionality of Iambic changes",
@@ -538,6 +541,8 @@ class BaseTemplate(
         )
         sorted_input_dict = sort_dict(input_dict)
         sorted_input_dict = create_commented_map(sorted_input_dict)
+        if notes := sorted_input_dict.get("notes"):
+            sorted_input_dict["notes"] = LiteralScalarString(notes)
         as_yaml = yaml.dump(sorted_input_dict)
         # Force template_type to be at the top of the yaml
         template_type_str = f"template_type: {self.template_type}"
@@ -590,7 +595,7 @@ class BaseTemplate(
 
     @classmethod
     def iambic_specific_knowledge(cls) -> set[str]:
-        return {"iambic_managed", "file_path", "owner"}
+        return {"iambic_managed", "file_path", "owner", "notes"}
 
 
 class Variable(PydanticBaseModel):

--- a/iambic/core/utils.py
+++ b/iambic/core/utils.py
@@ -17,7 +17,7 @@ from urllib.parse import unquote_plus
 import aiofiles
 import jwt
 from asgiref.sync import sync_to_async
-from ruamel.yaml import YAML
+from ruamel.yaml import YAML, scalarstring
 
 from iambic.core import noq_json as json
 from iambic.core.aio_utils import gather_limit
@@ -38,6 +38,8 @@ IAMBIC_ERR_MSG = (
 )
 
 __WRITABLE_DIRECTORY__ = pathlib.Path.home()
+
+LiteralScalarString = scalarstring.LiteralScalarString
 
 
 def init_writable_directory() -> None:

--- a/test/core/test_models.py
+++ b/test/core/test_models.py
@@ -21,7 +21,10 @@ from iambic.core.template_generation import merge_model
 
 def test_merge_model():
     existing_template = BaseTemplate(
-        template_type="foo", file_path="bar", iambic_managed=IambicManaged.IMPORT_ONLY
+        template_type="foo",
+        notes="test_notes",
+        file_path="bar",
+        iambic_managed=IambicManaged.IMPORT_ONLY,
     )
     new_template = BaseTemplate(
         template_type="foo_new",
@@ -32,6 +35,7 @@ def test_merge_model():
     assert merged_template.template_type == new_template.template_type
     assert merged_template.iambic_managed == IambicManaged.IMPORT_ONLY
     assert merged_template.file_path == existing_template.file_path
+    assert merged_template.notes == existing_template.notes
 
 
 def test_merge_model_with_none():
@@ -114,6 +118,9 @@ def test_expiry_model_from_json_with_null():
 
 
 TEST_TEMPLATE_YAML = """template_type: NOQ::Example::LocalFile
+notes: |-
+  This is a test note
+  with a newline
 name: test_template
 expires_at: tomorrow
 properties:


### PR DESCRIPTION
## What changed?
* This PR is a result of user feedback that having free-form notes in an IAMbic template could be useful for context sharing. Such context would allow users to codify details about an identity or a policy that aren't easy to represent in a standardized way in a provider, and this can be exposed to end-users in a web UI or via other means.

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [ ] Unit Tests
- [ ] Functional Tests
- [X] Manually Verified
