### PR TITLE
Fix template generation details

### DIFF
--- a/iambic/core/models.py
+++ b/iambic/core/models.py
@@ -589,15 +589,21 @@ class BaseTemplate(
         if notes := sorted_input_dict.get("notes"):
             sorted_input_dict["notes"] = LiteralScalarString(notes)
         as_yaml = yaml.dump(sorted_input_dict)
+
         # Force template_type and template_schema_url to be at the top of the yaml
-        #   with the default value
+        #  with the default value
+        header_lines = []
         for boosted_attr in ["template_type", "template_schema_url"]:
             boosted_attr_str = (
                 f"{boosted_attr}: {self.__fields__[boosted_attr].default}"
             )
+            header_lines.append(boosted_attr_str)
             as_yaml = as_yaml.replace(f"{boosted_attr_str}\n", "")
             as_yaml = as_yaml.replace(f"\n{boosted_attr_str}", "")
-            as_yaml = f"{boosted_attr_str}\n{as_yaml}"
+
+        header_text = "\n".join(header_lines)
+        as_yaml = f"{header_text}\n{as_yaml}"
+
         return as_yaml
 
     def write(self, exclude_none=True, exclude_unset=True, exclude_defaults=True):

--- a/iambic/core/models.py
+++ b/iambic/core/models.py
@@ -589,20 +589,38 @@ class BaseTemplate(
         if notes := sorted_input_dict.get("notes"):
             sorted_input_dict["notes"] = LiteralScalarString(notes)
         as_yaml = yaml.dump(sorted_input_dict)
+        as_yaml_lines = as_yaml.split("\n")
 
-        # Force template_type and template_schema_url to be at the top of the yaml
-        #  with the default value
-        header_lines = []
+        # prepare iambic_header_lines
+        iambic_header_lines = []
         for boosted_attr in ["template_type", "template_schema_url"]:
             boosted_attr_str = (
                 f"{boosted_attr}: {self.__fields__[boosted_attr].default}"
             )
-            header_lines.append(boosted_attr_str)
-            as_yaml = as_yaml.replace(f"{boosted_attr_str}\n", "")
-            as_yaml = as_yaml.replace(f"\n{boosted_attr_str}", "")
+            iambic_header_lines.append(boosted_attr_str)
 
-        header_text = "\n".join(header_lines)
-        as_yaml = f"{header_text}\n{as_yaml}"
+        # prepare file header that is just #
+        file_header_lines = []
+        last_line_number = 0
+        for line_number, line in enumerate(as_yaml_lines):
+            if line.startswith("#"):
+                file_header_lines.append(line)
+                last_line_number = line_number + 1
+            else:
+                break
+
+        remaining_lines = []
+        # Get rid of lines that are already included in iambic_header_lines
+        for line in as_yaml_lines[last_line_number:]:
+            if line not in iambic_header_lines:
+                remaining_lines.append(line)
+
+        final_lines = []
+        final_lines.extend(file_header_lines)
+        final_lines.extend(iambic_header_lines)
+        final_lines.extend(remaining_lines)
+
+        as_yaml = "\n".join(final_lines)
 
         return as_yaml
 

--- a/iambic/core/template_generation.py
+++ b/iambic/core/template_generation.py
@@ -137,6 +137,7 @@ async def base_group_str_attribute(
     The reverse of resource_val_map which is an int representing the elem with a list of all resource_val reprs
         Under elem_resource_val_map
     """
+    num_provider_child_resources = len(provider_child_resources)
     for provider_child_resource_elem, provider_child_resource in enumerate(
         provider_child_resources
     ):
@@ -164,13 +165,20 @@ async def base_group_str_attribute(
             # Concretely, if a literal can both be repeated across accounts
             # or templatized across accounts, greedy algorithm may reach
             # different states.
-
-            provider_child_resources[provider_child_resource_elem]["resource_val_map"][
-                templatized_resource_val
-            ] = resource_elem
-            provider_child_resources[provider_child_resource_elem][
-                "elem_resource_val_map"
-            ][resource_elem] = [templatized_resource_val]
+            if num_provider_child_resources < 2:
+                provider_child_resources[provider_child_resource_elem][
+                    "resource_val_map"
+                ][resource_val] = resource_elem
+                provider_child_resources[provider_child_resource_elem][
+                    "elem_resource_val_map"
+                ][resource_elem] = [resource_val]
+            else:
+                provider_child_resources[provider_child_resource_elem][
+                    "resource_val_map"
+                ][templatized_resource_val] = resource_elem
+                provider_child_resources[provider_child_resource_elem][
+                    "elem_resource_val_map"
+                ][resource_elem] = [templatized_resource_val]
 
     grouped_resource_map = defaultdict(
         list
@@ -273,6 +281,7 @@ async def base_group_dict_attribute(
     Create a reverse of resource_hash_map which is an int representing the elem with a list of all resource_hash reprs
         Under elem_resource_hash_map
     """
+    num_provider_child_resources = len(provider_child_resources)
     hash_map = dict()
 
     for provider_child_resource_elem, provider_child_resource in enumerate(
@@ -395,6 +404,10 @@ async def base_group_dict_attribute(
                 resource_hash = resource_hashes[
                     -1
                 ]  # take the last one because it's the templatized version
+
+                # EXCEPT if there is only account, we won't templatized
+                if num_provider_child_resources < 2:
+                    resource_hash = resource_hashes[0]
 
             grouped_resource_map[resource_hash] = {
                 "resource_val": hash_map[resource_hash],

--- a/test/core/test_models.py
+++ b/test/core/test_models.py
@@ -224,3 +224,26 @@ async def test_template_delete(templates_repo: tuple[str, str]):
     # that don't actually exist in filesystem. those path
     # are relative to the git tree
     assert f"{repo_dir}/{diff_removed.a_path}" == template_path
+
+
+@pytest.mark.asyncio
+async def test_get_body(templates_repo: tuple[str, str]):
+    config_path, repo_dir = templates_repo
+    config = await load_config(config_path)
+
+    repo = git.Repo(repo_dir)
+    diff_index = repo.index.diff("HEAD")
+    # assert there is no local changes
+    assert len(diff_index) == 0
+
+    template = load_templates(
+        [f"{repo_dir}/{TEST_TEMPLATE_PATH}"], config.template_map
+    )[0]
+    template_body = template.get_body()
+    template_lines = template_body.split("\n")
+
+    # we have the order being explicit here
+    # this is to ensure first line is the type
+    # this is to ensure second lien is the schema url
+    assert template_lines[0] == "template_type: NOQ::Example::LocalFile"
+    assert template_lines[1] == "template_schema_url: test_url"

--- a/test/core/test_models.py
+++ b/test/core/test_models.py
@@ -122,7 +122,8 @@ def test_expiry_model_from_json_with_null():
     assert actual_model == expected_model
 
 
-TEST_TEMPLATE_YAML = """template_type: NOQ::Example::LocalFile
+TEST_TEMPLATE_YAML = """# comment line 1
+template_type: NOQ::Example::LocalFile
 template_schema_url: test_url
 notes: |-
   This is a test note
@@ -245,5 +246,6 @@ async def test_get_body(templates_repo: tuple[str, str]):
     # we have the order being explicit here
     # this is to ensure first line is the type
     # this is to ensure second lien is the schema url
-    assert template_lines[0] == "template_type: NOQ::Example::LocalFile"
-    assert template_lines[1] == "template_schema_url: test_url"
+    assert template_lines[0] == "# comment line 1"
+    assert template_lines[1] == "template_type: NOQ::Example::LocalFile"
+    assert template_lines[2] == "template_schema_url: test_url"

--- a/test/core/test_template_generation.py
+++ b/test/core/test_template_generation.py
@@ -170,7 +170,7 @@ def test_merge_model_mix_types_4():
 
 
 @pytest.mark.asyncio
-async def test_group_dict_attribute(aws_accounts: list):
+async def test_group_dict_attribute_with_one_accounts(aws_accounts: list):
     number_of_accounts = 1
     target_account = aws_accounts[0]
     target_account_id = target_account.account_id
@@ -182,17 +182,7 @@ async def test_group_dict_attribute(aws_accounts: list):
     ]
     aws_accounts_map = {account.account_id: account for account in aws_accounts}
 
-    # validate the case if we don't prefer templatized resources
-    # dict_attributes = await group_dict_attribute(
-    #     aws_accounts_map,
-    #     number_of_accounts,
-    #     account_resources,
-    #     False,
-    #     prefer_templatized=False,
-    # )
-    # assert dict_attributes[0] == target_account_id
-
-    # validate the case if we prefer templatized resources
+    # validate the case if we have literal we the incoming account is only 1
     dict_attributes = await group_dict_attribute(
         aws_accounts_map,
         number_of_accounts,
@@ -202,7 +192,39 @@ async def test_group_dict_attribute(aws_accounts: list):
         False,
         prefer_templatized=True,
     )
-    assert dict_attributes[0] == "{{var.account_id}}"
+    assert dict_attributes[0] == target_account_id
+
+
+@pytest.mark.asyncio
+async def test_group_dict_attribute_with_two_accounts(aws_accounts: list):
+    assert len(aws_accounts) > 1
+    number_of_accounts = 1
+    target_account = aws_accounts[0]
+    target_account_id = target_account.account_id
+    another_account_id = aws_accounts[1].account_id
+    account_resources = [
+        {
+            "account_id": target_account_id,
+            "resources": [{"resource_val": {"test": f"{target_account_id}"}}],
+        },
+        {
+            "account_id": another_account_id,
+            "resources": [{"resource_val": {"test": f"{another_account_id}"}}],
+        },
+    ]
+    aws_accounts_map = {account.account_id: account for account in aws_accounts}
+
+    # validate the case if we have literal we the incoming account is only 1
+    dict_attributes = await group_dict_attribute(
+        aws_accounts_map,
+        number_of_accounts,
+        account_resources,
+        "account_id",
+        "included_accounts",
+        False,
+        prefer_templatized=True,
+    )
+    assert dict_attributes[0]["test"] == "{{var.account_id}}"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed?
* template_type is on line 1, template_schema_url is on on line 2
* If there resource is only a single account, don't use the variables.

## Rationale
* The previous fix although fix the sort stability, the implementation details always put template_schema_url on first line.
* We have feedback that template looks strange when the resource is only a single account. Then literal is more understandable when its only a single account.

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [x] Unit Tests
- [ ] Functional Tests
- [x] Manually Verified

Run import on iambic-templates-example to see the single account is now using literal.