### PR TITLE
Handle CUSTOMER type as Google Group member

### DIFF
--- a/docs/web/docs/3-reference/3-schemas/aws_iam_group_template.json
+++ b/docs/web/docs/3-reference/3-schemas/aws_iam_group_template.json
@@ -76,6 +76,10 @@
       "description": "Owner of the group",
       "type": "string"
     },
+    "notes": {
+      "title": "Notes",
+      "type": "string"
+    },
     "iambic_managed": {
       "description": "Controls the directionality of Iambic changes",
       "default": "undefined",
@@ -572,6 +576,11 @@
               "$ref": "#/definitions/PolicyStatement"
             }
           ]
+        },
+        "id": {
+          "title": "Id",
+          "description": "The Id element specifies an optional identifier for the policy. The ID is used differently in different services.",
+          "type": "string"
         }
       },
       "required": [

--- a/docs/web/docs/3-reference/3-schemas/aws_iam_group_template.mdx
+++ b/docs/web/docs/3-reference/3-schemas/aws_iam_group_template.mdx
@@ -21,6 +21,7 @@ configurations for other models used in IAMbic.*
 - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
 - **`template_type`** *(string)*: Default: `"NOQ::AWS::IAM::Group"`.
 - **`owner`** *(string)*: Owner of the group.
+- **`notes`** *(string)*
 - **`iambic_managed`**: Controls the directionality of Iambic changes. Default: `"undefined"`.
   - **All of**
     - : Refer to *[#/definitions/IambicManaged](#definitions/IambicManaged)*.
@@ -169,6 +170,7 @@ configurations for other models used in IAMbic. Cannot contain additional proper
       - *array*
         - **Items**: Refer to *[#/definitions/PolicyStatement](#definitions/PolicyStatement)*.
       - : Refer to *[#/definitions/PolicyStatement](#definitions/PolicyStatement)*.
+  - **`id`** *(string)*: The Id element specifies an optional identifier for the policy. The ID is used differently in different services.
 
 <a id="definitions/GroupProperties"></a>
 

--- a/docs/web/docs/3-reference/3-schemas/aws_iam_managed_policy_template.json
+++ b/docs/web/docs/3-reference/3-schemas/aws_iam_managed_policy_template.json
@@ -75,6 +75,10 @@
       "title": "Owner",
       "type": "string"
     },
+    "notes": {
+      "title": "Notes",
+      "type": "string"
+    },
     "iambic_managed": {
       "description": "Controls the directionality of Iambic changes",
       "default": "undefined",

--- a/docs/web/docs/3-reference/3-schemas/aws_iam_managed_policy_template.mdx
+++ b/docs/web/docs/3-reference/3-schemas/aws_iam_managed_policy_template.mdx
@@ -21,6 +21,7 @@ configurations for other models used in IAMbic.*
 - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
 - **`template_type`** *(string)*: Default: `"NOQ::AWS::IAM::ManagedPolicy"`.
 - **`owner`** *(string)*
+- **`notes`** *(string)*
 - **`iambic_managed`**: Controls the directionality of Iambic changes. Default: `"undefined"`.
   - **All of**
     - : Refer to *[#/definitions/IambicManaged](#definitions/IambicManaged)*.

--- a/docs/web/docs/3-reference/3-schemas/aws_iam_role_template.json
+++ b/docs/web/docs/3-reference/3-schemas/aws_iam_role_template.json
@@ -76,6 +76,10 @@
       "description": "Owner of the role",
       "type": "string"
     },
+    "notes": {
+      "title": "Notes",
+      "type": "string"
+    },
     "iambic_managed": {
       "description": "Controls the directionality of Iambic changes",
       "default": "undefined",
@@ -919,6 +923,11 @@
               "$ref": "#/definitions/PolicyStatement"
             }
           ]
+        },
+        "id": {
+          "title": "Id",
+          "description": "The Id element specifies an optional identifier for the policy. The ID is used differently in different services.",
+          "type": "string"
         }
       },
       "required": [

--- a/docs/web/docs/3-reference/3-schemas/aws_iam_role_template.mdx
+++ b/docs/web/docs/3-reference/3-schemas/aws_iam_role_template.mdx
@@ -21,6 +21,7 @@ configurations for other models used in IAMbic.*
 - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
 - **`template_type`** *(string)*: Default: `"NOQ::AWS::IAM::Role"`.
 - **`owner`** *(string)*: Owner of the role.
+- **`notes`** *(string)*
 - **`iambic_managed`**: Controls the directionality of Iambic changes. Default: `"undefined"`.
   - **All of**
     - : Refer to *[#/definitions/IambicManaged](#definitions/IambicManaged)*.
@@ -260,6 +261,7 @@ configurations for other models used in IAMbic. Cannot contain additional proper
       - *array*
         - **Items**: Refer to *[#/definitions/PolicyStatement](#definitions/PolicyStatement)*.
       - : Refer to *[#/definitions/PolicyStatement](#definitions/PolicyStatement)*.
+  - **`id`** *(string)*: The Id element specifies an optional identifier for the policy. The ID is used differently in different services.
 
 <a id="definitions/RoleProperties"></a>
 

--- a/docs/web/docs/3-reference/3-schemas/aws_iam_user_template.json
+++ b/docs/web/docs/3-reference/3-schemas/aws_iam_user_template.json
@@ -75,6 +75,10 @@
       "title": "Owner",
       "type": "string"
     },
+    "notes": {
+      "title": "Notes",
+      "type": "string"
+    },
     "iambic_managed": {
       "description": "Controls the directionality of Iambic changes",
       "default": "undefined",
@@ -843,6 +847,11 @@
               "$ref": "#/definitions/PolicyStatement"
             }
           ]
+        },
+        "id": {
+          "title": "Id",
+          "description": "The Id element specifies an optional identifier for the policy. The ID is used differently in different services.",
+          "type": "string"
         }
       },
       "required": [

--- a/docs/web/docs/3-reference/3-schemas/aws_iam_user_template.mdx
+++ b/docs/web/docs/3-reference/3-schemas/aws_iam_user_template.mdx
@@ -21,6 +21,7 @@ configurations for other models used in IAMbic.*
 - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
 - **`template_type`** *(string)*: Default: `"NOQ::AWS::IAM::User"`.
 - **`owner`** *(string)*
+- **`notes`** *(string)*
 - **`iambic_managed`**: Controls the directionality of Iambic changes. Default: `"undefined"`.
   - **All of**
     - : Refer to *[#/definitions/IambicManaged](#definitions/IambicManaged)*.
@@ -236,6 +237,7 @@ configurations for other models used in IAMbic. Cannot contain additional proper
       - *array*
         - **Items**: Refer to *[#/definitions/PolicyStatement](#definitions/PolicyStatement)*.
       - : Refer to *[#/definitions/PolicyStatement](#definitions/PolicyStatement)*.
+  - **`id`** *(string)*: The Id element specifies an optional identifier for the policy. The ID is used differently in different services.
 
 <a id="definitions/UserProperties"></a>
 

--- a/docs/web/docs/3-reference/3-schemas/aws_identity_center_permission_set_template.json
+++ b/docs/web/docs/3-reference/3-schemas/aws_identity_center_permission_set_template.json
@@ -36,6 +36,10 @@
       "description": "Owner of the permission set",
       "type": "string"
     },
+    "notes": {
+      "title": "Notes",
+      "type": "string"
+    },
     "iambic_managed": {
       "description": "Controls the directionality of Iambic changes",
       "default": "undefined",

--- a/docs/web/docs/3-reference/3-schemas/aws_identity_center_permission_set_template.mdx
+++ b/docs/web/docs/3-reference/3-schemas/aws_identity_center_permission_set_template.mdx
@@ -13,6 +13,7 @@ configurations for other models used in IAMbic.*
 - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
 - **`template_type`** *(string)*: Default: `"NOQ::AWS::IdentityCenter::PermissionSet"`.
 - **`owner`** *(string)*: Owner of the permission set.
+- **`notes`** *(string)*
 - **`iambic_managed`**: Controls the directionality of Iambic changes. Default: `"undefined"`.
   - **All of**
     - : Refer to *[#/definitions/IambicManaged](#definitions/IambicManaged)*.

--- a/docs/web/docs/3-reference/3-schemas/awsorganization.json
+++ b/docs/web/docs/3-reference/3-schemas/awsorganization.json
@@ -87,7 +87,7 @@
     "preferred_spoke_role_name": {
       "title": "Preferred Spoke Role Name",
       "description": "SpokeRoleName use across organization",
-      "default": "IambicSpokeRoleCurtis",
+      "default": "IambicSpokeRole",
       "type": "string"
     }
   },

--- a/docs/web/docs/3-reference/3-schemas/awsorganization.mdx
+++ b/docs/web/docs/3-reference/3-schemas/awsorganization.mdx
@@ -21,7 +21,7 @@
 - **`account_rules`** *(array)*: A list of rules used to determine how organization accounts are handled. Default: `[]`.
   - **Items**: Refer to *[#/definitions/AWSOrgAccountRule](#definitions/AWSOrgAccountRule)*.
 - **`spoke_role_is_read_only`** *(boolean)*: if true, the spoke role will be limited to read-only permissions. Default: `false`.
-- **`preferred_spoke_role_name`** *(string)*: SpokeRoleName use across organization. Default: `"IambicSpokeRoleCurtis"`.
+- **`preferred_spoke_role_name`** *(string)*: SpokeRoleName use across organization. Default: `"IambicSpokeRole"`.
 ## Definitions
 
 

--- a/docs/web/docs/3-reference/3-schemas/azure_active_directory_group_template.json
+++ b/docs/web/docs/3-reference/3-schemas/azure_active_directory_group_template.json
@@ -13,6 +13,10 @@
       "description": "Owner of the group",
       "type": "string"
     },
+    "notes": {
+      "title": "Notes",
+      "type": "string"
+    },
     "iambic_managed": {
       "description": "Controls the directionality of Iambic changes",
       "default": "undefined",
@@ -320,8 +324,7 @@
       },
       "required": [
         "name"
-      ],
-      "additionalProperties": false
+      ]
     }
   }
 }

--- a/docs/web/docs/3-reference/3-schemas/azure_active_directory_group_template.mdx
+++ b/docs/web/docs/3-reference/3-schemas/azure_active_directory_group_template.mdx
@@ -7,6 +7,7 @@ configurations for other models used in IAMbic.*
 
 - **`template_type`** *(string)*: Default: `"NOQ::AzureAD::Group"`.
 - **`owner`** *(string)*: Owner of the group.
+- **`notes`** *(string)*
 - **`iambic_managed`**: Controls the directionality of Iambic changes. Default: `"undefined"`.
   - **All of**
     - : Refer to *[#/definitions/IambicManaged](#definitions/IambicManaged)*.
@@ -48,7 +49,7 @@ configurations for other models used in IAMbic. Cannot contain additional proper
 <a id="definitions/GroupTemplateProperties"></a>
 
 - **`GroupTemplateProperties`** *(object)*: A base model class that provides additional helper methods and
-configurations for other models used in IAMbic. Cannot contain additional properties.
+configurations for other models used in IAMbic.
   - **`expires_at`**: The date and time the resource will be/was set to deleted.
     - **Any of**
       - *string*

--- a/docs/web/docs/3-reference/3-schemas/azure_active_directory_user_template.json
+++ b/docs/web/docs/3-reference/3-schemas/azure_active_directory_user_template.json
@@ -12,6 +12,10 @@
       "title": "Owner",
       "type": "string"
     },
+    "notes": {
+      "title": "Notes",
+      "type": "string"
+    },
     "iambic_managed": {
       "description": "Controls the directionality of Iambic changes",
       "default": "undefined",
@@ -203,8 +207,7 @@
       "required": [
         "username",
         "display_name"
-      ],
-      "additionalProperties": false
+      ]
     }
   }
 }

--- a/docs/web/docs/3-reference/3-schemas/azure_active_directory_user_template.mdx
+++ b/docs/web/docs/3-reference/3-schemas/azure_active_directory_user_template.mdx
@@ -7,6 +7,7 @@ configurations for other models used in IAMbic.*
 
 - **`template_type`** *(string)*: Default: `"NOQ::AzureAD::User"`.
 - **`owner`** *(string)*
+- **`notes`** *(string)*
 - **`iambic_managed`**: Controls the directionality of Iambic changes. Default: `"undefined"`.
   - **All of**
     - : Refer to *[#/definitions/IambicManaged](#definitions/IambicManaged)*.
@@ -34,7 +35,7 @@ configurations for other models used in IAMbic.*
 <a id="definitions/UserTemplateProperties"></a>
 
 - **`UserTemplateProperties`** *(object)*: A base model class that provides additional helper methods and
-configurations for other models used in IAMbic. Cannot contain additional properties.
+configurations for other models used in IAMbic.
   - **`expires_at`**: The date and time the resource will be/was set to deleted.
     - **Any of**
       - *string*

--- a/docs/web/docs/3-reference/3-schemas/config.json
+++ b/docs/web/docs/3-reference/3-schemas/config.json
@@ -12,6 +12,10 @@
       "title": "Owner",
       "type": "string"
     },
+    "notes": {
+      "title": "Notes",
+      "type": "string"
+    },
     "iambic_managed": {
       "description": "Controls the directionality of Iambic changes",
       "default": "undefined",
@@ -32,27 +36,27 @@
       "default": [
         {
           "type": "DIRECTORY_PATH",
-          "location": "/home/ccastrapel/localrepos/iambic/iambic/plugins/v0_1_0/aws",
+          "location": "/Users/ccastrapel/localrepos/iambic/iambic/plugins/v0_1_0/aws",
           "version": "v0.1.0"
         },
         {
           "type": "DIRECTORY_PATH",
-          "location": "/home/ccastrapel/localrepos/iambic/iambic/plugins/v0_1_0/google_workspace",
+          "location": "/Users/ccastrapel/localrepos/iambic/iambic/plugins/v0_1_0/google_workspace",
           "version": "v0.1.0"
         },
         {
           "type": "DIRECTORY_PATH",
-          "location": "/home/ccastrapel/localrepos/iambic/iambic/plugins/v0_1_0/okta",
+          "location": "/Users/ccastrapel/localrepos/iambic/iambic/plugins/v0_1_0/okta",
           "version": "v0.1.0"
         },
         {
           "type": "DIRECTORY_PATH",
-          "location": "/home/ccastrapel/localrepos/iambic/iambic/plugins/v0_1_0/github",
+          "location": "/Users/ccastrapel/localrepos/iambic/iambic/plugins/v0_1_0/github",
           "version": "v0.1.0"
         },
         {
           "type": "DIRECTORY_PATH",
-          "location": "/home/ccastrapel/localrepos/iambic/iambic/plugins/v0_1_0/azure_ad",
+          "location": "/Users/ccastrapel/localrepos/iambic/iambic/plugins/v0_1_0/azure_ad",
           "version": "v0.1.0"
         }
       ],

--- a/docs/web/docs/3-reference/3-schemas/config.mdx
+++ b/docs/web/docs/3-reference/3-schemas/config.mdx
@@ -7,11 +7,12 @@ configurations for other models used in IAMbic.*
 
 - **`template_type`** *(string)*: Default: `"NOQ::Core::Config"`.
 - **`owner`** *(string)*
+- **`notes`** *(string)*
 - **`iambic_managed`**: Controls the directionality of Iambic changes. Default: `"undefined"`.
   - **All of**
     - : Refer to *[#/definitions/IambicManaged](#definitions/IambicManaged)*.
 - **`version`** *(string)*: Do not change! The version of iambic this repo is compatible with.
-- **`plugins`** *(array)*: The plugins used by your IAMbic template repo. Default: `[{"type": "DIRECTORY_PATH", "location": "/home/ccastrapel/localrepos/iambic/iambic/plugins/v0_1_0/aws", "version": "v0.1.0"}, {"type": "DIRECTORY_PATH", "location": "/home/ccastrapel/localrepos/iambic/iambic/plugins/v0_1_0/google_workspace", "version": "v0.1.0"}, {"type": "DIRECTORY_PATH", "location": "/home/ccastrapel/localrepos/iambic/iambic/plugins/v0_1_0/okta", "version": "v0.1.0"}, {"type": "DIRECTORY_PATH", "location": "/home/ccastrapel/localrepos/iambic/iambic/plugins/v0_1_0/github", "version": "v0.1.0"}, {"type": "DIRECTORY_PATH", "location": "/home/ccastrapel/localrepos/iambic/iambic/plugins/v0_1_0/azure_ad", "version": "v0.1.0"}]`.
+- **`plugins`** *(array)*: The plugins used by your IAMbic template repo. Default: `[{"type": "DIRECTORY_PATH", "location": "/Users/ccastrapel/localrepos/iambic/iambic/plugins/v0_1_0/aws", "version": "v0.1.0"}, {"type": "DIRECTORY_PATH", "location": "/Users/ccastrapel/localrepos/iambic/iambic/plugins/v0_1_0/google_workspace", "version": "v0.1.0"}, {"type": "DIRECTORY_PATH", "location": "/Users/ccastrapel/localrepos/iambic/iambic/plugins/v0_1_0/okta", "version": "v0.1.0"}, {"type": "DIRECTORY_PATH", "location": "/Users/ccastrapel/localrepos/iambic/iambic/plugins/v0_1_0/github", "version": "v0.1.0"}, {"type": "DIRECTORY_PATH", "location": "/Users/ccastrapel/localrepos/iambic/iambic/plugins/v0_1_0/azure_ad", "version": "v0.1.0"}]`.
   - **Items**: Refer to *[#/definitions/PluginDefinition](#definitions/PluginDefinition)*.
 - **`extends`** *(array)*: Default: `[]`.
   - **Items**: Refer to *[#/definitions/ExtendsConfig](#definitions/ExtendsConfig)*.

--- a/docs/web/docs/3-reference/3-schemas/github_config.json
+++ b/docs/web/docs/3-reference/3-schemas/github_config.json
@@ -37,6 +37,37 @@
       "description": "Commit message to use during changes through git-apply",
       "default": "Replace relative time with absolute time",
       "type": "string"
+    },
+    "allowed_bot_approvers": {
+      "title": "Allowed Bot Approvers",
+      "description": "list of allowed bot approver",
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/GithubBotApprover"
+      }
+    }
+  },
+  "definitions": {
+    "GithubBotApprover": {
+      "title": "GithubBotApprover",
+      "type": "object",
+      "properties": {
+        "login": {
+          "title": "Login",
+          "description": "login for allowed bot approver",
+          "type": "string"
+        },
+        "es256_pub_key": {
+          "title": "Es256 Pub Key",
+          "description": "ES256 Pub Key for allowed bot approver",
+          "type": "string"
+        }
+      },
+      "required": [
+        "login",
+        "es256_pub_key"
+      ]
     }
   }
 }

--- a/docs/web/docs/3-reference/3-schemas/github_config.mdx
+++ b/docs/web/docs/3-reference/3-schemas/github_config.mdx
@@ -8,3 +8,13 @@
 - **`commit_message_for_import`** *(string)*: Commit message to use during changes through import operations. Default: `"Import changes from import operation"`.
 - **`commit_message_for_expire`** *(string)*: Commit message to use during changes through expire operations. Default: `"Periodic Expiration"`.
 - **`commit_message_for_git_apply`** *(string)*: Commit message to use during changes through git-apply. Default: `"Replace relative time with absolute time"`.
+- **`allowed_bot_approvers`** *(array)*: list of allowed bot approver. Default: `[]`.
+  - **Items**: Refer to *[#/definitions/GithubBotApprover](#definitions/GithubBotApprover)*.
+## Definitions
+
+
+<a id="definitions/GithubBotApprover"></a>
+
+- **`GithubBotApprover`** *(object)*
+  - **`login`** *(string)*: login for allowed bot approver.
+  - **`es256_pub_key`** *(string)*: ES256 Pub Key for allowed bot approver.

--- a/docs/web/docs/3-reference/3-schemas/google_workspace_group_template.json
+++ b/docs/web/docs/3-reference/3-schemas/google_workspace_group_template.json
@@ -36,6 +36,10 @@
       "description": "Owner of the group",
       "type": "string"
     },
+    "notes": {
+      "title": "Notes",
+      "type": "string"
+    },
     "iambic_managed": {
       "description": "Controls the directionality of Iambic changes",
       "default": "undefined",
@@ -80,7 +84,8 @@
       "enum": [
         "USER",
         "GROUP",
-        "EXTERNAL"
+        "EXTERNAL",
+        "CUSTOMER"
       ]
     },
     "GroupMemberStatus": {
@@ -90,7 +95,8 @@
         "ACTIVE",
         "INACTIVE",
         "PENDING",
-        "UNDEFINED"
+        "UNDEFINED",
+        "SUSPENDED"
       ]
     },
     "GroupMemberSubscription": {
@@ -133,6 +139,12 @@
         },
         "email": {
           "title": "Email",
+          "description": "Email address. However, when the type is CUSTOMER, it represents all users in a domain",
+          "type": "string"
+        },
+        "customer_id": {
+          "title": "Customerid",
+          "description": "When the type is CUSTOMER, it represents customer id of a domain",
           "type": "string"
         },
         "expand": {
@@ -174,9 +186,6 @@
           ]
         }
       },
-      "required": [
-        "email"
-      ],
       "additionalProperties": false
     },
     "WhoCanInvite": {

--- a/docs/web/docs/3-reference/3-schemas/google_workspace_group_template.mdx
+++ b/docs/web/docs/3-reference/3-schemas/google_workspace_group_template.mdx
@@ -13,6 +13,7 @@ configurations for other models used in IAMbic.*
 - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
 - **`template_type`** *(string)*: Default: `"NOQ::GoogleWorkspace::Group"`.
 - **`owner`** *(string)*: Owner of the group.
+- **`notes`** *(string)*
 - **`iambic_managed`**: Controls the directionality of Iambic changes. Default: `"undefined"`.
   - **All of**
     - : Refer to *[#/definitions/IambicManaged](#definitions/IambicManaged)*.
@@ -30,11 +31,11 @@ configurations for other models used in IAMbic.*
 
 <a id="definitions/GroupMemberType"></a>
 
-- **`GroupMemberType`**: An enumeration. Must be one of: `["USER", "GROUP", "EXTERNAL"]`.
+- **`GroupMemberType`**: An enumeration. Must be one of: `["USER", "GROUP", "EXTERNAL", "CUSTOMER"]`.
 
 <a id="definitions/GroupMemberStatus"></a>
 
-- **`GroupMemberStatus`**: An enumeration. Must be one of: `["ACTIVE", "INACTIVE", "PENDING", "UNDEFINED"]`.
+- **`GroupMemberStatus`**: An enumeration. Must be one of: `["ACTIVE", "INACTIVE", "PENDING", "UNDEFINED", "SUSPENDED"]`.
 
 <a id="definitions/GroupMemberSubscription"></a>
 
@@ -50,7 +51,8 @@ configurations for other models used in IAMbic. Cannot contain additional proper
       - *string*
       - *string*
   - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
-  - **`email`** *(string)*
+  - **`email`** *(string)*: Email address. However, when the type is CUSTOMER, it represents all users in a domain.
+  - **`customer_id`** *(string)*: When the type is CUSTOMER, it represents customer id of a domain.
   - **`expand`** *(boolean)*: Expand the group into the members of the group. This is useful for nested groups. Default: `false`.
   - **`role`**: Default: `"MEMBER"`.
     - **All of**

--- a/docs/web/docs/3-reference/3-schemas/okta_app_template.json
+++ b/docs/web/docs/3-reference/3-schemas/okta_app_template.json
@@ -36,6 +36,10 @@
       "description": "Owner of the app",
       "type": "string"
     },
+    "notes": {
+      "title": "Notes",
+      "type": "string"
+    },
     "iambic_managed": {
       "description": "Controls the directionality of Iambic changes",
       "default": "undefined",

--- a/docs/web/docs/3-reference/3-schemas/okta_app_template.mdx
+++ b/docs/web/docs/3-reference/3-schemas/okta_app_template.mdx
@@ -13,6 +13,7 @@ configurations for other models used in IAMbic.*
 - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
 - **`template_type`** *(string)*: Default: `"NOQ::Okta::App"`.
 - **`owner`** *(string)*: Owner of the app.
+- **`notes`** *(string)*
 - **`iambic_managed`**: Controls the directionality of Iambic changes. Default: `"undefined"`.
   - **All of**
     - : Refer to *[#/definitions/IambicManaged](#definitions/IambicManaged)*.

--- a/docs/web/docs/3-reference/3-schemas/okta_group_template.json
+++ b/docs/web/docs/3-reference/3-schemas/okta_group_template.json
@@ -36,6 +36,10 @@
       "description": "Owner of the group",
       "type": "string"
     },
+    "notes": {
+      "title": "Notes",
+      "type": "string"
+    },
     "iambic_managed": {
       "description": "Controls the directionality of Iambic changes",
       "default": "undefined",
@@ -225,6 +229,7 @@
         "group_id": {
           "title": "Groupid",
           "description": "Unique Group ID for the group. This value is imported by IAMbic, and doesn't need to be manually set.",
+          "default": "",
           "type": "string"
         },
         "description": {

--- a/docs/web/docs/3-reference/3-schemas/okta_group_template.mdx
+++ b/docs/web/docs/3-reference/3-schemas/okta_group_template.mdx
@@ -13,6 +13,7 @@ configurations for other models used in IAMbic.*
 - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
 - **`template_type`** *(string)*: Default: `"NOQ::Okta::Group"`.
 - **`owner`** *(string)*: Owner of the group.
+- **`notes`** *(string)*
 - **`iambic_managed`**: Controls the directionality of Iambic changes. Default: `"undefined"`.
   - **All of**
     - : Refer to *[#/definitions/IambicManaged](#definitions/IambicManaged)*.
@@ -68,7 +69,7 @@ configurations for other models used in IAMbic. Cannot contain additional proper
       - *string*
   - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
   - **`name`** *(string)*: Name of the group.
-  - **`group_id`** *(string)*: Unique Group ID for the group. This value is imported by IAMbic, and doesn't need to be manually set.
+  - **`group_id`** *(string)*: Unique Group ID for the group. This value is imported by IAMbic, and doesn't need to be manually set. Default: `""`.
   - **`description`** *(string)*: Description of the group. Default: `""`.
   - **`extra`**: Extra attributes to store.
   - **`members`** *(array)*: Users in the group. Default: `[]`.

--- a/docs/web/docs/3-reference/3-schemas/okta_user_template.json
+++ b/docs/web/docs/3-reference/3-schemas/okta_user_template.json
@@ -35,6 +35,10 @@
       "title": "Owner",
       "type": "string"
     },
+    "notes": {
+      "title": "Notes",
+      "type": "string"
+    },
     "iambic_managed": {
       "description": "Controls the directionality of Iambic changes",
       "default": "undefined",
@@ -103,6 +107,7 @@
         "user_id": {
           "title": "Userid",
           "description": "Unique User ID for the user. This value is imported by IAMbic, and doesn't need to be manually set.",
+          "default": "",
           "type": "string"
         },
         "status": {

--- a/docs/web/docs/3-reference/3-schemas/okta_user_template.mdx
+++ b/docs/web/docs/3-reference/3-schemas/okta_user_template.mdx
@@ -13,6 +13,7 @@ configurations for other models used in IAMbic.*
 - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
 - **`template_type`** *(string)*: Default: `"NOQ::Okta::User"`.
 - **`owner`** *(string)*
+- **`notes`** *(string)*
 - **`iambic_managed`**: Controls the directionality of Iambic changes. Default: `"undefined"`.
   - **All of**
     - : Refer to *[#/definitions/IambicManaged](#definitions/IambicManaged)*.
@@ -35,7 +36,7 @@ configurations for other models used in IAMbic.*
 - **`UserProperties`** *(object)*: A base model class that provides additional helper methods and
 configurations for other models used in IAMbic.
   - **`username`** *(string)*: Username of the user.
-  - **`user_id`** *(string)*: Unique User ID for the user. This value is imported by IAMbic, and doesn't need to be manually set.
+  - **`user_id`** *(string)*: Unique User ID for the user. This value is imported by IAMbic, and doesn't need to be manually set. Default: `""`.
   - **`status`**: Status of the user. Default: `"active"`.
     - **All of**
       - : Refer to *[#/definitions/UserStatus](#definitions/UserStatus)*.

--- a/iambic/plugins/v0_1_0/google_workspace/group/models.py
+++ b/iambic/plugins/v0_1_0/google_workspace/group/models.py
@@ -47,7 +47,14 @@ GOOGLE_GROUP_TEMPLATE_TYPE = "NOQ::GoogleWorkspace::Group"
 
 
 class GroupMember(BaseModel, ExpiryModel):
-    email: str
+    email: Optional[str] = Field(
+        None,
+        description="Email address. However, when the type is CUSTOMER, it represents all users in a domain",
+    )
+    customer_id: Optional[str] = Field(
+        None,
+        description="When the type is CUSTOMER, it represents customer id of a domain",
+    )
     expand: bool = Field(
         False,
         description="Expand the group into the members of the group. This is useful for nested groups.",
@@ -63,7 +70,10 @@ class GroupMember(BaseModel, ExpiryModel):
 
     @property
     def resource_id(self):
-        return self.email
+        if self.type == GroupMemberType.CUSTOMER:
+            return self.customer_id
+        else:
+            return self.email
 
 
 class GroupProperties(BaseModel):
@@ -95,7 +105,7 @@ class GroupProperties(BaseModel):
 
     @validator("members")
     def sort_groups(cls, v: list[GroupMember]):
-        sorted_v = sorted(v, key=lambda member: member.email)
+        sorted_v = sorted(v, key=lambda member: member.email or member.customer_id)
         return sorted_v
 
 

--- a/iambic/plugins/v0_1_0/google_workspace/group/utils.py
+++ b/iambic/plugins/v0_1_0/google_workspace/group/utils.py
@@ -317,7 +317,7 @@ async def maybe_delete_group(
     return response
 
 
-async def get_group_members(service, group):
+def create_group_member_from_dict(d):
     from iambic.plugins.v0_1_0.google_workspace.group.models import (
         GroupMember,
         GroupMemberRole,
@@ -325,12 +325,29 @@ async def get_group_members(service, group):
         GroupMemberType,
     )
 
+    if d["type"] == "CUSTOMER":
+        return GroupMember(
+            customer_id=d["id"],
+            role=GroupMemberRole(d["role"]),
+            type=GroupMemberType(d["type"]),
+            status=GroupMemberStatus(d.get("status", GroupMemberStatus.UNDEFINED)),
+        )
+    else:
+        return GroupMember(
+            email=d["email"],
+            role=GroupMemberRole(d["role"]),
+            type=GroupMemberType(d["type"]),
+            status=GroupMemberStatus(d.get("status", GroupMemberStatus.UNDEFINED)),
+        )
+
+
+async def get_group_members(service, group):
     http = _auth.authorized_http(service._http.credentials)
     group_email_address = group["email"]
     member_req = service.members().list(groupKey=group_email_address)
     member_res = member_req.execute(http=http) or {}
     members = member_res.get("members", [])
-    required_keys = ["email", "role", "type"]
+    required_keys = ["role", "type"]
     # validate response data because we have reports that member without email address
     for member in members:
         missing_required_keys = set(required_keys) - set(member.keys())
@@ -338,15 +355,7 @@ async def get_group_members(service, group):
             raise ValueError(
                 f"for google group: {group_email_address} missing keys: {missing_required_keys} for member: {member}"
             )
-    return [
-        GroupMember(
-            email=member["email"],
-            role=GroupMemberRole(member["role"]),
-            type=GroupMemberType(member["type"]),
-            status=GroupMemberStatus(member.get("status", GroupMemberStatus.UNDEFINED)),
-        )
-        for member in members
-    ]
+    return [create_group_member_from_dict(member) for member in members]
 
 
 async def update_group_members(
@@ -371,11 +380,13 @@ async def update_group_members(
         log.exception("Unable to process google groups.", error=err)
         return
 
-    if users_to_remove := [
-        member
-        for member in current_members
-        if member.email not in [m.email for m in proposed_members]
-    ]:
+    current_members_keys_to_members = {m.resource_id: m for m in current_members}
+    proposed_members_keys_to_members = {m.resource_id: m for m in proposed_members}
+    keys_to_remove = set(current_members_keys_to_members.keys()) - set(
+        proposed_members_keys_to_members.keys()
+    )
+    users_to_remove = [current_members_keys_to_members[k] for k in keys_to_remove]
+    if users_to_remove:
         log_str = "Detected users to remove from group"
         response.append(
             ProposedChange(
@@ -384,31 +395,34 @@ async def update_group_members(
                 resource_type="google:group:template",
                 attribute="users",
                 change_summary={
-                    "UsersToRemove": [user.email for user in users_to_remove]
+                    "UsersToRemove": [user.resource_id for user in users_to_remove]
                 },
-                current_value=[user.email for user in current_members],
-                new_value=[user.email for user in proposed_members],
+                current_value=[user.resource_id for user in current_members],
+                new_value=[user.resource_id for user in proposed_members],
             )
         )
         if ctx.execute:
             log_str = "Removing users from group"
             for user in users_to_remove:
                 http = _auth.authorized_http(service._http.credentials)
+                member_key = user.email if user.email else user.customer_id
                 tasks.append(
                     aio_wrapper(
                         service.members()
-                        .delete(groupKey=group_email, memberKey=user.email)
+                        .delete(groupKey=group_email, memberKey=member_key)
                         .execute,
                         http=http,
                     )
                 )
-        log.info(log_str, users=[user.email for user in users_to_remove], **log_params)
+        log.info(
+            log_str, users=[user.resource_id for user in users_to_remove], **log_params
+        )
 
-    if users_to_add := [
-        member
-        for member in proposed_members
-        if member.email not in [m.email for m in current_members]
-    ]:
+    keys_to_add = set(proposed_members_keys_to_members.keys()) - set(
+        current_members_keys_to_members.keys()
+    )
+    users_to_add = [proposed_members_keys_to_members[k] for k in keys_to_add]
+    if users_to_add:
         log_str = "Detected new users to add to group"
         response.append(
             ProposedChange(
@@ -417,32 +431,39 @@ async def update_group_members(
                 resource_type="google:group:template",
                 attribute="users",
                 change_summary={"UsersToAdd": [user.email for user in users_to_add]},
-                current_value=[user.email for user in current_members],
-                new_value=[user.email for user in proposed_members],
+                current_value=[user.resource_id for user in current_members],
+                new_value=[user.resource_id for user in proposed_members],
             )
         )
         if ctx.execute:
             log_str = "Adding users to group"
             for user in users_to_add:
                 http = _auth.authorized_http(service._http.credentials)
+                body = {
+                    "email": user.email,
+                    "role": user.role.value,
+                    "type": user.type.value,
+                }
+                if body["type"] == "CUSTOMER":
+                    del body[
+                        "email"
+                    ]  # email is not an supported attribute customer type
+                    body["id"] = user.customer_id
                 tasks.append(
                     aio_wrapper(
                         service.members()
                         .insert(
                             groupKey=group_email,
-                            body={
-                                "email": user.email,
-                                "role": user.role.value,
-                                "type": user.type.value,
-                                "status": user.status.value,
-                            },
+                            body=body,
                         )
                         .execute,
                         http=http,
                     )
                 )
 
-        log.info(log_str, users=[user.email for user in users_to_add], **log_params)
+        log.info(
+            log_str, users=[user.resource_id for user in users_to_add], **log_params
+        )
     if tasks:
         res = await asyncio.gather(*tasks, return_exceptions=True)
         for r in res:

--- a/iambic/plugins/v0_1_0/google_workspace/models.py
+++ b/iambic/plugins/v0_1_0/google_workspace/models.py
@@ -76,6 +76,7 @@ class GroupMemberType(Enum):
     USER = "USER"
     GROUP = "GROUP"
     EXTERNAL = "EXTERNAL"
+    CUSTOMER = "CUSTOMER"
 
 
 class GroupMemberStatus(Enum):


### PR DESCRIPTION
## What changed?
* CUSTOMER type represents the entire google workspace organization. 

## Rationale
* Without CUSTOMER type support, import on Google Workspace will crash. 

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [ ] Unit Tests
- [ ] Functional Tests
- [x] Manually Verified


import google group with customer type. add customer type as member, remove customer as member.