### PR TITLE
Handle multiple iam paths

### DIFF
--- a/iambic/plugins/v0_1_0/aws/iam/group/models.py
+++ b/iambic/plugins/v0_1_0/aws/iam/group/models.py
@@ -84,6 +84,17 @@ class AwsIamGroupTemplate(AWSTemplate, AccessModel):
         description="Properties of the group",
     )
 
+    def _apply_resource_dict(self, aws_account: AWSAccount = None) -> dict:
+        response = super(AwsIamGroupTemplate, self)._apply_resource_dict(aws_account)
+        # Ensure only 1 of the following objects
+        # TODO: Have this handled in a cleaner way. Maybe via an attribute on a pydantic field
+        for flat_key in {"Path"}:
+            if isinstance(response.get(flat_key), list):
+                response[flat_key] = response[flat_key][0]
+                if nested_val := response[flat_key].get(flat_key):
+                    response[flat_key] = nested_val
+        return response
+
     def _is_iambic_import_only(self):
         return "aws-service-group" in self.properties.path
 

--- a/iambic/plugins/v0_1_0/aws/iam/group/template_generation.py
+++ b/iambic/plugins/v0_1_0/aws/iam/group/template_generation.py
@@ -86,6 +86,8 @@ def get_templated_group_file_path(
         .lower()
     )
 
+    # stitch desired location together
+    os_paths = [group_dir, separator]
     # using path components from path attribute
     if group_path:
         group_path_components = group_path.split("/")
@@ -93,10 +95,7 @@ def get_templated_group_file_path(
         group_path_components = [
             component for component in group_path_components if component
         ]
-
-    # stitch desired location together
-    os_paths = [group_dir, separator]
-    os_paths.extend(group_path_components)
+        os_paths.extend(group_path_components)
     os_paths.append(f"{file_name}.yaml")
 
     return str(os.path.join(*os_paths))
@@ -359,7 +358,7 @@ async def create_templated_group(  # noqa: C901
         group_dir,
         group_name,
         group_template_params.get("included_accounts"),
-        group_path=path,
+        group_path=path if isinstance(path, str) else None,
     )
     return create_or_update_template(
         file_path,

--- a/iambic/plugins/v0_1_0/aws/iam/models.py
+++ b/iambic/plugins/v0_1_0/aws/iam/models.py
@@ -9,7 +9,7 @@ from iambic.plugins.v0_1_0.aws.models import ARN_RE, AccessModel
 
 
 class Path(AccessModel):
-    file_path: str = Field(..., hidden_from_schema=True)
+    path: str = Field(..., hidden_from_schema=True)
 
     @property
     def resource_type(self) -> str:
@@ -17,7 +17,7 @@ class Path(AccessModel):
 
     @property
     def resource_id(self) -> str:
-        return self.file_path
+        return self.path
 
 
 class MaxSessionDuration(AccessModel):

--- a/iambic/plugins/v0_1_0/aws/iam/policy/models.py
+++ b/iambic/plugins/v0_1_0/aws/iam/policy/models.py
@@ -316,15 +316,19 @@ class AwsIamManagedPolicyTemplate(AWSTemplate, AccessModel):
         return f"arn:{aws_account.partition.value}:iam::{aws_account.account_id}:policy{path}{policy_name}"
 
     def _apply_resource_dict(self, aws_account: AWSAccount = None) -> dict:
-        resource_dict = super()._apply_resource_dict(aws_account)
-        resource_dict["Arn"] = self.get_arn_for_account(aws_account)
+        response = super()._apply_resource_dict(aws_account)
+        response.setdefault("Tags", [])
+        response["Arn"] = self.get_arn_for_account(aws_account)
 
-        if policy_document := resource_dict.pop("PolicyDocument", []):
-            if isinstance(policy_document, list):
-                policy_document = policy_document[0]
-            resource_dict["PolicyDocument"] = policy_document
+        # Ensure only 1 of the following objects
+        # TODO: Have this handled in a cleaner way. Maybe via an attribute on a pydantic field
+        for flat_key in {"Path", "PolicyDocument"}:
+            if isinstance(response.get(flat_key), list):
+                response[flat_key] = response[flat_key][0]
+                if nested_val := response[flat_key].get(flat_key):
+                    response[flat_key] = nested_val
 
-        return resource_dict
+        return response
 
     async def _apply_to_account(self, aws_account: AWSAccount) -> AccountChangeDetails:
         client = await aws_account.get_boto3_client("iam")

--- a/iambic/plugins/v0_1_0/aws/iam/policy/template_generation.py
+++ b/iambic/plugins/v0_1_0/aws/iam/policy/template_generation.py
@@ -84,6 +84,8 @@ def get_templated_managed_policy_file_path(
         .lower()
     )
 
+    # stitch desired location together
+    os_paths = [managed_policy_dir, separator]
     # using path components from path attribute
     if managed_policy_path:
         managed_policy_path_components = managed_policy_path.split("/")
@@ -91,10 +93,7 @@ def get_templated_managed_policy_file_path(
         managed_policy_path_components = [
             component for component in managed_policy_path_components if component
         ]
-
-    # stitch desired location together
-    os_paths = [managed_policy_dir, separator]
-    os_paths.extend(managed_policy_path_components)
+        os_paths.extend(managed_policy_path_components)
     os_paths.append(f"{file_name}.yaml")
 
     return str(os.path.join(*os_paths))
@@ -358,7 +357,7 @@ async def create_templated_managed_policy(  # noqa: C901
         managed_policy_name,
         template_params.get("included_accounts"),
         aws_account_map,
-        managed_policy_path=path,
+        managed_policy_path=path if isinstance(path, str) else None,
     )
     return create_or_update_template(
         file_path,

--- a/iambic/plugins/v0_1_0/aws/iam/role/template_generation.py
+++ b/iambic/plugins/v0_1_0/aws/iam/role/template_generation.py
@@ -88,6 +88,8 @@ def get_templated_role_file_path(
         .lower()
     )
 
+    # stitch desired location together
+    os_paths = [role_dir, separator]
     # using path components from path attribute
     if role_path:
         role_path_components = role_path.split("/")
@@ -95,10 +97,7 @@ def get_templated_role_file_path(
         role_path_components = [
             component for component in role_path_components if component
         ]
-
-    # stitch desired location together
-    os_paths = [role_dir, separator]
-    os_paths.extend(role_path_components)
+        os_paths.extend(role_path_components)
     os_paths.append(f"{file_name}.yaml")
 
     return str(os.path.join(*os_paths))
@@ -467,7 +466,7 @@ async def create_templated_role(  # noqa: C901
         role_dir,
         role_name,
         role_template_params.get("included_accounts"),
-        role_path=path,
+        role_path=path if isinstance(path, str) else None,
     )
     try:
         return create_or_update_template(

--- a/iambic/plugins/v0_1_0/aws/iam/user/models.py
+++ b/iambic/plugins/v0_1_0/aws/iam/user/models.py
@@ -140,16 +140,15 @@ class AwsIamUserTemplate(AWSTemplate, AccessModel):
 
     def _apply_resource_dict(self, aws_account: AWSAccount = None) -> dict:
         response = super(AwsIamUserTemplate, self)._apply_resource_dict(aws_account)
-        if "Tags" not in response:
-            response["Tags"] = []
+        response.setdefault("Tags", [])
 
-        if permissions_boundary := response.pop("PermissionsBoundary", []):
-            if isinstance(permissions_boundary, list):
-                permissions_boundary = permissions_boundary[0]
-            response["PermissionsBoundary"] = permissions_boundary
-
-        if isinstance(response.get("Description"), list):
-            response["Description"] = response["Description"][0]["Description"]
+        # Ensure only 1 of the following objects
+        # TODO: Have this handled in a cleaner way. Maybe via an attribute on a pydantic field
+        for flat_key in {"Description", "PermissionsBoundary", "Path"}:
+            if isinstance(response.get(flat_key), list):
+                response[flat_key] = response[flat_key][0]
+                if nested_val := response[flat_key].get(flat_key):
+                    response[flat_key] = nested_val
 
         return response
 

--- a/iambic/plugins/v0_1_0/aws/iam/user/template_generation.py
+++ b/iambic/plugins/v0_1_0/aws/iam/user/template_generation.py
@@ -83,6 +83,8 @@ def get_templated_user_file_path(
         .lower()
     )
 
+    # stitch desired location together
+    os_paths = [user_dir, separator]
     # using path components from path attribute
     if user_path:
         user_path_components = user_path.split("/")
@@ -90,10 +92,7 @@ def get_templated_user_file_path(
         user_path_components = [
             component for component in user_path_components if component
         ]
-
-    # stitch desired location together
-    os_paths = [user_dir, separator]
-    os_paths.extend(user_path_components)
+        os_paths.extend(user_path_components)
     os_paths.append(f"{file_name}.yaml")
 
     return str(os.path.join(*os_paths))
@@ -436,7 +435,7 @@ async def create_templated_user(  # noqa: C901
         user_dir,
         user_name,
         user_template_params.get("included_accounts"),
-        user_path=path,
+        user_path=path if isinstance(path, str) else None,
     )
     return create_or_update_template(
         file_path,

--- a/iambic/plugins/v0_1_0/aws/tests/test_models.py
+++ b/iambic/plugins/v0_1_0/aws/tests/test_models.py
@@ -73,7 +73,7 @@ class TestBaseModel(unittest.TestCase):
                     included_accounts=["not_test_account"], max_session_duration=600
                 ),
             ],
-            path=[Path(file_path="/")],
+            path=[Path(path="/")],
         )
         self.role_template = AwsIamRoleTemplate(
             identifier="test_role",

--- a/test/plugins/v0_1_0/aws/iam/group/test_models.py
+++ b/test/plugins/v0_1_0/aws/iam/group/test_models.py
@@ -5,8 +5,8 @@ from iambic.plugins.v0_1_0.aws.iam.group.models import GroupProperties
 
 def test_user_path_validation():
     path = [
-        {"included_accounts": ["account_1", "account_2"], "file_path": "/engineering"},
-        {"included_accounts": ["account_3"], "file_path": "/finance"},
+        {"included_accounts": ["account_1", "account_2"], "path": "/engineering"},
+        {"included_accounts": ["account_3"], "path": "/finance"},
     ]
     properties_1 = GroupProperties(group_name="foo", path=path)
     path_1 = properties_1.path

--- a/test/plugins/v0_1_0/aws/iam/policy/test_models.py
+++ b/test/plugins/v0_1_0/aws/iam/policy/test_models.py
@@ -146,8 +146,8 @@ def test_merge_policy_document_without_sid(aws_accounts):
 
 def test_policy_path_validation():
     path = [
-        {"included_accounts": ["account_1", "account_2"], "file_path": "/engineering"},
-        {"included_accounts": ["account_3"], "file_path": "/finance"},
+        {"included_accounts": ["account_1", "account_2"], "path": "/engineering"},
+        {"included_accounts": ["account_3"], "path": "/finance"},
     ]
     properties_1 = ManagedPolicyProperties(
         policy_name="foo", path=path, policy_document={}

--- a/test/plugins/v0_1_0/aws/iam/role/test_models.py
+++ b/test/plugins/v0_1_0/aws/iam/role/test_models.py
@@ -732,8 +732,8 @@ def test_role_permissions_boundary_validation():
 
 def test_role_path_validation():
     path = [
-        {"included_accounts": ["account_1", "account_2"], "file_path": "/engineering"},
-        {"included_accounts": ["account_3"], "file_path": "/finance"},
+        {"included_accounts": ["account_1", "account_2"], "path": "/engineering"},
+        {"included_accounts": ["account_3"], "path": "/finance"},
     ]
     properties_1 = RoleProperties(role_name="foo", path=path)
     path_1 = properties_1.path

--- a/test/plugins/v0_1_0/aws/iam/user/test_models.py
+++ b/test/plugins/v0_1_0/aws/iam/user/test_models.py
@@ -68,8 +68,8 @@ def test_user_properties_sorting():
 
 def test_user_path_validation():
     path = [
-        {"included_accounts": ["account_1", "account_2"], "file_path": "/engineering"},
-        {"included_accounts": ["account_3"], "file_path": "/finance"},
+        {"included_accounts": ["account_1", "account_2"], "path": "/engineering"},
+        {"included_accounts": ["account_3"], "path": "/finance"},
     ]
     properties_1 = UserProperties(user_name="foo", path=path)
     path_1 = properties_1.path


### PR DESCRIPTION
## What changed?
Fixed import behavior when an IAM resource has a different path across accounts. 
Fixed _apply_resource_dict handling when an IAM resource has a different path across accounts. 
Refactor of Path.file_path -> Path.path

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [x] Unit Tests
- [x] Functional Tests
- [x] Manually Verified (Import, Create, and Delete w/ multiple Paths)
