### PR TITLE
Fix #491 Support "merge", "squash", and "rebase" merge method

### DIFF
--- a/iambic/plugins/v0_1_0/github/github.py
+++ b/iambic/plugins/v0_1_0/github/github.py
@@ -447,13 +447,24 @@ def maybe_merge(
 ):
     """Attempts to merge the PR at specific sha, this function will retry a few times because
     desired sha maybe not available yet"""
+
+    merge_method = None
+    if templates_repo.allow_merge_commit:
+        merge_method = "merge"
+    elif templates_repo.allow_squash_merge:
+        merge_method = "squash"
+    elif templates_repo.allow_rebase_merge:
+        merge_method = "rebase"
+    else:
+        merge_method = "NOT_SUPPORTED"
+
     attempts = 0
     merge_status = None
     last_known_traceback = None
     while attempts < max_attempts:
         pull_request = templates_repo.get_pull(pull_number)
         try:
-            merge_status = pull_request.merge(sha=merge_sha)
+            merge_status = pull_request.merge(sha=merge_sha, merge_method=merge_method)
             break
         except github.GithubException:
             last_known_traceback = traceback.format_exc()

--- a/test/plugins/v0_1_0/github/test_github.py
+++ b/test/plugins/v0_1_0/github/test_github.py
@@ -492,7 +492,7 @@ def test_issue_comment_with_clean_mergeable_state_with_additional_commits(
     )
 
     # verify we are merging with the latest local repo sha
-    mock_pull_request.merge.assert_called_with(sha=post_sha)
+    mock_pull_request.merge.assert_called_with(sha=post_sha, merge_method="merge")
 
 
 def test_run_handler():


### PR DESCRIPTION
## What changed?
* Prefer "merge" > "squash" > "rebase"

## Rationale
* Use the repository setting to determine which merge method to use. Without this feature, we won't be able to support repository that restrict what merge method for the pull request.

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [x] Unit Tests
- [ ] Functional Tests
- [x] Manually Verified

We have tested against a repository that supports linear history + squash merge enabled: https://github.com/noqdev/iambic-templates-itest-linear-history/pull/1

We also have tested against a repository that support merge commits: https://github.com/noqdev/iambic-templates-itest/pull/317