### PR TITLE
Use alternative implementation of list_users and list_groups

### DIFF
--- a/iambic/plugins/v0_1_0/aws/identity_center/permission_set/active_directory_utils.py
+++ b/iambic/plugins/v0_1_0/aws/identity_center/permission_set/active_directory_utils.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import json
+import socket
+
+import aiohttp
+from botocore.auth import SigV4Auth
+from botocore.awsrequest import AWSRequest
+
+
+async def alternate_list_users(session, directory_id, region):
+    domain = f"up.sso.{region}.amazonaws.com"
+    try:
+        ip_list = list({addr[-1][0] for addr in socket.getaddrinfo(domain, 0, 0, 0, 0)})
+    except socket.gaierror:
+        domain = f"up-sso.{region}.amazonaws.com"
+        try:
+            ip_list = list(
+                {addr[-1][0] for addr in socket.getaddrinfo(domain, 0, 0, 0, 0)}
+            )
+            assert ip_list
+        except socket.gaierror:
+            raise
+    url = f"https://{domain}/identitystore/"
+
+    payload = {"IdentityStoreId": directory_id, "MaxResults": 100}
+    data = json.dumps(payload)
+
+    sigv4 = SigV4Auth(session.get_credentials(), "identitystore", region)
+
+    headers = {
+        "Content-Type": "application/x-amz-json-1.1",
+        "X-Amz-Target": "AWSIdentityStoreService.SearchUsers",
+    }
+    request = AWSRequest(method="POST", url=url, data=data, headers=headers)
+    request.context["payload_signing_enabled"] = True
+    sigv4.add_auth(request)
+
+    prepped = request.prepare()
+    text = None
+    total_users = []
+
+    async with aiohttp.ClientSession(headers=headers) as aiohttp_session:
+        async with aiohttp_session.post(
+            prepped.url, headers=prepped.headers, data=data
+        ) as r:
+            text = await r.text()
+
+        # necessary because the response header is not regular json
+        id_resp = json.loads(text)
+        total_users.extend(id_resp["Users"])
+
+        while "NextToken" in id_resp:
+            payload["NextToken"] = id_resp["NextToken"]
+            data = json.dumps(payload)
+            request = AWSRequest(method="POST", url=url, data=data, headers=headers)
+            request.context["payload_signing_enabled"] = True
+            sigv4.add_auth(request)
+
+            prepped = request.prepare()
+            async with aiohttp_session.post(
+                prepped.url, headers=prepped.headers, data=data
+            ) as r:
+                text = await r.text
+                id_resp = json.loads(text)
+
+            total_users.extend(id_resp["Users"])
+
+    # for compatibility for list_users
+    for user in total_users:
+        if "display_name" in user.get("user_attributes", {}).get(
+            "display_name", {}
+        ).get("string_value", None):
+            user["display_name"] = user["user_attributes"]["display_name"][
+                "string_value"
+            ]
+        else:
+            user["display_name"] = "ERROR UNABLE TO DECODE, CONTACT DEVELOPERS"
+
+    return {"Users": total_users}
+
+
+async def alternate_list_groups(session, directory_id, region):
+    domain = f"up.sso.{region}.amazonaws.com"
+    try:
+        ip_list = list({addr[-1][0] for addr in socket.getaddrinfo(domain, 0, 0, 0, 0)})
+    except socket.gaierror:
+        domain = f"up-sso.{region}.amazonaws.com"
+        try:
+            ip_list = list(
+                {addr[-1][0] for addr in socket.getaddrinfo(domain, 0, 0, 0, 0)}
+            )
+            assert ip_list
+        except socket.gaierror:
+            raise
+    url = f"https://{domain}/identitystore/"
+    payload = {"IdentityStoreId": directory_id, "MaxResults": 100}
+    data = json.dumps(payload)
+
+    sigv4 = SigV4Auth(session.get_credentials(), "identitystore", region)
+
+    headers = {
+        "Content-Type": "application/x-amz-json-1.1",
+        "X-Amz-Target": "AWSIdentityStoreService.SearchGroups",
+    }
+    request = AWSRequest(method="POST", url=url, data=data, headers=headers)
+    request.context["payload_signing_enabled"] = True
+    sigv4.add_auth(request)
+
+    prepped = request.prepare()
+    # response = requests.post(prepped.url, headers=prepped.headers, data=data)
+    text = None
+    total_groups = []
+
+    async with aiohttp.ClientSession(headers=headers) as aiohttp_session:
+        async with aiohttp_session.post(
+            prepped.url, headers=prepped.headers, data=data
+        ) as r:
+            text = await r.text()
+
+        id_resp = json.loads(text)
+        total_groups.extend(id_resp["Groups"])
+
+        while "NextToken" in id_resp:
+            payload["NextToken"] = id_resp["NextToken"]
+            data = json.dumps(payload)
+            request = AWSRequest(method="POST", url=url, data=data, headers=headers)
+            request.context["payload_signing_enabled"] = True
+            sigv4.add_auth(request)
+
+            prepped = request.prepare()
+            async with aiohttp_session.post(
+                prepped.url, headers=prepped.headers, data=data
+            ) as r:
+                text = await r.text
+                id_resp = json.loads(text)
+                total_groups.extend(id_resp["Groups"])
+
+    # for compatibility for list_users
+    for group in total_groups:
+        if "display_name" in group.get("group_attributes", {}).get(
+            "display_name", {}
+        ).get("string_value", None):
+            group["display_name"] = group["group_attributes"]["display_name"][
+                "string_value"
+            ]
+        else:
+            group["display_name"] = "ERROR UNABLE TO DECODE, CONTACT DEVELOPERS"
+
+    return {"Groups": total_groups}

--- a/iambic/plugins/v0_1_0/aws/identity_center/permission_set/active_directory_utils.py
+++ b/iambic/plugins/v0_1_0/aws/identity_center/permission_set/active_directory_utils.py
@@ -135,16 +135,10 @@ async def alternate_list_groups(session, directory_id, region):
                 id_resp = noq_json.loads(text)
                 total_groups.extend(id_resp["Groups"])
 
-    # for compatibility for list_users
+    # for compatibility for list_groups
     for group in total_groups:
-        if (
-            group.get("group_attributes", {})
-            .get("display_name", {})
-            .get("string_value", None)
-        ):
-            group["display_name"] = group["group_attributes"]["display_name"][
-                "string_value"
-            ]
+        if group.get("DisplayName", None):
+            group["display_name"] = group["DisplayName"]
         else:
             group["display_name"] = "ERROR UNABLE TO DECODE, CONTACT DEVELOPERS"
 


### PR DESCRIPTION
## What changed?
* User undocumented API to implement list_users and list_groups

## Rationale
* AWS Console seem to use some undocumented API to get users and groups. This alternate implementation is only use when the standard api fail

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [ ] Unit Tests
- [ ] Functional Tests
- [x] Manually Verified
