### PR TITLE
Update App Manifest to subscribe to Workflow run

### DIFF
--- a/docs/web/docs/1-getting_started/7-github.mdx
+++ b/docs/web/docs/1-getting_started/7-github.mdx
@@ -193,7 +193,7 @@ Permission explanation
 
 1. Modify `your_org_name` to your Github organization name and paste it into your browser.
 ```
-https://github.com/organizations/your_org_name/settings/apps/new?name=iambic-integration-for-your_org_name&description=iambic-github-integration&url=https%3A%2F%2Fnoq.dev%2F&webhook_active=false&events[]=meta&events[]=issue_comment&&events[]=pull_request&contents=write&pull_requests=write&issues=write
+https://github.com/organizations/your_org_name/settings/apps/new?name=iambic-integration-for-your_org_name&description=iambic-github-integration&url=https%3A%2F%2Fnoq.dev%2F&webhook_active=false&events[]=meta&events[]=issue_comment&&events[]=pull_request&events[]=workflow_run&contents=write&pull_requests=write&issues=write
 ```
 2. Click "Create GitHub App".
 3. Scroll down to "Private Keys".


### PR DESCRIPTION

## What changed?
* Update App Manifest to subscribe to Workflow run

## Rationale
* Workflow Run is needed and was missing from GitHub App Manifest

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [ ] Unit Tests
- [ ] Functional Tests
- [x] Manually Verified

To Test: 
1. Use the manifest url (remember to replace the org_name appropriately)
2. you need to add https://noq.dev/ and turn on webhook to verify later, then click create.
3. verify Workflow run is selected in the Permissions & events tab.