### PR TITLE
Fix #512 Handle FileNotFoundException

### DIFF
--- a/iambic/core/utils.py
+++ b/iambic/core/utils.py
@@ -139,10 +139,14 @@ async def resource_file_upsert(
 async def file_regex_search(
     file_path: Union[str, Path], re_pattern: str
 ) -> Union[str, None]:
-    async with aiofiles.open(file_path, mode="r") as f:
-        file_content = await f.read()
-        if re.search(re_pattern, file_content):
-            return file_path
+    try:
+        async with aiofiles.open(file_path, mode="r") as f:
+            file_content = await f.read()
+            if re.search(re_pattern, file_content):
+                return file_path
+    except FileNotFoundError:
+        # race condition with different providers
+        return None
 
 
 async def gather_templates(repo_dir: str, template_type: str = None) -> list[str]:


### PR DESCRIPTION
During import operation, each provider tries to find existing templates that matches their template types. However, those provider are run independently. So if one of them (Google Workspace provider) delete a Google Workspace Group template file (the checked in file is removed when the corresponding cloud resource is gone); another provider like (Okta) maybe in the middle of opening a file that is removed.

## What changed?
* Suppression FileNotFoundError

## Rationale
* file_regex_search is used across by different providers. Because different providers can run at the same on the same filesystem instance. It's possible provider A remove template type A, but provider B is still trying to local template type B in the same filesystem. 

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [ ] Unit Tests
- [ ] Functional Tests
- [x] Manually Verified
