### PR TITLE
Fix condition in policy statement

### DIFF
--- a/iambic/plugins/v0_1_0/aws/iam/policy/models.py
+++ b/iambic/plugins/v0_1_0/aws/iam/policy/models.py
@@ -178,6 +178,24 @@ class PolicyStatement(AccessModel, ExpiryModel):
     def resource_id(self):
         return self.sid
 
+    @validator("condition")
+    def strip_metadata_commented_dict_for_condition(cls, v: dict):
+        # We have to lose comments because condition is stored as dict
+        # in AWS, and by the time it arrives, it always trump local version
+        # In addition, these extra fields become an issue when it is use
+        # for assume role policy document input
+        recursive_remove_key(v, "metadata_commented_dict")
+        return v
+
+
+def recursive_remove_key(input_dict, k):
+    if not isinstance(input_dict, dict):
+        return
+    if k in input_dict:
+        del input_dict[k]
+    for value in input_dict.values():
+        recursive_remove_key(value, k)
+
 
 class AssumeRolePolicyDocument(AccessModel):
     version: str = "2008-10-17"


### PR DESCRIPTION
## What changed?
*  We cannot preserve comments in policy statement condition because the entire value is a dictionary feed directly into AWS

## Rationale
* Our approach to yaml comments is we transfer commented map comments to a special key, such that we can write back out at the end. This is a problem for condition in policy statements because it's typed dict. The cloud 

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [ ] Unit Tests
- [ ] Functional Tests
- [x] Manually Verified

Try to modify a assume role policy document using iambic that has condition 