### PR TITLE
Fixed bug where none type description was causing an exception on role

### DIFF
--- a/iambic/plugins/v0_1_0/aws/iam/role/models.py
+++ b/iambic/plugins/v0_1_0/aws/iam/role/models.py
@@ -339,10 +339,7 @@ class AwsIamRoleTemplate(AWSTemplate, AccessModel):
                             await boto_crud_call(
                                 client.update_role,
                                 RoleName=role_name,
-                                **{
-                                    k: account_role.get(k)
-                                    for k in supported_update_key_values.keys()
-                                },
+                                **update_role_params,
                             )
                         except Exception as e:
                             exceptions.append(str(e))
@@ -351,12 +348,12 @@ class AwsIamRoleTemplate(AWSTemplate, AccessModel):
                         for key in update_role_params.keys():
                             proposed_role_changes.append(
                                 ProposedChange(
-                                    attribute=supported_update_key_values[key],
+                                    attribute=key,
                                     change_type=ProposedChangeType.UPDATE,
                                     resource_id=role_name,
                                     resource_type=self.resource_type,
                                     exceptions_seen=exceptions,
-                                    current_value={key: current_role[key]},
+                                    current_value={key: current_role.get(key)},
                                     new_value={key: account_role[key]},
                                 )
                             )
@@ -368,11 +365,11 @@ class AwsIamRoleTemplate(AWSTemplate, AccessModel):
                     for key in update_role_params.keys():
                         account_change_details.proposed_changes.append(
                             ProposedChange(
-                                attribute=supported_update_key_values[key],
+                                attribute=key,
                                 change_type=ProposedChangeType.UPDATE,
                                 resource_id=role_name,
                                 resource_type=self.resource_type,
-                                current_value={key: current_role[key]},
+                                current_value={key: current_role.get(key)},
                                 new_value={key: account_role[key]},
                             )
                         )

--- a/iambic/plugins/v0_1_0/aws/iam/role/models.py
+++ b/iambic/plugins/v0_1_0/aws/iam/role/models.py
@@ -315,7 +315,7 @@ class AwsIamRoleTemplate(AWSTemplate, AccessModel):
                 "MaxSessionDuration": "max_session_duration",
             }
             update_resource_log_params = {**log_params}
-            update_role_params = {}
+            update_role_keys = set()
             for k in supported_update_key_values.keys():
                 if account_role.get(k) is not None and account_role.get(
                     k
@@ -323,9 +323,9 @@ class AwsIamRoleTemplate(AWSTemplate, AccessModel):
                     update_resource_log_params[k] = dict(
                         old_value=current_role.get(k), new_value=account_role.get(k)
                     )
-                    update_role_params[k] = current_role.get(k)
+                    update_role_keys.add(k)
 
-            if update_role_params:
+            if update_role_keys:
                 log_str = "Out of date resource found."
                 if ctx.execute:
                     log.debug(
@@ -339,13 +339,13 @@ class AwsIamRoleTemplate(AWSTemplate, AccessModel):
                             await boto_crud_call(
                                 client.update_role,
                                 RoleName=role_name,
-                                **update_role_params,
+                                **{key: account_role[key] for key in update_role_keys},
                             )
                         except Exception as e:
                             exceptions.append(str(e))
 
                         proposed_role_changes = []
-                        for key in update_role_params.keys():
+                        for key in update_role_keys:
                             proposed_role_changes.append(
                                 ProposedChange(
                                     attribute=key,
@@ -362,7 +362,7 @@ class AwsIamRoleTemplate(AWSTemplate, AccessModel):
                     tasks.append(update_role())
                 else:
                     log.debug(log_str, **update_resource_log_params)
-                    for key in update_role_params.keys():
+                    for key in update_role_keys:
                         account_change_details.proposed_changes.append(
                             ProposedChange(
                                 attribute=key,

--- a/iambic/plugins/v0_1_0/aws/iam/role/utils.py
+++ b/iambic/plugins/v0_1_0/aws/iam/role/utils.py
@@ -214,6 +214,14 @@ async def apply_role_tags(
 
         log.debug(log_str, tags=tags_to_remove, **log_params)
 
+        if tasks:
+            results: list[list[ProposedChange]] = await asyncio.gather(
+                *tasks, return_exceptions=True
+            )
+            for r in results:
+                response.extend(r)
+
+    tasks = []
     if tags_to_apply:
         log_str = "New tags discovered in AWS."
 


### PR DESCRIPTION
## What changed?
* Improved the way AWS IAM Role attributes are updated to fix a bug causing Roles with a None type description to throw an exception.

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [ ] Unit Tests
- [ ] Functional Tests
- [x] Manually Verified
