### PR TITLE
Fix/492 gh app deployment non mgmt account

### DIFF
--- a/docs/web/docs/1-getting_started/7-github.mdx
+++ b/docs/web/docs/1-getting_started/7-github.mdx
@@ -211,7 +211,7 @@ and as it adds comments in each pull request, it provides a link to the summary 
 
 1. **Create a new GitHub repository** in your organization that will host the IAMbic Plan and Apply Summaries.
    The repository must have the same name as your IAMbic templates repository, with `-gist` appended to the end.
-   For example, if your repoistory name is `iambic-templates`, the new repository must be named `iambic-templates-gist`.
+   For example, if your repository name is `iambic-templates`, the new repository must be named `iambic-templates-gist`.
 
 2. **Ensure the IAMbic GitHub App has write access to the new repository.
    - To set the repository permissions:

--- a/docs/web/docs/1-getting_started/7-github.mdx
+++ b/docs/web/docs/1-getting_started/7-github.mdx
@@ -242,14 +242,20 @@ and as it adds comments in each pull request, it provides a link to the summary 
 
 1. Place the above IAMbic template to your `iambic-templates` repo under `resources/github/iam_role_lambda.yaml`
 
-<!-- for us, NAME_OF_AWS_ACCOUNT_THAT_HAS_IambicHubRole should be aws_hub_account_name -->
+:::tip
+
+Remember to replace `TARGET_ACCOUNT_ID` with the actual account id literal. This account id is the account
+id that deploys the lambda function.
+:::
+
 ```yaml
 template_type: NOQ::AWS::IAM::Role
 included_accounts:
-  # You will need to replace the "NAME_OF_AWS_ACCOUNT_THAT_HAS_IambicHubRole"
-  # with the account name of the AWS account holding the IambicHubRole.
+  # You will need to replace the "TARGET_ACCOUNT_NAME"
+  # with the account name of the AWS account can run compute and reasonably secured
+  # because it is managing your infrastructure.
   # In the event you change the secret names, you need to update those values as well.
-  - NAME_OF_AWS_ACCOUNT_THAT_HAS_IambicHubRole
+  - TARGET_ACCOUNT_NAME
 identifier: iambic_github_app_lambda_execution
 properties:
   description: Github App Lambda Execution
@@ -294,16 +300,23 @@ properties:
 2. You can then apply the template via `iambic apply resources/github/iam_role_lambda.yaml`
 3. Allow the `iambic_github_app_lambda_execution` to assume to `IambicHubRole` in the organization management account.
 
+:::tip
+
+Remember to replace `TARGET_ACCOUNT_ID` with the actual account id literal. This account id is the account
+id that deploys the lambda function.
+:::
+
 ```diff
 properties:
   assume_role_policy_document:
     statement:
-+      - action:
++      - sid: IambicGitHubIntegration
++        action:
 +          - sts:AssumeRole
 +          - sts:TagSession
 +        effect: Allow
 +        principal:
-+          aws: arn:aws:iam::{{var.account_id}}:role/iambic_github_app_lambda_execution
++          aws: arn:aws:iam::TARGET_ACCOUNT_ID:role/iambic_github_app_lambda_execution
 ```
 
 Update the IambicHubRole by running `iambic apply <path-to-iambic-hub-role-of-mgmt-account>`


### PR DESCRIPTION
## What changed?
Fixed #492 Update documentation to deploy GH App in a non-mgmt account

## Rationale
Move compute usage out of AWS mgmt account into a different aws account for GH App integration

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] Manually Verified
