### PR TITLE
Fix detect interpreter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 
 # Change Log
 
+## 0.10.11 (July 17, 2023)
+
+BUG FIXES:
+* Fixed race condition on iambic detect not using templated resource id grouping resources  
+* Fixed issue where a resource could show as excluded on a resource it was never evaluated on
+
+ENHANCEMENTS:
+* Improved ordering of template attributes
+* `base_group_dict_attribute` is now more deterministic in its grouping
+* `iambic detect` performance optimizations. 
+  * Now only evaluates on the account a resource id change is detected on as opposed to all accounts.
+  * Example if `engineering` is on all accounts and detect is ran for account a, only `engineering` on account a is evaluated.
+
 ## 0.10.1 (July 3, 2023)
 
 DOCS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,16 @@
 ## 0.10.11 (July 17, 2023)
 
 BUG FIXES:
-* Fixed race condition on iambic detect not using templated resource id grouping resources  
-* Fixed issue where a resource could show as excluded on a resource it was never evaluated on
+* Fixed race condition on iambic detect not using templated resource id grouping resources.
+* Fixed issue where a resource could show as excluded on a resource it was never evaluated on.
 
 ENHANCEMENTS:
-* Improved ordering of template attributes
-* `base_group_dict_attribute` is now more deterministic in its grouping
-* `iambic detect` performance optimizations. 
+* Improved ordering of template attributes.
+* `base_group_dict_attribute` is now more deterministic in its grouping.
+* `iambic detect` performance optimizations.
   * Now only evaluates on the account a resource id change is detected on as opposed to all accounts.
   * Example if `engineering` is on all accounts and detect is ran for account a, only `engineering` on account a is evaluated.
+* Removed remaining AWS provider references from core.
 
 ## 0.10.1 (July 3, 2023)
 

--- a/iambic/core/detect.py
+++ b/iambic/core/detect.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 from collections import defaultdict
 from typing import Type
 
-from iambic.core.models import ProviderChild, BaseTemplate
+from iambic.core.models import BaseTemplate, ProviderChild
 from iambic.core.utils import evaluate_on_provider
 
 
@@ -25,13 +27,15 @@ def group_detect_messages(group_by: str, messages: list) -> dict:
 def generate_template_output(
     excluded_provider_ids: list[str],
     provider_child_map: dict[str, ProviderChild],
-    template: Type[BaseTemplate]
+    template: Type[BaseTemplate],
 ) -> dict[str, dict]:
     provider_children_value_map = dict()
     for provider_child_id, provider_child in provider_child_map.items():
         if provider_child_id in excluded_provider_ids:
             continue
-        elif not evaluate_on_provider(template, provider_child, exclude_import_only=False):
+        elif not evaluate_on_provider(
+            template, provider_child, exclude_import_only=False
+        ):
             continue
 
         if provider_child_value := template.apply_resource_dict(provider_child):

--- a/iambic/core/detect.py
+++ b/iambic/core/detect.py
@@ -1,0 +1,40 @@
+from collections import defaultdict
+from typing import Type
+
+from iambic.core.models import ProviderChild, BaseTemplate
+from iambic.core.utils import evaluate_on_provider
+
+
+def group_detect_messages(group_by: str, messages: list) -> dict:
+    """Group messages by a key in the message dict.
+
+    Args:
+        group_by (str): The key to group by.
+        messages (list): The messages to group.
+
+    Returns:
+        dict: The grouped messages.
+    """
+    grouped_messages = defaultdict(list)
+    for message in messages:
+        grouped_messages[getattr(message, group_by)].append(message)
+
+    return grouped_messages
+
+
+def generate_template_output(
+    excluded_provider_ids: list[str],
+    provider_child_map: dict[str, ProviderChild],
+    template: Type[BaseTemplate]
+) -> dict[str, dict]:
+    provider_children_value_map = dict()
+    for provider_child_id, provider_child in provider_child_map.items():
+        if provider_child_id in excluded_provider_ids:
+            continue
+        elif not evaluate_on_provider(template, provider_child, exclude_import_only=False):
+            continue
+
+        if provider_child_value := template.apply_resource_dict(provider_child):
+            provider_children_value_map[provider_child_id] = provider_child_value
+
+    return provider_children_value_map

--- a/iambic/core/detect.py
+++ b/iambic/core/detect.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Type
+from typing import Optional, Type
 
 from iambic.core.models import BaseTemplate, ProviderChild
 from iambic.core.utils import evaluate_on_provider
@@ -27,9 +27,11 @@ def group_detect_messages(group_by: str, messages: list) -> dict:
 def generate_template_output(
     excluded_provider_ids: list[str],
     provider_child_map: dict[str, ProviderChild],
-    template: Type[BaseTemplate],
+    template: Optional[Type[BaseTemplate]],
 ) -> dict[str, dict]:
     provider_children_value_map = dict()
+    if not template:
+        return provider_children_value_map
     for provider_child_id, provider_child in provider_child_map.items():
         if provider_child_id in excluded_provider_ids:
             continue

--- a/iambic/core/models.py
+++ b/iambic/core/models.py
@@ -39,12 +39,13 @@ from iambic.core.utils import (
     LiteralScalarString,
     apply_to_provider,
     create_commented_map,
+    get_rendered_template_str_value,
     get_writable_directory,
     simplify_dt,
     snake_to_camelcap,
     sort_dict,
     transform_comments,
-    yaml, get_rendered_template_str_value,
+    yaml,
 )
 
 if TYPE_CHECKING:

--- a/iambic/core/utils.py
+++ b/iambic/core/utils.py
@@ -17,6 +17,8 @@ from urllib.parse import unquote_plus
 import aiofiles
 import jwt
 from asgiref.sync import sync_to_async
+from jinja2 import BaseLoader
+from jinja2.sandbox import ImmutableSandboxedEnvironment
 from ruamel.yaml import YAML, scalarstring
 
 from iambic.core import noq_json as json
@@ -26,7 +28,7 @@ from iambic.core.iambic_enum import IambicManaged
 from iambic.core.logger import log
 
 if TYPE_CHECKING:
-    from iambic.core.models import ProposedChange
+    from iambic.core.models import ProposedChange, ProviderChild
 
 
 NOQ_TEMPLATE_REGEX = r".*template_type:\n?.*NOQ::"
@@ -892,3 +894,27 @@ def decode_with_reference_time(encoded_jwt, public_key, algorithms, reference_ti
             )
 
     return payload
+
+
+def get_rendered_template_str_value(
+    template_value: str, provider_child: typing.Type[ProviderChild]
+) -> str:
+    """
+    Render a template string with the variables from the provider child.
+    """
+    valid_characters_re = r"[\w_+=,.@-]"
+    variables = {var.key: var.value for var in getattr(provider_child, "variables", [])}
+    for extra_attr in {"account_id", "account_name", "owner"}:
+        if attr_val := getattr(provider_child, extra_attr, None):
+            variables[extra_attr] = attr_val
+
+    if not variables:
+        return template_value
+
+    variables = {
+        k: sanitize_string(v, valid_characters_re) for k, v in variables.items()
+    }
+    rtemplate = ImmutableSandboxedEnvironment(loader=BaseLoader()).from_string(
+        template_value
+    )
+    return rtemplate.render(var=variables)

--- a/iambic/plugins/v0_1_0/aws/iam/policy/models.py
+++ b/iambic/plugins/v0_1_0/aws/iam/policy/models.py
@@ -318,6 +318,12 @@ class AwsIamManagedPolicyTemplate(AWSTemplate, AccessModel):
     def _apply_resource_dict(self, aws_account: AWSAccount = None) -> dict:
         resource_dict = super()._apply_resource_dict(aws_account)
         resource_dict["Arn"] = self.get_arn_for_account(aws_account)
+
+        if policy_document := resource_dict.pop("PolicyDocument", []):
+            if isinstance(policy_document, list):
+                policy_document = policy_document[0]
+            resource_dict["PolicyDocument"] = policy_document
+
         return resource_dict
 
     async def _apply_to_account(self, aws_account: AWSAccount) -> AccountChangeDetails:

--- a/iambic/plugins/v0_1_0/aws/iam/policy/template_generation.py
+++ b/iambic/plugins/v0_1_0/aws/iam/policy/template_generation.py
@@ -367,7 +367,7 @@ async def create_templated_managed_policy(  # noqa: C901
         AwsIamManagedPolicyTemplate,
         template_params,
         ManagedPolicyProperties(**template_properties),
-        [aws_account_map[mp_ref["account_id"]] for mp_ref in managed_policy_refs],
+        list(aws_account_map.values()),
     )
 
 

--- a/iambic/plugins/v0_1_0/aws/iam/role/template_generation.py
+++ b/iambic/plugins/v0_1_0/aws/iam/role/template_generation.py
@@ -153,15 +153,16 @@ async def generate_role_resource_file_for_all_accounts(
     role_name: str,
     aws_account_map: dict[str, AWSAccount],
     updated_account_ids: list[str],
-    iambic_template: AwsIamRoleTemplate,
+    iambic_template: Optional[AwsIamRoleTemplate],
 ) -> list:
     async def get_role_for_account(aws_account: AWSAccount):
         iam_client = await aws_account.get_boto3_client("iam")
         account_role_name = get_rendered_template_str_value(role_name, aws_account)
         role = await get_role(account_role_name, iam_client)
-        role["PermissionsBoundary"]["PolicyArn"] = role["PermissionsBoundary"].pop(
-            "PermissionsBoundaryArn"
-        )
+        if "PermissionsBoundary" in role:
+            role["PermissionsBoundary"]["PolicyArn"] = role["PermissionsBoundary"].pop(
+                "PermissionsBoundaryArn"
+            )
         return {aws_account.account_id: role}
 
     account_resource_dir_map = {

--- a/iambic/plugins/v0_1_0/aws/iam/role/template_generation.py
+++ b/iambic/plugins/v0_1_0/aws/iam/role/template_generation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import itertools
 import os
 from collections import defaultdict
@@ -8,13 +9,19 @@ from typing import TYPE_CHECKING, Optional
 import aiofiles
 
 from iambic.core import noq_json as json
+from iambic.core.detect import generate_template_output, group_detect_messages
 from iambic.core.logger import log
 from iambic.core.models import ExecutionMessage
 from iambic.core.template_generation import (
     create_or_update_template,
     delete_orphaned_templates,
 )
-from iambic.core.utils import NoqSemaphore, normalize_dict_keys, resource_file_upsert
+from iambic.core.utils import (
+    NoqSemaphore,
+    get_rendered_template_str_value,
+    normalize_dict_keys,
+    resource_file_upsert,
+)
 from iambic.plugins.v0_1_0.aws.event_bridge.models import RoleMessageDetails
 from iambic.plugins.v0_1_0.aws.iam.policy.models import AssumeRolePolicyDocument
 from iambic.plugins.v0_1_0.aws.iam.role.models import (
@@ -23,7 +30,7 @@ from iambic.plugins.v0_1_0.aws.iam.role.models import (
     RoleProperties,
 )
 from iambic.plugins.v0_1_0.aws.iam.role.utils import (
-    get_role_across_accounts,
+    get_role,
     get_role_inline_policies,
     get_role_managed_policies,
     list_role_tags,
@@ -143,20 +150,39 @@ async def generate_account_role_resource_files(
 
 async def generate_role_resource_file_for_all_accounts(
     exe_message: ExecutionMessage,
-    aws_accounts: list[AWSAccount],
     role_name: str,
+    aws_account_map: dict[str, AWSAccount],
+    updated_account_ids: list[str],
+    iambic_template: AwsIamRoleTemplate,
 ) -> list:
+    async def get_role_for_account(aws_account: AWSAccount):
+        iam_client = await aws_account.get_boto3_client("iam")
+        account_role_name = get_rendered_template_str_value(role_name, aws_account)
+        role = await get_role(account_role_name, iam_client)
+        role["PermissionsBoundary"]["PolicyArn"] = role["PermissionsBoundary"].pop(
+            "PermissionsBoundaryArn"
+        )
+        return {aws_account.account_id: role}
+
     account_resource_dir_map = {
         aws_account.account_id: get_response_dir(exe_message, aws_account)
-        for aws_account in aws_accounts
+        for aws_account in aws_account_map.values()
     }
     role_resource_file_upsert_semaphore = NoqSemaphore(resource_file_upsert, 10)
     messages = []
     response = []
 
-    role_across_accounts = await get_role_across_accounts(
-        aws_accounts, role_name, False
+    role_across_accounts = generate_template_output(
+        updated_account_ids, aws_account_map, iambic_template
     )
+    updated_account_roles = await asyncio.gather(
+        *[
+            get_role_for_account(aws_account_map[account_id])
+            for account_id in updated_account_ids
+        ]
+    )
+    for updated_account_role in updated_account_roles:
+        role_across_accounts.update(updated_account_role)
     role_across_accounts = {k: v for k, v in role_across_accounts.items() if v}
 
     log.debug(
@@ -450,7 +476,7 @@ async def create_templated_role(  # noqa: C901
             AwsIamRoleTemplate,
             role_template_params,
             RoleProperties(**role_template_properties),
-            list(aws_account_map.values()),
+            [aws_account_map[role_ref["account_id"]] for role_ref in role_refs],
         )
     except Exception as e:
         log_params = {
@@ -491,18 +517,21 @@ async def collect_aws_roles(
     )
 
     if detect_messages:
-        aws_accounts = list(aws_account_map.values())
         generate_role_resource_file_for_all_accounts_semaphore = NoqSemaphore(
             generate_role_resource_file_for_all_accounts, 45
         )
+        grouped_detect_messages = group_detect_messages("role_name", detect_messages)
         tasks = [
             {
                 "exe_message": exe_message,
-                "aws_accounts": aws_accounts,
-                "role_name": role.role_name,
+                "aws_account_map": aws_account_map,
+                "role_name": role_name,
+                "updated_account_ids": [
+                    message.account_id for message in role_messages
+                ],
+                "iambic_template": existing_template_map.get(role_name),
             }
-            for role in detect_messages
-            if not role.delete
+            for role_name, role_messages in grouped_detect_messages.items()
         ]
 
         # Remove deleted or mark templates for update
@@ -519,15 +548,6 @@ async def collect_aws_roles(
                     ):
                         # It's the only account for the template so delete it
                         existing_template.delete()
-                    else:
-                        # There are other accounts for the template so re-eval the template
-                        tasks.append(
-                            {
-                                "exe_message": exe_message,
-                                "aws_accounts": aws_accounts,
-                                "role_name": existing_template.properties.role_name,
-                            }
-                        )
 
         account_role_list = (
             await generate_role_resource_file_for_all_accounts_semaphore.process(tasks)
@@ -568,19 +588,24 @@ async def collect_aws_roles(
                 }
             )
 
-    log.info(
-        "Setting inline policies in role templates",
-        accounts=list(aws_account_map.keys()),
-    )
-    await set_role_resource_inline_policies_semaphore.process(messages)
-    log.info(
-        "Setting managed policies in role templates",
-        accounts=list(aws_account_map.keys()),
-    )
-    await set_role_resource_managed_policies_semaphore.process(messages)
-    log.info("Setting tags in role templates", accounts=list(aws_account_map.keys()))
-    await set_role_resource_tags_semaphore.process(messages)
-    log.info("Finished retrieving role details", accounts=list(aws_account_map.keys()))
+    if not detect_messages:
+        log.info(
+            "Setting inline policies in role templates",
+            accounts=list(aws_account_map.keys()),
+        )
+        await set_role_resource_inline_policies_semaphore.process(messages)
+        log.info(
+            "Setting managed policies in role templates",
+            accounts=list(aws_account_map.keys()),
+        )
+        await set_role_resource_managed_policies_semaphore.process(messages)
+        log.info(
+            "Setting tags in role templates", accounts=list(aws_account_map.keys())
+        )
+        await set_role_resource_tags_semaphore.process(messages)
+        log.info(
+            "Finished retrieving role details", accounts=list(aws_account_map.keys())
+        )
 
     account_role_output = json.dumps(account_roles)
     with open(

--- a/iambic/plugins/v0_1_0/aws/iam/role/template_generation.py
+++ b/iambic/plugins/v0_1_0/aws/iam/role/template_generation.py
@@ -477,7 +477,7 @@ async def create_templated_role(  # noqa: C901
             AwsIamRoleTemplate,
             role_template_params,
             RoleProperties(**role_template_properties),
-            [aws_account_map[role_ref["account_id"]] for role_ref in role_refs],
+            list(aws_account_map.values()),
         )
     except Exception as e:
         log_params = {

--- a/iambic/plugins/v0_1_0/aws/iam/role/utils.py
+++ b/iambic/plugins/v0_1_0/aws/iam/role/utils.py
@@ -10,7 +10,11 @@ from deepdiff import DeepDiff
 from iambic.core.context import ctx
 from iambic.core.logger import log
 from iambic.core.models import ProposedChange, ProposedChangeType
-from iambic.core.utils import aio_wrapper, plugin_apply_wrapper
+from iambic.core.utils import (
+    aio_wrapper,
+    get_rendered_template_str_value,
+    plugin_apply_wrapper,
+)
 from iambic.plugins.v0_1_0.aws.models import AWSAccount
 from iambic.plugins.v0_1_0.aws.utils import boto_crud_call, paginated_search
 
@@ -99,7 +103,7 @@ async def get_role_managed_policies(role_name: str, iam_client) -> list[dict[str
         else:
             break
 
-    return policies
+    return [{"PolicyArn": policy["PolicyArn"]} for policy in policies]
 
 
 async def get_role(role_name: str, iam_client, include_policies: bool = True) -> dict:
@@ -107,6 +111,8 @@ async def get_role(role_name: str, iam_client, include_policies: bool = True) ->
         current_role = (await boto_crud_call(iam_client.get_role, RoleName=role_name))[
             "Role"
         ]
+        current_role.get("PermissionsBoundary", {}).pop("PermissionsBoundaryType", None)
+
         if include_policies:
             current_role["ManagedPolicies"] = await get_role_managed_policies(
                 role_name, iam_client
@@ -129,9 +135,10 @@ async def get_role_across_accounts(
 ) -> dict:
     async def get_role_for_account(aws_account: AWSAccount):
         iam_client = await aws_account.get_boto3_client("iam")
+        account_role_name = get_rendered_template_str_value(role_name, aws_account)
         return {
             aws_account.account_id: await get_role(
-                role_name, iam_client, include_policies
+                account_role_name, iam_client, include_policies
             )
         }
 

--- a/iambic/plugins/v0_1_0/aws/iam/user/template_generation.py
+++ b/iambic/plugins/v0_1_0/aws/iam/user/template_generation.py
@@ -445,7 +445,7 @@ async def create_templated_user(  # noqa: C901
         AwsIamUserTemplate,
         user_template_params,
         UserProperties(**user_template_properties),
-        [aws_account_map[user_ref["account_id"]] for user_ref in user_refs],
+        list(aws_account_map.values()),
     )
 
 

--- a/iambic/plugins/v0_1_0/aws/iam/user/utils.py
+++ b/iambic/plugins/v0_1_0/aws/iam/user/utils.py
@@ -85,7 +85,7 @@ async def get_user_managed_policies(user_name: str, iam_client) -> list[dict[str
         else:
             break
 
-    return policies
+    return [{"PolicyArn": policy["PolicyArn"]} for policy in policies]
 
 
 async def get_user(user_name: str, iam_client, include_policies: bool = True) -> dict:

--- a/iambic/plugins/v0_1_0/aws/identity_center/permission_set/template_generation.py
+++ b/iambic/plugins/v0_1_0/aws/identity_center/permission_set/template_generation.py
@@ -387,7 +387,7 @@ async def create_templated_permission_set(  # noqa: C901
         AwsIdentityCenterPermissionSetTemplate,
         template_params,
         PermissionSetProperties(**template_properties),
-        [aws_account_map[ps_ref["account_id"]] for ps_ref in permission_set_refs],
+        list(aws_account_map.values()),
     )
 
 

--- a/iambic/plugins/v0_1_0/aws/identity_center/permission_set/template_generation.py
+++ b/iambic/plugins/v0_1_0/aws/identity_center/permission_set/template_generation.py
@@ -387,7 +387,7 @@ async def create_templated_permission_set(  # noqa: C901
         AwsIdentityCenterPermissionSetTemplate,
         template_params,
         PermissionSetProperties(**template_properties),
-        list(aws_account_map.values()),
+        [aws_account_map[ps_ref["account_id"]] for ps_ref in permission_set_refs],
     )
 
 

--- a/test/plugins/v0_1_0/aws/iam/group/test_template_generation.py
+++ b/test/plugins/v0_1_0/aws/iam/group/test_template_generation.py
@@ -112,7 +112,11 @@ async def test_generate_group_resource_file_for_all_accounts(
 ):
     _, templates_base_dir = mock_fs
     files = await generate_group_resource_file_for_all_accounts(
-        mock_execution_message, [mock_aws_account], EXAMPLE_GROUPNAME
+        mock_execution_message,
+        EXAMPLE_GROUPNAME,
+        {mock_aws_account.account_id: mock_aws_account},
+        [mock_aws_account.account_id],
+        None,
     )
     assert len(files) == 1
     assert files[0]["name"] == EXAMPLE_GROUPNAME

--- a/test/plugins/v0_1_0/aws/iam/policy/test_template_generation.py
+++ b/test/plugins/v0_1_0/aws/iam/policy/test_template_generation.py
@@ -17,6 +17,7 @@ import iambic
 from iambic.core.iambic_enum import Command
 from iambic.core.models import ExecutionMessage
 from iambic.core.template_generation import get_existing_template_map
+from iambic.plugins.v0_1_0.aws.event_bridge.models import ManagedPolicyMessageDetails
 from iambic.plugins.v0_1_0.aws.iam.policy.template_generation import (
     collect_aws_managed_policies,
     generate_account_managed_policy_resource_files,
@@ -115,9 +116,17 @@ async def test_generate_managed_policy_resource_file_for_all_accounts(
     policy_path = "/"
     files = await generate_managed_policy_resource_file_for_all_accounts(
         mock_execution_message,
-        [mock_aws_account],
-        policy_path,
         EXAMPLE_MANAGED_POLICY_NAME,
+        {mock_aws_account.account_id: mock_aws_account},
+        [
+            ManagedPolicyMessageDetails(
+                policy_path=policy_path,
+                account_id=mock_aws_account.account_id,
+                policy_name=EXAMPLE_MANAGED_POLICY_NAME,
+                delete=False,
+            )
+        ],
+        None,
     )
     assert len(files) == 1
     assert files[0]["policy_name"] == EXAMPLE_MANAGED_POLICY_NAME

--- a/test/plugins/v0_1_0/aws/iam/role/test_template_generation.py
+++ b/test/plugins/v0_1_0/aws/iam/role/test_template_generation.py
@@ -191,7 +191,11 @@ async def test_generate_role_resource_file_for_all_accounts(
 ):
     _, templates_base_dir = mock_fs
     files = await generate_role_resource_file_for_all_accounts(
-        mock_execution_message, [mock_aws_account], EXAMPLE_ROLE_NAME
+        mock_execution_message,
+        EXAMPLE_ROLE_NAME,
+        {mock_aws_account.account_id: mock_aws_account},
+        [mock_aws_account.account_id],
+        None,
     )
     assert len(files) == 1
     assert files[0]["name"] == EXAMPLE_ROLE_NAME

--- a/test/plugins/v0_1_0/aws/iam/user/test_template_generation.py
+++ b/test/plugins/v0_1_0/aws/iam/user/test_template_generation.py
@@ -115,7 +115,11 @@ async def test_generate_user_resource_file_for_all_accounts(
 ):
     _, templates_base_dir = mock_fs
     files = await generate_user_resource_file_for_all_accounts(
-        mock_execution_message, [mock_aws_account], EXAMPLE_USERNAME
+        mock_execution_message,
+        EXAMPLE_USERNAME,
+        {mock_aws_account.account_id: mock_aws_account},
+        [mock_aws_account.account_id],
+        None,
     )
     assert len(files) == 1
     assert files[0]["name"] == EXAMPLE_USERNAME


### PR DESCRIPTION
BUG FIXES:
 * Fixed race condition on iambic detect not using templated resource id grouping resources.
 * Fixed issue where a resource could show as excluded on a resource it was never evaluated on.

 ENHANCEMENTS:
 * Improved ordering of template attributes.
 * `base_group_dict_attribute` is now more deterministic in its grouping.
 * `iambic detect` performance optimizations.
   * Now only evaluates on the account a resource id change is detected on as opposed to all accounts.
   * Example if `engineering` is on all accounts and detect is ran for account a, only `engineering` on account a is evaluated.
 * Removed remaining AWS provider references from core.
