### PR TITLE
Addresses some of #490 Plan output improvement 

### DIFF
--- a/iambic/output/models.py
+++ b/iambic/output/models.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import pathlib
+from collections import defaultdict
 from typing import Any, Dict, List, Optional, Set
 
 from dictdiffer import diff
@@ -317,7 +318,12 @@ class ExceptionSummary(PydanticBaseModel):
 
 
 class ActionSummaries(PydanticBaseModel):
-    num_actions: Optional[int]
+    num_create_actions: Optional[int]
+    num_update_actions: Optional[int]
+    num_delete_actions: Optional[int]
+    num_attach_actions: Optional[int]
+    num_detach_actions: Optional[int]
+    num_unknown_actions: Optional[int]
     num_templates: Optional[int]
     num_accounts: Optional[int]
     num_exceptions: Optional[int]
@@ -331,9 +337,20 @@ class ActionSummaries(PydanticBaseModel):
             ActionSummary.compile_proposed_changes(changes, x)
             for x in list([e.value for e in ProposedChangeType])
         ]
-        instance.num_actions = sum(
-            [1 for x in instance.action_summaries if x.count > 0]
-        )
+
+        # Aggregate action type to counts
+        action_type_to_count = defaultdict(int)
+        for action_summary in instance.action_summaries:
+            count_so_far = action_type_to_count[action_summary.action]
+            count_so_far += action_summary.count
+            action_type_to_count[action_summary.action] = count_so_far
+        instance.num_create_actions = action_type_to_count["Create"]
+        instance.num_update_actions = action_type_to_count["Update"]
+        instance.num_delete_actions = action_type_to_count["Delete"]
+        instance.num_attach_actions = action_type_to_count["Attach"]
+        instance.num_detach_actions = action_type_to_count["Detach"]
+        instance.num_unknown_actions = action_type_to_count["Unknown"]
+
         instance.num_templates = sum(
             [len(x.templates) for x in instance.action_summaries]
         )

--- a/iambic/output/templates/github_summary.jinja2
+++ b/iambic/output/templates/github_summary.jinja2
@@ -1,6 +1,23 @@
 # IAMbic Summary
 ## Change Detection
-* {{ iambic.num_actions }} distinct actions.
+{% if iambic.num_create_actions > 0 -%}
+* {{ iambic.num_create_actions }} Create actions were recorded.
+{% endif -%}
+{% if iambic.num_update_actions > 0 -%}
+* {{ iambic.num_update_actions }} Update actions were recorded.
+{% endif -%}
+{% if iambic.num_delete_actions > 0 -%}
+* {{ iambic.num_delete_actions }} Delete actions were recorded.
+{% endif -%}
+{% if iambic.num_attach_actions > 0 -%}
+* {{ iambic.num_attach_actions }} Attach actions were recorded.
+{% endif -%}
+{% if iambic.num_detach_actions > 0 -%}
+* {{ iambic.num_detach_actions }} Detach actions were recorded.
+{% endif -%}
+{% if iambic.num_unknown_actions > 0 -%}
+* {{ iambic.num_unknown_actions }} Unknown actions were recorded.
+{% endif -%}
 * {{ iambic.num_templates }} templates with changes.
 * {{ iambic.num_accounts }} accounts affected.
 

--- a/iambic/output/templates/github_summary.jinja2
+++ b/iambic/output/templates/github_summary.jinja2
@@ -3,8 +3,11 @@
 * {{ iambic.num_actions }} distinct actions.
 * {{ iambic.num_templates }} templates with changes.
 * {{ iambic.num_accounts }} accounts affected.
+
+{% if iambic.num_exceptions > 0 -%}
 ## Exceptions
 * {{ iambic.num_exceptions }} exceptions were recorded.
+{% endif -%}
 
 {% if iambic.num_templates > 0 -%}
 

--- a/iambic/output/templates/text_file_summary.jinja2
+++ b/iambic/output/templates/text_file_summary.jinja2
@@ -2,12 +2,32 @@
 
 {{ "Change Detection" | rich_format("italic blue") }}
 
-* {{ iambic.num_actions | rich_format("blue") }} {{ "distinct actions." | rich_format("blue") }}
+{% if iambic.num_create_actions > 0 -%}
+* {{ iambic.num_create_actions | rich_format("blue") }} {{ "Create actions." | rich_format("blue") }}
+{% endif -%}
+{% if iambic.num_update_actions > 0 -%}
+* {{ iambic.num_update_actions | rich_format("blue") }} {{ "Update actions." | rich_format("blue") }}
+{% endif -%}
+{% if iambic.num_delete_actions > 0 -%}
+* {{ iambic.num_delete_actions | rich_format("blue") }} {{ "Delete actions." | rich_format("blue") }}
+{% endif -%}
+{% if iambic.num_attach_actions > 0 -%}
+* {{ iambic.num_attach_actions | rich_format("blue") }} {{ "Attach actions." | rich_format("blue") }}
+{% endif -%}
+{% if iambic.num_detach_actions > 0 -%}
+* {{ iambic.num_detach_actions | rich_format("blue") }} {{ "Detach actions." | rich_format("blue") }}
+{% endif -%}
+{% if iambic.num_unknown_actions > 0 -%}
+* {{ iambic.num_unknown_actions | rich_format("blue") }} {{ "Unknown actions." | rich_format("blue") }}
+{% endif -%}
 * {{ iambic.num_templates | rich_format("blue") }} {{ "templates with changes." | rich_format("blue") }}
 * {{ iambic.num_accounts | rich_format("blue") }} {{ "accounts affected." | rich_format("blue") }}
 
+{% if iambic.num_exceptions > 0 -%}
 {{ "Exceptions" | rich_format("italic blue") }}
 * {{ iambic.num_exceptions | rich_format("blue") }} {{ "exceptions were recorded." | rich_format("blue") }}
+{% endif -%}
+
 {% if iambic.num_templates > 0 -%}
 {{ "IAMbic Change Details" | rich_format("bold blue") }}
 {% for action_summary in iambic.action_summaries -%}

--- a/iambic/output/templates/text_screen_summary.jinja2
+++ b/iambic/output/templates/text_screen_summary.jinja2
@@ -2,12 +2,32 @@
 
 {{ "Change Detection" | rich_format("italic blue") }}
 
-* {{ iambic.num_actions | rich_format("blue") }} {{ "distinct actions." | rich_format("blue") }}
+{% if iambic.num_create_actions > 0 -%}
+* {{ iambic.num_create_actions | rich_format("blue") }} {{ "Create actions." | rich_format("blue") }}
+{% endif -%}
+{% if iambic.num_update_actions > 0 -%}
+* {{ iambic.num_update_actions | rich_format("blue") }} {{ "Update actions." | rich_format("blue") }}
+{% endif -%}
+{% if iambic.num_delete_actions > 0 -%}
+* {{ iambic.num_delete_actions | rich_format("blue") }} {{ "Delete actions." | rich_format("blue") }}
+{% endif -%}
+{% if iambic.num_attach_actions > 0 -%}
+* {{ iambic.num_attach_actions | rich_format("blue") }} {{ "Attach actions." | rich_format("blue") }}
+{% endif -%}
+{% if iambic.num_detach_actions > 0 -%}
+* {{ iambic.num_detach_actions | rich_format("blue") }} {{ "Detach actions." | rich_format("blue") }}
+{% endif -%}
+{% if iambic.num_unknown_actions > 0 -%}
+* {{ iambic.num_unknown_actions | rich_format("blue") }} {{ "Unknown actions." | rich_format("blue") }}
+{% endif -%}
 * {{ iambic.num_templates | rich_format("blue") }} {{ "templates with changes." | rich_format("blue") }}
 * {{ iambic.num_accounts | rich_format("blue") }} {{ "accounts affected." | rich_format("blue") }}
 
+{% if iambic.num_exceptions > 0 -%}
 {{ "Exceptions" | rich_format("italic blue") }}
 * {{ iambic.num_exceptions | rich_format("blue") }} {{ "exceptions were recorded." | rich_format("blue") }}
+{% endif -%}
+
 {% if iambic.num_templates > 0 -%}
 {{ "IAMbic Change Details" | rich_format("bold blue") }}
 {% for action_summary in iambic.action_summaries -%}

--- a/test/output/test_markdown_generator.py
+++ b/test/output/test_markdown_generator.py
@@ -14,11 +14,11 @@ from . import get_templates_mixed, get_update_template
     [
         (
             get_templates_mixed(),
-            ActionSummaries(num_accounts=10, num_actions=1, num_templates=2),
+            ActionSummaries(num_accounts=10, num_create_actions=11, num_templates=2),
         ),
         (
             get_update_template(),
-            ActionSummaries(num_accounts=1, num_actions=1, num_templates=1),
+            ActionSummaries(num_accounts=1, num_create_actions=2, num_templates=1),
         ),
     ],
 )
@@ -28,7 +28,7 @@ def test_get_template_data(
 ):
     template_data = get_template_data(template_change_details)
     assert template_data.num_accounts == expected_output.num_accounts
-    assert template_data.num_actions == expected_output.num_actions
+    assert template_data.num_create_actions == expected_output.num_create_actions
     assert template_data.num_templates == expected_output.num_templates
 
 
@@ -37,11 +37,11 @@ def test_get_template_data(
     [
         (
             get_templates_mixed(),
-            ActionSummaries(num_accounts=10, num_actions=1, num_templates=2),
+            ActionSummaries(num_accounts=10, num_create_actions=1, num_templates=2),
         ),
         (
             get_update_template(),
-            ActionSummaries(num_accounts=10, num_actions=1, num_templates=1),
+            ActionSummaries(num_accounts=10, num_create_actions=1, num_templates=1),
         ),
     ],
 )


### PR DESCRIPTION
## What changed?
* Only output the `Exception` section if there are exceptions
* Aggregate `Create`, `Update`, `Delete`, `Detach`, `Attach` actions instead of outputting just `n distinct actions`

## Rationale
* Address the usability suggestions from #490 

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [ ] Unit Tests
- [ ] Functional Tests
- [x] Manually Verified

See https://github.com/noqdev/iambic-templates-itest/pull/322