### PR TITLE
EN-2379 Turn on CF Stacksets for Organizations when possible

### DIFF
--- a/iambic/config/wizard.py
+++ b/iambic/config/wizard.py
@@ -387,11 +387,11 @@ class ConfigurationWizard:
                         return self._has_cf_stacksets_permissions
 
                 click.echo(
-                    f"\nThis requires that you have the ability to "
-                    f"create CloudFormation stacks, stack sets, and stack set instances.\n"
-                    f"If you are using an AWS Organization, be sure that trusted access is enabled.\n"
-                    f"You can check this using the AWS Console:\n  "
-                    f"https://{self.aws_default_region}.console.aws.amazon.com/organizations/v2/home/services/CloudFormation%20StackSets"
+                    "\nThis requires that you have the ability to "
+                    "create CloudFormation stacks, stack sets, and stack set instances.\n"
+                    "If you are using an AWS Organization, be sure that trusted access is enabled.\n"
+                    "You can check this using the AWS Console:\n  "
+                    "https://us-east-1.console.aws.amazon.com/organizations/v2/home/services/CloudFormation%20StackSets"
                 )
                 if self._has_cf_stacksets_permissions is None:
                     self._has_cf_stacksets_permissions = questionary.confirm(


### PR DESCRIPTION
## What changed?
* Use API to turn on CF Stacksets for Organizations when possible
* Fixed AWS Org url is only available in us-east-1

## Rationale
* Use API to turn on CF Stacksets for Organizations when possible. When we require the user to do it out-of-band, the context switch is not helpful.
* AWS Org url is only available in us-east-1

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [ ] Unit Tests
- [ ] Functional Tests
- [x] Manually Verified

How to test. Mint a new account, turn on organization. Test the flow. If you really want to test it in an existing org account. u have to use cf client to deactivate organization access. (I am not sure the ramification for existing deployed stacksets tho.)