### PR TITLE
Workaround for #557 Defer GUID resolution

### DIFF
--- a/functional_tests/aws/permission_set/test_update_template.py
+++ b/functional_tests/aws/permission_set/test_update_template.py
@@ -17,6 +17,7 @@ from iambic.plugins.v0_1_0.aws.identity_center.permission_set.models import (
     PermissionSetAccess,
 )
 from iambic.plugins.v0_1_0.aws.identity_center.permission_set.utils import (
+    WrapIdentityCenterStoreClient,
     get_permission_set_users_and_groups_as_access_rules,
 )
 
@@ -121,6 +122,14 @@ class UpdatePermissionSetTestCase(IsolatedAsyncioTestCase):
         )
 
         # test assignment
+        identity_store_client = await IAMBIC_TEST_DETAILS.identity_center_account.get_boto3_client(
+            "identitystore",
+            region_name=IAMBIC_TEST_DETAILS.identity_center_account.identity_center_details.region_name,
+        )
+        wrap_identity_store_client = WrapIdentityCenterStoreClient(
+            identity_store_client,
+            IAMBIC_TEST_DETAILS.identity_center_account.identity_center_details.identity_store_id,
+        )
 
         identity_center_client = await IAMBIC_TEST_DETAILS.identity_center_account.get_boto3_client(
             "sso-admin",
@@ -132,6 +141,7 @@ class UpdatePermissionSetTestCase(IsolatedAsyncioTestCase):
             "PermissionSetArn"
         ]
         cloud_access_rules = await get_permission_set_users_and_groups_as_access_rules(
+            wrap_identity_store_client,
             identity_center_client,
             IAMBIC_TEST_DETAILS.identity_center_account.identity_center_details.instance_arn,
             permission_set_arn,
@@ -146,6 +156,7 @@ class UpdatePermissionSetTestCase(IsolatedAsyncioTestCase):
         changes = await self.template.apply(IAMBIC_TEST_DETAILS.config.aws)
         screen_render_resource_changes([changes])
         cloud_access_rules = await get_permission_set_users_and_groups_as_access_rules(
+            wrap_identity_store_client,
             identity_center_client,
             IAMBIC_TEST_DETAILS.identity_center_account.identity_center_details.instance_arn,
             permission_set_arn,

--- a/iambic/plugins/v0_1_0/aws/identity_center/permission_set/models.py
+++ b/iambic/plugins/v0_1_0/aws/identity_center/permission_set/models.py
@@ -21,6 +21,7 @@ from iambic.core.models import (
 from iambic.core.utils import aio_wrapper, evaluate_on_provider, plugin_apply_wrapper
 from iambic.plugins.v0_1_0.aws.iam.policy.models import PolicyStatement
 from iambic.plugins.v0_1_0.aws.identity_center.permission_set.utils import (
+    WrapIdentityCenterStoreClient,
     apply_account_assignments,
     apply_permission_set_aws_managed_policies,
     apply_permission_set_customer_managed_policies,
@@ -413,6 +414,13 @@ class AwsIdentityCenterPermissionSetTemplate(
         :return:
         """
 
+        identity_store_client = await aws_account.get_boto3_client(
+            "identitystore", region_name=aws_account.identity_center_details.region_name
+        )
+        wrap_identity_store_client = WrapIdentityCenterStoreClient(
+            identity_store_client, aws_account.identity_center_details.identity_store_id
+        )
+
         identity_center_client = await aws_account.get_boto3_client(
             "sso-admin", region_name=aws_account.identity_center_details.region_name
         )
@@ -461,6 +469,7 @@ class AwsIdentityCenterPermissionSetTemplate(
 
             current_account_assignments = (
                 await get_permission_set_users_and_groups_as_access_rules(
+                    wrap_identity_store_client,
                     identity_center_client,
                     instance_arn,
                     permission_set_arn,

--- a/iambic/plugins/v0_1_0/aws/identity_center/permission_set/template_generation.py
+++ b/iambic/plugins/v0_1_0/aws/identity_center/permission_set/template_generation.py
@@ -23,6 +23,7 @@ from iambic.plugins.v0_1_0.aws.identity_center.permission_set.models import (
     PermissionSetProperties,
 )
 from iambic.plugins.v0_1_0.aws.identity_center.permission_set.utils import (
+    WrapIdentityCenterStoreClient,
     enrich_permission_set_details,
     get_permission_set_details,
     get_permission_set_users_and_groups,
@@ -107,6 +108,7 @@ async def gather_permission_set_names(
 
 
 async def generate_permission_set_resource_file(
+    wrap_identity_store_client,
     identity_center_client,
     account_id: str,
     instance_arn: str,
@@ -119,6 +121,7 @@ async def generate_permission_set_resource_file(
         identity_center_client, instance_arn, permission_set
     )
     permission_set["assignments"] = await get_permission_set_users_and_groups(
+        wrap_identity_store_client,
         identity_center_client,
         instance_arn,
         permission_set["PermissionSetArn"],
@@ -463,6 +466,12 @@ async def collect_aws_permission_sets(
         identity_center_client = await aws_account.get_boto3_client(
             "sso-admin", region_name=aws_account.identity_center_details.region_name
         )
+        identity_store_client = await aws_account.get_boto3_client(
+            "identitystore", region_name=aws_account.identity_center_details.region_name
+        )
+        wrap_identity_store_client = WrapIdentityCenterStoreClient(
+            identity_store_client, aws_account.identity_center_details.identity_store_id
+        )
 
         if permission_set_names:
             for name in permission_set_names:
@@ -472,6 +481,7 @@ async def collect_aws_permission_sets(
                     messages.append(
                         dict(
                             account_id=aws_account.account_id,
+                            wrap_identity_store_client=wrap_identity_store_client,
                             identity_center_client=identity_center_client,
                             instance_arn=instance_arn,
                             permission_set=permission_set,
@@ -487,6 +497,7 @@ async def collect_aws_permission_sets(
                 messages.append(
                     dict(
                         account_id=aws_account.account_id,
+                        wrap_identity_store_client=wrap_identity_store_client,
                         identity_center_client=identity_center_client,
                         instance_arn=instance_arn,
                         permission_set=permission_set,

--- a/iambic/plugins/v0_1_0/aws/identity_center/permission_set/utils.py
+++ b/iambic/plugins/v0_1_0/aws/identity_center/permission_set/utils.py
@@ -132,9 +132,9 @@ async def get_permission_set_users_and_groups(
 
     for account_assignments in all_account_assignments:
         for aa in account_assignments:
-            # FIXME
+            # Special case handling when identity_store using AD integrations
+            # cannot list users and groups ahead of time without filters.
             if aa["PrincipalId"] not in response[aa["PrincipalType"].lower()]:
-                "d-9067a5ad2b"
                 object_type = aa["PrincipalType"].lower()
 
                 if object_type == "user":
@@ -161,6 +161,8 @@ async def get_permission_set_users_and_groups(
                     }
                 else:
                     log.error(f"unknown object_type: {object_type}")
+            # End Special case handling when identity_store using AD integrations
+            # cannot list users and groups ahead of time without filters.
 
             response[aa["PrincipalType"].lower()][aa["PrincipalId"]]["accounts"].append(
                 aa["AccountId"]

--- a/iambic/plugins/v0_1_0/aws/identity_center/permission_set/utils.py
+++ b/iambic/plugins/v0_1_0/aws/identity_center/permission_set/utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from functools import cache
 from itertools import chain
 
 from botocore.exceptions import ClientError
@@ -35,6 +36,24 @@ async def get_permission_set_details(
             return {}
         else:
             raise
+
+
+class WrapIdentityCenterStoreClient(object):
+    def __init__(self, boto3_identity_center_store_client, store_id):
+        self.boto3_identity_center_store_client = boto3_identity_center_store_client
+        self.store_id = store_id
+
+    @cache
+    def describe_user(self, guid):
+        return self.boto3_identity_center_store_client.describe_user(
+            IdentityStoreId=self.store_id, UserId=guid
+        )
+
+    @cache
+    def describe_group(self, guid):
+        return self.boto3_identity_center_store_client.describe_group(
+            IdentityStoreId=self.store_id, GroupId=guid
+        )
 
 
 async def generate_permission_set_map(aws_accounts: list[AWSAccount], templates: list):
@@ -78,6 +97,7 @@ async def generate_permission_set_map(aws_accounts: list[AWSAccount], templates:
 
 
 async def get_permission_set_users_and_groups(
+    wrap_identity_store_client,
     identity_center_client,
     instance_arn: str,
     permission_set_arn: str,
@@ -112,6 +132,36 @@ async def get_permission_set_users_and_groups(
 
     for account_assignments in all_account_assignments:
         for aa in account_assignments:
+            # FIXME
+            if aa["PrincipalId"] not in response[aa["PrincipalType"].lower()]:
+                "d-9067a5ad2b"
+                object_type = aa["PrincipalType"].lower()
+
+                if object_type == "user":
+                    info = wrap_identity_store_client.describe_user(aa["PrincipalId"])
+                    user_name = info.get("UserName", "ERROR_UNABLE_TO_LOOKUP_USERNAME")
+                    display_name = info.get(
+                        "DisplayName", "ERROR_UNABLE_TO_LOOKUP_DISPLAYNAME"
+                    )
+                    response[aa["PrincipalType"].lower()][aa["PrincipalId"]] = {
+                        "accounts": [],
+                        "user_name": user_name,
+                        "display_name": display_name,
+                    }
+                elif object_type == "group":
+                    info = wrap_identity_store_client.describe_group(aa["PrincipalId"])
+                    group_id = info.get("GroupId", "ERROR_UNABLE_TO_LOOKUP_GROUPID")
+                    display_name = info.get(
+                        "DisplayName", "ERROR_UNABLE_TO_LOOKUP_DISPLAYNAME"
+                    )
+                    response[aa["PrincipalType"].lower()][aa["PrincipalId"]] = {
+                        "accounts": [],
+                        "group_id": group_id,
+                        "display_name": display_name,
+                    }
+                else:
+                    log.error(f"unknown object_type: {object_type}")
+
             response[aa["PrincipalType"].lower()][aa["PrincipalId"]]["accounts"].append(
                 aa["AccountId"]
             )
@@ -122,6 +172,7 @@ async def get_permission_set_users_and_groups(
 
 
 async def get_permission_set_users_and_groups_as_access_rules(
+    wrap_identity_center_store_client,
     identity_center_client,
     instance_arn: str,
     permission_set_arn: str,
@@ -131,7 +182,12 @@ async def get_permission_set_users_and_groups_as_access_rules(
 ) -> list[dict]:
     name_map = {"user": "UserName", "group": "DisplayName"}
     permission_set_users_and_groups = await get_permission_set_users_and_groups(
-        identity_center_client, instance_arn, permission_set_arn, user_map, group_map
+        wrap_identity_center_store_client,
+        identity_center_client,
+        instance_arn,
+        permission_set_arn,
+        user_map,
+        group_map,
     )
     response = []
 

--- a/iambic/plugins/v0_1_0/aws/models.py
+++ b/iambic/plugins/v0_1_0/aws/models.py
@@ -471,9 +471,6 @@ class AWSAccount(ProviderChild, BaseAWSAccountAndOrgModel):
                 for x in exceptions_seen:
                     log.error(x)
 
-            # technically, it will more like exceptions from the above flow
-            # so we will need to return_exceptions=True and handle exceptions parsing
-            users_and_groups = []  # FIXME to simulate we receive no results
             for user_or_group in users_and_groups:
                 if "Users" in user_or_group:
                     self.identity_center_details.user_map = {

--- a/iambic/plugins/v0_1_0/aws/models.py
+++ b/iambic/plugins/v0_1_0/aws/models.py
@@ -439,7 +439,6 @@ class AWSAccount(ProviderChild, BaseAWSAccountAndOrgModel):
                     for permission_set in permission_set_details
                 }
 
-            # FIXME to simulate no knowledge of users and groups
             tmp_users_and_groups = await asyncio.gather(
                 *[
                     legacy_paginated_search(

--- a/test/plugins/v0_1_0/aws/identity_center/permission_set/test_utils.py
+++ b/test/plugins/v0_1_0/aws/identity_center/permission_set/test_utils.py
@@ -76,6 +76,11 @@ class FakeAccount(ProviderChild):
 
 
 @pytest.fixture
+def mock_wrap_identity_center_store_client():
+    yield MagicMock()
+
+
+@pytest.fixture
 def mock_ssoadmin_client_bundle():
     with mock_ssoadmin():
         ssoadmin_client = boto3.client("sso-admin")
@@ -158,10 +163,13 @@ async def test_generate_permission_set_map(mock_ssoadmin_client_bundle: tuple):
 
 
 @pytest.mark.asyncio
-async def test_get_permission_set_users_and_groups(mock_ssoadmin_client_bundle: tuple):
+async def test_get_permission_set_users_and_groups(
+    mock_ssoadmin_client_bundle: tuple, mock_wrap_identity_center_store_client
+):
     mock_ssoadmin_client, permission_set_arn = mock_ssoadmin_client_bundle
 
     response = await get_permission_set_users_and_groups(
+        mock_wrap_identity_center_store_client,
         mock_ssoadmin_client,
         EXAMPLE_IDENTITY_CENTER_INSTANCE_ARN,
         permission_set_arn,
@@ -174,11 +182,13 @@ async def test_get_permission_set_users_and_groups(mock_ssoadmin_client_bundle: 
 
 @pytest.mark.asyncio
 async def test_get_permission_set_users_and_groups_as_access_rules(
+    mock_wrap_identity_center_store_client,
     mock_ssoadmin_client_bundle: tuple,
 ):
     mock_ssoadmin_client, permission_set_arn = mock_ssoadmin_client_bundle
 
     response = await get_permission_set_users_and_groups_as_access_rules(
+        mock_wrap_identity_center_store_client,
         mock_ssoadmin_client,
         EXAMPLE_IDENTITY_CENTER_INSTANCE_ARN,
         permission_set_arn,


### PR DESCRIPTION
## What changed?
* Handle list_users and list_groups not working for identity center store due to current integration limit with AD integration
* if we cannot fetch users and group in the beginning, wait til encounter of GUID, on-the-fly use describe_user or describe_group API to resolve GUID. (with simple caching decorator to minimize API hit)

## Rationale
* When identity center store is integrate with AD, some AD setup refuse to propagate list_users and list_groups with a filter. (this has to do with how identity center store service team has implement the integration. boto3 sdk already allow for no filter and it works with builtin identity center store directory.

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [ ] Unit Tests
- [ ] Functional Tests
- [x] Manually Verified

how to verify: I simulate the issue by just not calling the actual list users and list groups. 

this is likely only work for import. it will take some thoughts on how to implement change things from iambic-templates without user and group knowledge