### PR TITLE
EN-2381 Fixed identity center handling of suspended account

### DIFF
--- a/iambic/plugins/v0_1_0/aws/identity_center/permission_set/template_generation.py
+++ b/iambic/plugins/v0_1_0/aws/identity_center/permission_set/template_generation.py
@@ -278,6 +278,8 @@ async def create_templated_permission_set(  # noqa: C901
                                     nested_account_id
                                 ]
                                 for nested_account_id in details["accounts"]
+                                if nested_account_id
+                                in aws_account.identity_center_details.org_account_map  # IAMbic only tracks active account
                             ]
                         )
                     account_rules[account_rule_key] = {


### PR DESCRIPTION
## What changed?
* Suspended accounts are not capture in IAMbic AWS org models. IAMbic only tracks active accounts. So IdentityCenter has to handle assignment on suspended accounts. So we check if we can look up the target account id in IAMbic account model before tracking them.

## Rationale
* This is the least path of resistance. If we want to track suspended accounts in IAMbic, we have to track the account status in IAMbic AWS account model

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [ ] Unit Tests
- [ ] Functional Tests
- [x] Manually Verified

I have a permission set assigned to an account. Then I suspend the account. the permission set will contain an assignment to suspended account. (which IAMbic doesn't track because it only tracks active account). Try `iambic import` on the new change to see if import crashes.