### PR TITLE
Fix issue when identity center details is lost during 2nd setup

### DIFF
--- a/iambic/plugins/v0_1_0/aws/models.py
+++ b/iambic/plugins/v0_1_0/aws/models.py
@@ -609,6 +609,39 @@ class AWSIdentityCenter(PydanticBaseModel):
     def region_name(self):
         return self.region if isinstance(self.region, str) else self.region.value
 
+    def dict(
+        self,
+        *,
+        include: Optional[
+            Union["AbstractSetIntStr", "MappingIntStrAny"]  # noqa
+        ] = None,
+        exclude: Optional[
+            Union["AbstractSetIntStr", "MappingIntStrAny"]  # noqa
+        ] = None,
+        by_alias: bool = False,
+        skip_defaults: Optional[bool] = None,
+        exclude_unset: bool = True,
+        exclude_defaults: bool = False,
+        exclude_none: bool = True,
+    ) -> "DictStrAny":  # noqa
+        # We have to override the original method to always
+        # write out the region value because it has a default
+        # Unfortunately, iambic dynamic config uses json/dict
+        # roundtrip during config sync. If the region value
+        # is not preserved, the identity center value is
+        # consider not setup.
+
+        resp = super(AWSIdentityCenter, self).dict(
+            include=include,
+            exclude=exclude,
+            by_alias=by_alias,
+            skip_defaults=skip_defaults,
+            exclude_unset=exclude_unset,
+            exclude_defaults=False,
+            exclude_none=exclude_none,
+        )
+        return resp
+
 
 class AWSOrganization(BaseAWSAccountAndOrgModel):
     org_name: Optional[str] = Field(
@@ -646,6 +679,10 @@ class AWSOrganization(BaseAWSAccountAndOrgModel):
         IAMBIC_SPOKE_ROLE_NAME,
         description="SpokeRoleName use across organization",
     )
+
+    # @validator("identity_center")
+    # def _validate_identity_center(c):
+    #     pass
 
     async def _create_org_account_instance(
         self, account: dict, session: boto3.Session

--- a/iambic/plugins/v0_1_0/aws/models.py
+++ b/iambic/plugins/v0_1_0/aws/models.py
@@ -680,10 +680,6 @@ class AWSOrganization(BaseAWSAccountAndOrgModel):
         description="SpokeRoleName use across organization",
     )
 
-    # @validator("identity_center")
-    # def _validate_identity_center(c):
-    #     pass
-
     async def _create_org_account_instance(
         self, account: dict, session: boto3.Session
     ) -> Optional[AWSAccount]:


### PR DESCRIPTION
## What changed?
* Always write out the AWSIdentityCenter defaults

## Rationale
* If we don't, we will lose the AWSIdenittyCenter during json/dict round-trip

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [ ] Unit Tests
- [ ] Functional Tests
- [x] Manually Verified

Without the change, run `iambic setup`, choose AWS, wait til log mention config sync. Check if identity center value is lost in config?

With the change, run `iambic setup`, choose AWS, wait til log mention config sync. Check if identity center is lost?