### PR TITLE
Fix #520 Git commit message not reflecting the linting changes

### DIFF
--- a/iambic/request_handler/git_apply.py
+++ b/iambic/request_handler/git_apply.py
@@ -105,6 +105,61 @@ async def apply_git_changes(
     return template_changes
 
 
+async def lint_git_changes(
+    config_path: str,
+    repo_dir: str,
+    allow_dirty: bool = False,
+    from_sha: str = None,
+    to_sha: str = None,
+) -> list[TemplateChangeDetails]:
+    """Retrieves files added/updated/or removed when comparing the current branch to master
+
+    Works by taking the diff and adding implied changes to the templates that were modified.
+    These are the changes and this function detects:
+        Deleting a file
+        Removing 1 or more aws_accounts from included_accounts
+        Adding 1 or more aws_accounts to excluded_accounts
+
+    :param config_path:
+    :param repo_dir:
+    :param context:
+    :param allow_dirty:
+    :param from_sha:
+    :param to_sha:
+    :return:
+    """
+
+    config = await load_config(config_path)
+    file_changes = await retrieve_git_changes(
+        repo_dir,
+        config.template_map,
+        allow_dirty=allow_dirty,
+        from_sha=from_sha,
+        to_sha=to_sha,
+    )
+    if (
+        not file_changes["new_files"]
+        and not file_changes["modified_files"]
+        and not file_changes["deleted_files"]
+    ):
+        log.info("No changes found.")
+        return []
+
+    new_templates = load_templates(
+        [git_diff.path for git_diff in file_changes["new_files"]],
+        config.template_map,
+    )
+
+    modified_templates_doubles = create_templates_for_modified_files(
+        config,
+        file_changes["modified_files"],
+    )
+
+    for template in itertools.chain(new_templates, modified_templates_doubles):
+        # write always write in linted format
+        template.write()
+
+
 def commit_deleted_templates(
     repo_dir: str, templates: list[BaseTemplate], details: list[TemplateChangeDetails]
 ):


### PR DESCRIPTION
## What changed?
* Do a separate pass on listing before running apply
* Changes from linting are committed using message regarding listing

## Rationale
* Note: there is a problem to separately calling out relative time -> absolute because the relative is immediately normalize into absolute time during model loading.

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [ ] Unit Tests
- [ ] Functional Tests
- [x] Manually Verified

See https://github.com/noqdev/iambic-templates-itest/pull/316/commits