### PR TITLE
Fix for exception raised when iambic plan command is run on empty template file

### DIFF
--- a/iambic/core/utils.py
+++ b/iambic/core/utils.py
@@ -355,6 +355,11 @@ def flatten_comment_data(data):
 def transform_comments(yaml_dict):
     from ruamel.yaml import CommentedMap
 
+    # If this is None then return empty dictionary
+    # None can only occur if the template file is empty
+    if yaml_dict is None:
+        return {}
+
     comment_dict = {}
     yaml_dict["metadata_commented_dict"] = comment_dict
     if yaml_dict.ca.comment:


### PR DESCRIPTION
## Fix for Issue

- #577 

## What changed?

- Added a condition to return an empty dictionary if the template file is empty

## Rationale

- If a template file is empty, then an exception should not occur. This change prevents that.

## How was it tested?

- [ ] Unit Tests
- [ ] Functional Tests
- [x] Manually Verified
