### PR TITLE
Fixed #526 Support both iambic and /iambic syntax

### DIFF
--- a/iambic/plugins/v0_1_0/github/github.py
+++ b/iambic/plugins/v0_1_0/github/github.py
@@ -20,7 +20,7 @@ from cryptography.hazmat.primitives import serialization
 from github.PullRequest import PullRequest
 
 import iambic.output.markdown
-from iambic.config.dynamic_config import load_config
+from iambic.config.dynamic_config import CURRENT_IAMBIC_VERSION, load_config
 from iambic.config.utils import resolve_config_template_path
 from iambic.core.context import ctx
 from iambic.core.git import Repo, clone_git_repo, get_remote_default_branch
@@ -636,6 +636,24 @@ def handle_iambic_approve(
             )
         )
         raise e
+
+
+def handle_iambic_version(
+    context: dict[str, Any],
+    github_client: github.Github,
+    templates_repo: github.Repo,
+    pull_request: PullRequest,
+    repo_name: str,
+    pull_number: str,
+    pull_request_branch_name: str,
+    repo_url: str,
+    proposed_changes_path: str = None,
+    comment_user_login: str = None,
+    comment: str = None,
+):
+    pull_request.create_issue_comment(
+        f"`iambic-core` is at version `{CURRENT_IAMBIC_VERSION}`"
+    )
 
 
 def github_app_workflow_wrapper(workflow_func: Callable, ux_op_name: str) -> Callable:

--- a/iambic/plugins/v0_1_0/github/github_app.py
+++ b/iambic/plugins/v0_1_0/github/github_app.py
@@ -34,6 +34,7 @@ from iambic.plugins.v0_1_0.github.github import (
     handle_iambic_approve,
     handle_iambic_git_apply,
     handle_iambic_git_plan,
+    handle_iambic_version,
     iambic_app,
 )
 
@@ -383,12 +384,21 @@ EVENT_DISPATCH_MAP: dict[str, Callable] = {
 }
 
 
+# We are supporting both "iambic" and "/iambic"
+# for now during transition.
 COMMENT_DISPATCH_MAP: dict[str, Callable] = {
     "iambic git-apply": handle_iambic_git_apply,
+    "/iambic git-apply": handle_iambic_git_apply,
     "iambic git-plan": handle_iambic_git_plan,
+    "/iambic git-plan": handle_iambic_git_plan,
     "iambic apply": handle_iambic_git_apply,
+    "/iambic apply": handle_iambic_git_apply,
     "iambic plan": handle_iambic_git_plan,
+    "/iambic plan": handle_iambic_git_plan,
     "iambic approve": handle_iambic_approve,
+    "/iambic approve": handle_iambic_approve,
+    "iambic version": handle_iambic_version,
+    "/iambic version": handle_iambic_version,
 }
 
 WORKFLOW_DISPATCH_MAP: dict[str, Callable] = {


### PR DESCRIPTION
## What changed?
* Support both iambic and /iambic syntax
* Support "iambic version in GitHub comments

## Rationale
* During the transition, supports both `iambic` and `/iambic`
* Support `/iambic version` in PR comments

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [ ] Unit Tests
- [ ] Functional Tests
- [x] Manually Verified

See https://github.com/noqdev/iambic-templates-itest/pull/314#issuecomment-1664883364 for example