### PR TITLE
Fix #507 git apply exceptions is not properly reported in comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,29 @@
 
 # Change Log
 
+## 0.11.32 (Aug 8, 2023)
+
+ENHANCEMENTS:
+* Address part of #490. Name the hyperlink with more details [#549](https://github.com/noqdev/iambic/pull/549)
+* Added a template_schema_url to all IAMbic templates. [#534](https://github.com/noqdev/iambic/pull/534)
+* Addresses some of #490 Plan output improvement [#550](https://github.com/noqdev/iambic/pull/550)
+
+BUG FIXES:
+* EN-2345 Runs lint before plan [#547](https://github.com/noqdev/iambic/pull/547)
+* EN-2343: Show message when credentials are not provided  [#539](https://github.com/noqdev/iambic/pull/539)
+* Fix #489 Handle change_summary differently during rendering [#548](https://github.com/noqdev/iambic/pull/548)
+* Fix #507 git apply exceptions is not properly reported in comments [#554](https://github.com/noqdev/iambic/pull/554)
+
+DEV EXPERIENCE:
+* Track *.png and *.jpg using Git LFS [#551](https://github.com/noqdev/iambic/pull/551)
+
+
+THANKS:
+* `datfinesoul` for giving feedback on auto formatting and relative time -> absolute timestamp commits made by automation
+* `datfinesoul` on reporting plan output is incorrect [#489](https://github.com/noqdev/iambic/issues/489)
+* `datfinesoul` on giving feedback on the need of ease of use to lookup schema reference in templates
+* `mike.p` on community slack for reporting the issue when the PR contains invalid AWS principal during git apply cycle.
+
 ## 0.11.23 (Aug 4, 2023)
 
 DOCS:

--- a/iambic/output/models.py
+++ b/iambic/output/models.py
@@ -212,7 +212,7 @@ def get_applicable_changes(
         for proposed_change in getattr(template_change, attribute, []):
             if isinstance(proposed_change, AccountChangeDetails):
                 # If proposed change is a list of AccountChangeDetails, we need to iterate through those
-                for account_change in proposed_change.proposed_changes:
+                for account_change in getattr(proposed_change, attribute, []):
                     if account_change.change_type.value == proposed_change_type:
                         applicable_changes.add(
                             _get_annotated_change(

--- a/iambic/output/templates/github_summary.jinja2
+++ b/iambic/output/templates/github_summary.jinja2
@@ -122,6 +122,11 @@
                                     <td colspan="100%">{{ change.change.diff_plus_minus }}</td>
                                 </tr>
                                 {% endif -%}
+                                {% if change.change.exceptions_seen -%}
+                                <tr>
+                                    <td colspan="100%">{{ change.change.exceptions_seen }}</td>
+                                </tr>
+                                {% endif -%}
                             </tbody>
                         </table>
                         {% endfor -%}

--- a/iambic/plugins/v0_1_0/aws/iam/role/models.py
+++ b/iambic/plugins/v0_1_0/aws/iam/role/models.py
@@ -394,28 +394,31 @@ class AwsIamRoleTemplate(AWSTemplate, AccessModel):
                 ]["PolicyArn"]
 
             apply_awaitable = boto_crud_call(client.create_role, **account_role)
-            account_change_details.extend_changes(
-                await plugin_apply_wrapper(apply_awaitable, proposed_changes)
+            create_role_result = await plugin_apply_wrapper(
+                apply_awaitable, proposed_changes
             )
+            account_change_details.extend_changes(create_role_result)
 
-        tasks.extend(
-            [
-                apply_role_managed_policies(
-                    role_name,
-                    client,
-                    managed_policies,
-                    existing_managed_policies,
-                    log_params,
-                ),
-                apply_role_inline_policies(
-                    role_name,
-                    client,
-                    inline_policies,
-                    existing_inline_policies,
-                    log_params,
-                ),
-            ]
-        )
+            if not account_change_details.exceptions_seen:
+                # we can only proceed with the role creation is successful.
+                tasks.extend(
+                    [
+                        apply_role_managed_policies(
+                            role_name,
+                            client,
+                            managed_policies,
+                            existing_managed_policies,
+                            log_params,
+                        ),
+                        apply_role_inline_policies(
+                            role_name,
+                            client,
+                            inline_policies,
+                            existing_inline_policies,
+                            log_params,
+                        ),
+                    ]
+                )
 
         changes_made = await asyncio.gather(*tasks)
         if any(changes_made):

--- a/iambic/plugins/v0_1_0/aws/iam/role/models.py
+++ b/iambic/plugins/v0_1_0/aws/iam/role/models.py
@@ -399,26 +399,26 @@ class AwsIamRoleTemplate(AWSTemplate, AccessModel):
             )
             account_change_details.extend_changes(create_role_result)
 
-            if not account_change_details.exceptions_seen:
-                # we can only proceed with the role creation is successful.
-                tasks.extend(
-                    [
-                        apply_role_managed_policies(
-                            role_name,
-                            client,
-                            managed_policies,
-                            existing_managed_policies,
-                            log_params,
-                        ),
-                        apply_role_inline_policies(
-                            role_name,
-                            client,
-                            inline_policies,
-                            existing_inline_policies,
-                            log_params,
-                        ),
-                    ]
-                )
+        if not account_change_details.exceptions_seen:
+            # we can only proceed if we don't see other exceptions (like create exceptions).
+            tasks.extend(
+                [
+                    apply_role_managed_policies(
+                        role_name,
+                        client,
+                        managed_policies,
+                        existing_managed_policies,
+                        log_params,
+                    ),
+                    apply_role_inline_policies(
+                        role_name,
+                        client,
+                        inline_policies,
+                        existing_inline_policies,
+                        log_params,
+                    ),
+                ]
+            )
 
         changes_made = await asyncio.gather(*tasks)
         if any(changes_made):

--- a/test/plugins/v0_1_0/github/test_github.py
+++ b/test/plugins/v0_1_0/github/test_github.py
@@ -609,7 +609,7 @@ def mock_proposed_changes_filesystem():
 
     try:
         contents = """hello world"""
-        contents_path = f"{temp_templates_directory}/proposed_chagnes.yaml"
+        contents_path = f"{temp_templates_directory}/proposed_changes.yaml"
 
         with open(contents_path, "w") as f:
             f.write(contents)


### PR DESCRIPTION
## What changed?
* Fix exceptions propagation in Git Apply comment reporting
* Fix update_assume_role document exception handling
* Attach the machine json as well to gist
* Render exception in the Git Apply comment

## Rationale
* Exception reporting is not really happening correctly during git apply flow

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [ ] Unit Tests
- [ ] Functional Tests
- [x] Manually Verified

Test against this bad PR: https://github.com/noqdev/iambic-templates-itest/pull/323