### PR TITLE
Added a check to skip code if OS is Windows fixes #570

### DIFF
--- a/iambic/config/wizard.py
+++ b/iambic/config/wizard.py
@@ -125,11 +125,15 @@ def clear_stdin_buffer():
     """
     # Warning: This appears to work fine in a real terminal,
     # but not VSCode's Debug Terminal
-    r, _, _ = select.select([sys.stdin], [], [], 0)
-    while r:
-        # If there is input waiting, read and discard it.
-        sys.stdin.readline()
+
+    # Adding os check if windows then disabling this code as
+    # it is causing an error
+    if os.name != 'nt':
         r, _, _ = select.select([sys.stdin], [], [], 0)
+        while r:
+            # If there is input waiting, read and discard it.
+            sys.stdin.readline()
+            r, _, _ = select.select([sys.stdin], [], [], 0)
 
 
 def monkeypatch_questionary():


### PR DESCRIPTION
Issue #570 

What changed?

When setting up on Windows using 'iambic setup', there is an error which is occurring.

Error: 'signal' has no attribute 'SIGALRM'

To fix this issue, I've temporarily added a check to skip the error-causing code if the OS is windows.

## Rationale
'iambic setup' doesn't work on Windows 10

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [ ] Unit Tests
- [ ] Functional Tests
- [x] Manually Verified
