### PR TITLE
EN-2345 Runs lint before plan

### DIFF
--- a/dev_tools/simulate_github_lambda/simulate-github-lambda.py
+++ b/dev_tools/simulate_github_lambda/simulate-github-lambda.py
@@ -195,6 +195,9 @@ if __name__ == "__main__":
     ]
     queue = sqs.Queue(queue_url)
 
+    # to simulate lambda, we are pretending to be a lambda function
+    os.environ["AWS_LAMBDA_FUNCTION_NAME"] = "simulate-github-lambda.py"
+
     with patch(
         "iambic.plugins.v0_1_0.github.github_app._get_app_secrets_as_lambda_context_current",
         new=_get_app_secrets_as_lambda_context_current,

--- a/iambic/plugins/v0_1_0/github/github.py
+++ b/iambic/plugins/v0_1_0/github/github.py
@@ -540,9 +540,6 @@ def handle_iambic_git_plan(
             repo.remotes.origin.push(
                 refspec=f"HEAD:{pull_request_branch_name}"
             ).raise_if_error()
-            pull_request.create_issue_comment(
-                "Due to automatic lint, the pull request commits has been updated."
-            )
             return HandleIssueCommentReturnCode.LINTED
         else:
             log.debug("git_plan did not introduce linting changes")

--- a/iambic/plugins/v0_1_0/github/github.py
+++ b/iambic/plugins/v0_1_0/github/github.py
@@ -588,7 +588,7 @@ def handle_iambic_approve(
 
     try:
         repo_dir = get_lambda_repo_path()
-        _ = prepare_local_repo_for_new_commits(repo_url, repo_dir, "detect")
+        _ = prepare_local_repo_for_new_commits(repo_url, repo_dir, "approve")
         config_path = asyncio.run(resolve_config_template_path(repo_dir))
         # it's important to load the config from main branch
         # we want to guard against a requester directly changing the approver

--- a/iambic/plugins/v0_1_0/github/github_app.py
+++ b/iambic/plugins/v0_1_0/github/github_app.py
@@ -236,8 +236,9 @@ def run_handler(event=None, context=None):
     if f:
         f(github_override_token, github_client, webhook_payload)
     else:
-        log.error("no supported handler")
-        raise Exception("no supported handler")
+        # warning. what it means is we are getting events send to the lambda
+        # that we don't know how to handle.
+        log.warning(f"no supported handler for {github_client}")
 
 
 def handle_pull_request(

--- a/iambic/request_handler/git_apply.py
+++ b/iambic/request_handler/git_apply.py
@@ -7,6 +7,7 @@ import uuid
 from git import Repo
 
 from iambic.config.dynamic_config import load_config
+from iambic.core.context import ctx
 from iambic.core.git import (
     create_templates_for_deleted_files,
     create_templates_for_modified_files,
@@ -155,9 +156,17 @@ async def lint_git_changes(
         file_changes["modified_files"],
     )
 
+    old_command = ctx.command
+    old_eval_only = ctx.eval_only
+    ctx.command = Command.LINT
+    ctx.eval_only = True
+
     for template in itertools.chain(new_templates, modified_templates_doubles):
         # write always write in linted format
         template.write()
+
+    ctx.command = old_command
+    ctx.eval_only = old_eval_only
 
 
 def commit_deleted_templates(

--- a/test/plugins/v0_1_0/github/test_github.py
+++ b/test/plugins/v0_1_0/github/test_github.py
@@ -194,6 +194,15 @@ def mock_lint_git_changes():
 
 
 @pytest.fixture
+def mock_commits():
+    with patch(
+        "iambic.plugins.v0_1_0.github.github.prepare_local_repo_for_new_commits",
+        autospec=True,
+    ) as _mock_commits:
+        yield _mock_commits
+
+
+@pytest.fixture
 def mock_repository():
     with patch("iambic.core.git.Repo", autospec=True) as _mock_repository:
         yield _mock_repository
@@ -222,8 +231,6 @@ def test_issue_comment_with_not_applicable_comment_body(
 def test_issue_comment_with_clean_mergeable_state(
     mock_github_client,
     issue_comment_git_apply_context,
-    mock_lint_git_changes,
-    mock_resolve_config_template_path,
     mock_run_git_apply,
     mock_repository,
 ):
@@ -235,8 +242,6 @@ def test_issue_comment_with_clean_mergeable_state(
         issue_comment_git_apply_context["sha"]
     )
     handle_issue_comment(mock_github_client, issue_comment_git_apply_context)
-    assert mock_resolve_config_template_path.called
-    assert mock_lint_git_changes.called
     assert mock_run_git_apply.called
     assert mock_pull_request.merge.called
 
@@ -245,8 +250,6 @@ def test_issue_comment_with_clean_mergeable_state(
 def test_issue_comment_with_clean_mergeable_state_and_lambda_handler_crashed(
     mock_github_client,
     issue_comment_git_apply_context,
-    mock_lint_git_changes,
-    mock_resolve_config_template_path,
     mock_run_git_apply,
     mock_repository,
 ):
@@ -259,8 +262,6 @@ def test_issue_comment_with_clean_mergeable_state_and_lambda_handler_crashed(
     mock_run_git_apply.side_effect = Exception("unexpected failure")
     with pytest.raises(Exception):
         handle_issue_comment(mock_github_client, issue_comment_git_apply_context)
-    assert mock_resolve_config_template_path.called
-    assert mock_lint_git_changes.called
     assert mock_run_git_apply.called
     assert mock_pull_request.create_issue_comment.called
     assert "Traceback" in mock_pull_request.create_issue_comment.call_args[0][0]
@@ -271,6 +272,8 @@ def test_issue_comment_with_clean_mergeable_state_and_lambda_handler_crashed(
 def test_plan_issue_comment_with_clean_mergeable_state_and_lambda_handler_crashed(
     mock_github_client,
     issue_comment_git_plan_context,
+    mock_resolve_config_template_path,
+    mock_lint_git_changes,
     mock_run_git_plan,
     mock_repository,
 ):
@@ -283,6 +286,8 @@ def test_plan_issue_comment_with_clean_mergeable_state_and_lambda_handler_crashe
     mock_run_git_plan.side_effect = Exception("unexpected failure")
     with pytest.raises(Exception):
         handle_issue_comment(mock_github_client, issue_comment_git_plan_context)
+    assert mock_resolve_config_template_path.called
+    assert mock_lint_git_changes.called
     assert mock_run_git_plan.called
     assert mock_pull_request.create_issue_comment.called
     assert "Traceback" in mock_pull_request.create_issue_comment.call_args[0][0]
@@ -357,6 +362,8 @@ def test_get_session_name(repo_name, pr_number, expected_result):
 def test_issue_comment_with_git_plan(
     mock_github_client,
     issue_comment_git_plan_context,
+    mock_resolve_config_template_path,
+    mock_lint_git_changes,
     mock_run_git_plan,
     mock_repository,
 ):
@@ -367,6 +374,8 @@ def test_issue_comment_with_git_plan(
         issue_comment_git_plan_context["sha"]
     )
     handle_issue_comment(mock_github_client, issue_comment_git_plan_context)
+    assert mock_resolve_config_template_path.called
+    assert mock_lint_git_changes.called
     assert mock_run_git_plan.called
     assert not mock_pull_request.merge.called
 
@@ -377,11 +386,13 @@ def test_issue_comment_with_allowed_approver(
     mock_repository,
     mock_resolve_config_template_path,
     mock_load_config,
+    mock_commits,
 ):
     mock_pull_request = mock_github_client.get_repo.return_value.get_pull.return_value
     assert mock_repository
     assert mock_resolve_config_template_path
     assert mock_load_config
+    assert mock_commits
 
     approver: GithubBotApprover = (
         mock_load_config.side_effect.return_value.github.allowed_bot_approvers[0]
@@ -444,8 +455,10 @@ def test_issue_comment_with_not_allowed_approver(
     mock_repository,
     mock_resolve_config_template_path,
     mock_load_config,
+    mock_commits,
 ):
     mock_pull_request = mock_github_client.get_repo.return_value.get_pull.return_value
+    assert mock_commits
     assert mock_repository
     assert mock_resolve_config_template_path
     assert mock_load_config
@@ -459,8 +472,6 @@ def test_issue_comment_with_not_allowed_approver(
 def test_issue_comment_with_clean_mergeable_state_with_additional_commits(
     mock_github_client,
     issue_comment_git_apply_context,
-    mock_lint_git_changes,
-    mock_resolve_config_template_path,
     mock_run_git_apply,
     mock_repository,
 ):
@@ -480,8 +491,6 @@ def test_issue_comment_with_clean_mergeable_state_with_additional_commits(
     )
 
     handle_issue_comment(mock_github_client, issue_comment_git_apply_context)
-    assert mock_resolve_config_template_path.called
-    assert mock_lint_git_changes.called
     assert mock_run_git_apply.called
 
     # verify we did push back the changes to remote


### PR DESCRIPTION
## What changed?
* Runs lint before plan

## Rationale
* Runs lint before plan

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [ ] Unit Tests
- [ ] Functional Tests
- [x] Manually Verified

See https://github.com/noqdev/iambic-templates-itest/pull/321

How to replicate test? Open PR that re-order the template order and also a relative time change. Check that lint is run before plan. Check that the only change is a relative time -> absolute in iambic apply.