### PR TITLE
Enhance GitHub App local secrets handling

### DIFF
--- a/iambic/plugins/v0_1_0/github/create_github_app.py
+++ b/iambic/plugins/v0_1_0/github/create_github_app.py
@@ -64,6 +64,15 @@ def has_github_app_secrets_locally():
     return os.path.exists(full_path)
 
 
+def remove_github_app_secrets():
+    full_path = os.path.expanduser(SAVE_DIR)
+    os.makedirs(full_path, exist_ok=True)
+    full_path = f"{full_path}/.github_secrets.yaml"
+    if os.path.exists(full_path):
+        os.remove(full_path)
+        log.info(f"Remove local GitHub App secrets from {full_path}")
+
+
 def get_github_app_secrets():
     full_path = os.path.expanduser(SAVE_DIR)
     os.makedirs(full_path, exist_ok=True)


### PR DESCRIPTION
## What changed?
* Prompt user regarding existing GitHub App secrets
* Remove local GitHub App secrets when setup is successful

## Rationale
* We should not keep the local secrets when its successfully stored in SecretManager
* Explain to the user if there is local secrets for what org and what app

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [ ] Unit Tests
- [ ] Functional Tests
- [x] Manually Verified
