### PR TITLE
Verify GitHub access before proceeding

### DIFF
--- a/iambic/plugins/v0_1_0/github/create_github_app.py
+++ b/iambic/plugins/v0_1_0/github/create_github_app.py
@@ -57,6 +57,13 @@ def run_local_webserver():
     web.run_app(app, host="localhost", port=8080, print=False)
 
 
+def has_github_app_secrets_locally():
+    full_path = os.path.expanduser(SAVE_DIR)
+    os.makedirs(full_path, exist_ok=True)
+    full_path = f"{full_path}/.github_secrets.yaml"
+    return os.path.exists(full_path)
+
+
 def get_github_app_secrets():
     full_path = os.path.expanduser(SAVE_DIR)
     os.makedirs(full_path, exist_ok=True)

--- a/iambic/plugins/v0_1_0/github/manage_github_app.py
+++ b/iambic/plugins/v0_1_0/github/manage_github_app.py
@@ -63,12 +63,12 @@ def verify_access(encoded_jwt):
     r = requests.get(control_plane_url, headers=head)
     if r.status_code == 401:
         log.error(
-            "Error code 401. Please verify your system time. If time is correct, you may need to remove ~/.iambic/.github_secrets.yaml"
+            "Error code 401. Please verify your system time. If time is correct, you may need to remove ~/.iambic/.github_secrets.yaml and restart the process"
         )
         return False
     elif r.status_code == 404:
         log.error(
-            "Error code 404. Your existing secrets is out-of-date. Please remove ~/.iambic/.github_secrets.yaml"
+            "Error code 404. Your existing secrets are out-of-date. Please remove ~/.iambic/.github_secrets.yaml"
         )
         return False
     try:

--- a/iambic/plugins/v0_1_0/github/manage_github_app.py
+++ b/iambic/plugins/v0_1_0/github/manage_github_app.py
@@ -51,3 +51,29 @@ def update_webhook_url(webhook_url, encoded_jwt):
     log.info(f"Update GitHub App url to {webhook_url}")
     r = requests.patch(control_plane_url, data=json.dumps(payload), headers=head)
     r.raise_for_status()
+
+
+def verify_access(encoded_jwt):
+    head = {
+        "Authorization": f"Bearer {encoded_jwt}",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    control_plane_url = "https://api.github.com/app/hook/config"
+
+    r = requests.get(control_plane_url, headers=head)
+    if r.status_code == 401:
+        log.error(
+            "Error code 401. Please verify your system time. If time is correct, you may need to remove ~/.iambic/.github_secrets.yaml"
+        )
+        return False
+    elif r.status_code == 404:
+        log.error(
+            "Error code 404. Your existing secrets is out-of-date. Please remove ~/.iambic/.github_secrets.yaml"
+        )
+        return False
+    try:
+        r.raise_for_status()
+    except Exception as e:
+        log.error(e)
+        return False
+    return True


### PR DESCRIPTION
## What changed?
* Check GitHub access before proceeding

## Rationale
* The local ~/.iambic/.github_secrets.yaml may be out of date. or the host time may be wrong (lead to JWT not valid). 

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [ ] Unit Tests
- [ ] Functional Tests
- [x] Manually Verified
