### PR TITLE
EN-2348: add guards when schema generator fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+test/docs/schemas*/**
 
 # Translations
 *.mo

--- a/iambic/plugins/v0_1_0/aws/iam/group/models.py
+++ b/iambic/plugins/v0_1_0/aws/iam/group/models.py
@@ -102,7 +102,9 @@ class AwsIamGroupTemplate(AWSTemplate, AccessModel):
         return "aws-service-group" in self.properties.path
 
     async def _apply_to_account(  # noqa: C901
-        self, aws_account: AWSAccount
+        self,
+        aws_account: AWSAccount,
+        **kwargs,
     ) -> AccountChangeDetails:
         client = await aws_account.get_boto3_client("iam")
         account_group = self.apply_resource_dict(aws_account)

--- a/iambic/plugins/v0_1_0/aws/iam/policy/models.py
+++ b/iambic/plugins/v0_1_0/aws/iam/policy/models.py
@@ -351,7 +351,11 @@ class AwsIamManagedPolicyTemplate(AWSTemplate, AccessModel):
 
         return response
 
-    async def _apply_to_account(self, aws_account: AWSAccount) -> AccountChangeDetails:
+    async def _apply_to_account(
+        self,
+        aws_account: AWSAccount,
+        **kwargs,
+    ) -> AccountChangeDetails:
         client = await aws_account.get_boto3_client("iam")
         account_policy = self.apply_resource_dict(aws_account)
         policy_name = account_policy["PolicyName"]

--- a/iambic/plugins/v0_1_0/aws/iam/role/models.py
+++ b/iambic/plugins/v0_1_0/aws/iam/role/models.py
@@ -210,7 +210,9 @@ class AwsIamRoleTemplate(AWSTemplate, AccessModel):
         return "aws-service-role" in self.properties.path
 
     async def _apply_to_account(  # noqa: C901
-        self, aws_account: AWSAccount
+        self,
+        aws_account: AWSAccount,
+        **kwargs,
     ) -> AccountChangeDetails:
         client = await aws_account.get_boto3_client("iam")
         account_role = self.apply_resource_dict(aws_account)

--- a/iambic/plugins/v0_1_0/aws/iam/user/models.py
+++ b/iambic/plugins/v0_1_0/aws/iam/user/models.py
@@ -156,7 +156,9 @@ class AwsIamUserTemplate(AWSTemplate, AccessModel):
         return response
 
     async def _apply_to_account(  # noqa: C901
-        self, aws_account: AWSAccount
+        self,
+        aws_account: AWSAccount,
+        **kwargs,
     ) -> AccountChangeDetails:
         client = await aws_account.get_boto3_client("iam")
         self = await remove_expired_resources(

--- a/iambic/plugins/v0_1_0/aws/identity_center/permission_set/models.py
+++ b/iambic/plugins/v0_1_0/aws/identity_center/permission_set/models.py
@@ -406,7 +406,9 @@ class AwsIdentityCenterPermissionSetTemplate(
         return response
 
     async def _apply_to_account(  # noqa: C901
-        self, aws_account: AWSAccount
+        self,
+        aws_account: AWSAccount,
+        **kwargs,
     ) -> AccountChangeDetails:
         """Apply the permission set to the given AWS account
 

--- a/iambic/plugins/v0_1_0/aws/models.py
+++ b/iambic/plugins/v0_1_0/aws/models.py
@@ -310,7 +310,7 @@ class AWSAccount(ProviderChild, BaseAWSAccountAndOrgModel):
 
     organization: Optional[AWSOrganization if TYPE_CHECKING else Any] = Field(
         None, description="The AWS Organization this account belongs to"
-    )
+    )  # workaround for generate_docs
 
     class Config:
         fields = {"hub_session_info": {"exclude": True}}
@@ -486,7 +486,6 @@ class AWSAccount(ProviderChild, BaseAWSAccountAndOrgModel):
         when the account is the organization account
         """
         self.organization = organization
-        # self.aws_config = config
 
     def dict(
         self,
@@ -565,7 +564,6 @@ class AWSAccount(ProviderChild, BaseAWSAccountAndOrgModel):
     @property
     def organization_account(self) -> bool:
         """if current account is an organization account"""
-        # return bool(self.organization and self.aws_config)
         return bool(self.organization)
 
     def __str__(self):

--- a/iambic/plugins/v0_1_0/aws/organizations/scp/models.py
+++ b/iambic/plugins/v0_1_0/aws/organizations/scp/models.py
@@ -268,7 +268,12 @@ class AwsScpPolicyTemplate(AWSTemplate, AccessModel):
         resource_dict["Arn"] = self.get_arn()
         return resource_dict
 
-    async def _apply_to_account(self, aws_account: AWSAccount) -> AccountChangeDetails:
+    async def _apply_to_account(
+        self,
+        aws_account: AWSAccount,
+        aws_config: Optional[AWSConfig] = None,
+        **kwargs,
+    ) -> AccountChangeDetails:
         if self.account_id != aws_account.account_id:
             return AccountChangeDetails(
                 account=str(aws_account),
@@ -361,6 +366,7 @@ class AwsScpPolicyTemplate(AWSTemplate, AccessModel):
                 current_policy,
                 log_params,
                 aws_account,
+                aws_config,
             ]
 
             tasks = [
@@ -407,7 +413,14 @@ class AwsScpPolicyTemplate(AWSTemplate, AccessModel):
             current_policy = await get_policy(client, account_policy.get("PolicyId"))
             current_policy = current_policy.dict()
 
-            args = [client, account_policy, current_policy, log_params, aws_account]
+            args = [
+                client,
+                account_policy,
+                current_policy,
+                log_params,
+                aws_account,
+                aws_config,
+            ]
 
             tasks = [
                 apply_update_policy_tags(*args),

--- a/iambic/plugins/v0_1_0/aws/organizations/scp/utils.py
+++ b/iambic/plugins/v0_1_0/aws/organizations/scp/utils.py
@@ -16,6 +16,7 @@ from iambic.core.utils import NoqSemaphore, aio_wrapper, plugin_apply_wrapper
 from iambic.plugins.v0_1_0.aws.utils import boto_crud_call, legacy_paginated_search
 
 if TYPE_CHECKING:
+    from iambic.plugins.v0_1_0.aws.iambic_plugin import AWSConfig
     from iambic.plugins.v0_1_0.aws.models import AWSAccount
     from iambic.plugins.v0_1_0.aws.organizations.scp.models import (
         ServiceControlPolicyItem,
@@ -354,6 +355,7 @@ async def apply_update_policy_targets(
     current_policy,
     log_params,
     aws_account: AWSAccount,
+    aws_config: AWSConfig,
     *args,
 ) -> list[ProposedChange]:
     """Apply update policy targets.
@@ -376,6 +378,7 @@ async def apply_update_policy_targets(
         current_policy,
         log_params,
         aws_account,
+        aws_config,
     )
 
     tasks += t
@@ -387,6 +390,7 @@ async def apply_update_policy_targets(
         current_policy,
         log_params,
         aws_account,
+        aws_config,
     )
 
     tasks += t
@@ -552,6 +556,8 @@ def __apply_targets(
     current_policy,
     log_params,
     aws_account: AWSAccount,
+    aws_config: AWSConfig,
+    *args,
 ):
     """Apply targets to policy."""
     from iambic.plugins.v0_1_0.aws.organizations.scp.models import (
@@ -568,7 +574,7 @@ def __apply_targets(
             ).values()
         )
     )
-    targets = PolicyTargetProperties.unparse_targets(targets, aws_account.aws_config)
+    targets = PolicyTargetProperties.unparse_targets(targets, aws_config)
 
     current_targets = list(
         map(lambda t: t.get("TargetId"), current_policy.get("Targets"))
@@ -617,6 +623,7 @@ def __remove_targets(
     current_policy,
     log_params,
     aws_account: AWSAccount,
+    aws_config: AWSConfig,
 ):
     """Remove targets from policy that are not in the template."""
     from iambic.plugins.v0_1_0.aws.organizations.scp.models import (
@@ -633,7 +640,7 @@ def __remove_targets(
             ).values()
         )
     )
-    targets = PolicyTargetProperties.unparse_targets(targets, aws_account.aws_config)
+    targets = PolicyTargetProperties.unparse_targets(targets, aws_config)
 
     current_targets = list(
         map(lambda t: t.get("TargetId"), current_policy.get("Targets"))

--- a/test/docs/test_generate_docs.py
+++ b/test/docs/test_generate_docs.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import os
+
+import jsonschema2md2
+import pytest
+
+from docs.generate_schema import create_model_schemas
+from iambic.config.dynamic_config import Config, ExtendsConfig
+from iambic.core.models import Variable
+from iambic.plugins.v0_1_0.aws.iam.group.models import AwsIamGroupTemplate
+from iambic.plugins.v0_1_0.aws.iam.policy.models import AwsIamManagedPolicyTemplate
+from iambic.plugins.v0_1_0.aws.iam.role.models import AwsIamRoleTemplate
+from iambic.plugins.v0_1_0.aws.iam.user.models import AwsIamUserTemplate
+from iambic.plugins.v0_1_0.aws.iambic_plugin import AWSConfig
+from iambic.plugins.v0_1_0.aws.identity_center.permission_set.models import (
+    AwsIdentityCenterPermissionSetTemplate,
+)
+from iambic.plugins.v0_1_0.aws.models import (
+    AWSAccount,
+    AWSOrganization,
+    BaseAWSAccountAndOrgModel,
+)
+from iambic.plugins.v0_1_0.azure_ad.group.models import (
+    AzureActiveDirectoryGroupTemplate,
+)
+from iambic.plugins.v0_1_0.azure_ad.iambic_plugin import AzureADConfig
+from iambic.plugins.v0_1_0.azure_ad.user.models import AzureActiveDirectoryUserTemplate
+from iambic.plugins.v0_1_0.github.iambic_plugin import GithubConfig
+from iambic.plugins.v0_1_0.google_workspace.group.models import (
+    GoogleWorkspaceGroupTemplate,
+)
+from iambic.plugins.v0_1_0.google_workspace.iambic_plugin import GoogleWorkspaceConfig
+from iambic.plugins.v0_1_0.okta.app.models import OktaAppTemplate
+from iambic.plugins.v0_1_0.okta.group.models import OktaGroupTemplate
+from iambic.plugins.v0_1_0.okta.iambic_plugin import OktaConfig
+from iambic.plugins.v0_1_0.okta.user.models import OktaUserTemplate
+
+
+@pytest.mark.parametrize(
+    "klass",
+    [
+        AwsIamRoleTemplate,
+        AwsIamManagedPolicyTemplate,
+        AwsIdentityCenterPermissionSetTemplate,
+        AwsIamGroupTemplate,
+        AwsIamUserTemplate,
+        AzureActiveDirectoryGroupTemplate,
+        AzureActiveDirectoryUserTemplate,
+        GoogleWorkspaceGroupTemplate,
+        OktaGroupTemplate,
+        OktaUserTemplate,
+        OktaAppTemplate,
+        Config,
+        BaseAWSAccountAndOrgModel,
+        AWSConfig,
+        AWSAccount,
+        AWSOrganization,
+        OktaConfig,
+        AzureADConfig,
+        GoogleWorkspaceConfig,
+        ExtendsConfig,
+        Variable,
+        GithubConfig,
+    ],
+)
+def test_create_model_schemas(klass):
+    # TODO: look for all subclasses of BaseEntity
+    test_schema_dir = os.path.join("test", "docs", "schemas")
+    os.makedirs(test_schema_dir, exist_ok=True)
+    parser = jsonschema2md2.Parser(
+        examples_as_yaml=True,
+        show_examples="all",
+    )
+
+    try:
+        create_model_schemas(parser, test_schema_dir, "", [klass], raise_exception=True)
+    except Exception:
+        assert False
+    else:
+        assert True

--- a/test/plugins/v0_1_0/aws/organizations/scp/test_utils.py
+++ b/test/plugins/v0_1_0/aws/organizations/scp/test_utils.py
@@ -300,6 +300,7 @@ async def test_apply_update_policy_targets(mock_organizations_client):
         scp_item.dict(),
         dict(resource_type="policy"),
         AWSAccount(account_name="test"),
+        AWSConfig(),
     )
 
     assert len(changes) == 2


### PR DESCRIPTION
## What changed?
- add tests for schema generations
- add try-except to skip errors during generation
- log those errors
- remove aws_config from AWSAccount
- change typing of organizations at AWSAccount

## Rationale
We need testing to check the schema generator for IAMbic's docs. In some cases, some models have issues to be generated because of circular dependencies or forward_refs not loaded (pydantic).

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [x] Unit Tests
- [ ] Functional Tests
- [x] Manually Verified
