### PR TITLE
Fix EN-2380 clear known cf stacksets state if user enter into add org flow

### DIFF
--- a/iambic/config/wizard.py
+++ b/iambic/config/wizard.py
@@ -1219,7 +1219,7 @@ class ConfigurationWizard:
     def configuration_wizard_aws_organizations_add(self):
         # we reset the previous known states since the user chose
         # enter this flow again, so we will re-query the cloud control plane.
-        self._reset_cf_stacksets_known_states()  # address EN-2380
+        self._reset_cf_stacksets_known_states()  # address https://github.com/noqdev/iambic/issues/574
         if not self.has_cf_stacksets_permissions:
             log.info(
                 "Unable to edit this attribute without CloudFormation permissions."

--- a/iambic/config/wizard.py
+++ b/iambic/config/wizard.py
@@ -128,7 +128,7 @@ def clear_stdin_buffer():
 
     # Adding os check if windows then disabling this code as
     # it is causing an error
-    if os.name != 'nt':
+    if os.name != "nt":
         r, _, _ = select.select([sys.stdin], [], [], 0)
         while r:
             # If there is input waiting, read and discard it.
@@ -369,6 +369,11 @@ class ConfigurationWizard:
         asyncio.run(self.set_config_details())
         check_and_update_resource_limit(self.config)
         log.debug("Starting configuration wizard", config_path=self.config_path)
+
+    def _reset_cf_stacksets_known_states(self):
+        # call this if you want to bust the previous known states whether
+        # the user has CF StackSets permissions.
+        self._has_cf_stacksets_permissions = None
 
     @property
     def has_cf_stacksets_permissions(self):
@@ -1212,6 +1217,9 @@ class ConfigurationWizard:
             self.config.write()
 
     def configuration_wizard_aws_organizations_add(self):
+        # we reset the previous known states since the user chose
+        # enter this flow again, so we will re-query the cloud control plane.
+        self._reset_cf_stacksets_known_states()  # address EN-2380
         if not self.has_cf_stacksets_permissions:
             log.info(
                 "Unable to edit this attribute without CloudFormation permissions."


### PR DESCRIPTION
## What changed?
* clear known cf stacksets state if user enter into add org flow

## Rationale
* we cache the known cf config once. we now clear the known states if user go through the add org flow. so it will trigger the detection mechanism again 

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [ ] Unit Tests
- [ ] Functional Tests
- [x] Manually Verified

This is not obvious to test now. because we use The API to turn on CF stacksets organization access for the user when they enter the add org flow. in order to simulate the behavior, I have to use the debugger to manipulation self._has_cf_stacksets_permissions return value. to simulate the re-detection. 

now how is it still relevant. we can still be in that position if the user really does not have permission to turn on CF Stacksets for organizations, maybe a SCP or policy ceiling. in those cases, at least the detection mechanism will be exercise correctly. 