### PR TITLE
Fix #581 Relax Target to stay as account id if we cannot look up its account name

### DIFF
--- a/iambic/plugins/v0_1_0/aws/organizations/scp/models.py
+++ b/iambic/plugins/v0_1_0/aws/organizations/scp/models.py
@@ -115,12 +115,16 @@ class PolicyTargetProperties(BaseModel):
             elif target_id.startswith("r-"):
                 key = "roots"
             else:
-                target_id = list(
+                known_accounts = list(
                     map(
                         lambda a: a.account_name,
                         filter(lambda a: a.account_id == target_id, config.accounts),
                     )
-                )[0]
+                )
+                if len(known_accounts) > 0:
+                    # if an account is suspend and not assumable, we will not be able
+                    # to look up from config.
+                    target_id = known_accounts[0]
 
             data[key].append(target_id)
 


### PR DESCRIPTION
## What changed?
* Typically SCP model translate account id to friendly name. However, suspend account will not be track by AWSAccount Model and there are limit to assume a role once an account is suspended. So fall back to simply account id in such case.

## Rationale
* Typically SCP model translate account id to friendly name. However, suspend account will not be track by AWSAccount Model and there are limit to assume a role once an account is suspended. So fall back to simply account id in such case.

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [ ] Unit Tests
- [ ] Functional Tests
- [x] Manually Verified

I attach a SCP to a suspended account and see if I can import it.