### PR TITLE
Fix #555 Duplicate menu item

### DIFF
--- a/iambic/config/wizard.py
+++ b/iambic/config/wizard.py
@@ -2332,7 +2332,6 @@ class ConfigurationWizard:
 
             if self.has_aws_account_or_organizations:
                 choices.append("Setup GitHub App Integration using AWS Lambda")
-                choices.append("Setup AWS change detection")
                 if (
                     self.config.aws.organizations
                     and not self.config.aws.sqs_cloudtrail_changes_queues


### PR DESCRIPTION
## What changed?
* Fix duplicate menu item

## Rationale
* I think the bug was introduce by prior merge error. the append of the duplicate menu item is next to each other inside a conditional check.

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [ ] Unit Tests
- [ ] Functional Tests
- [x] Manually Verified
