### PR TITLE
Fix #593 PermissionSet InlinePolicy to support single statement syntax

### DIFF
--- a/iambic/plugins/v0_1_0/aws/identity_center/permission_set/models.py
+++ b/iambic/plugins/v0_1_0/aws/identity_center/permission_set/models.py
@@ -125,7 +125,11 @@ class SessionDuration(BaseModel):
 
 class InlinePolicy(BaseModel, ExpiryModel):
     version: Optional[str] = None
-    statement: Optional[List[PolicyStatement]] = Field(
+
+    # As usual, the non-list statement is a legacy syntax that AWS has continued
+    # to support. The grammar does not actually document this.
+    #
+    statement: Optional[Union[List[PolicyStatement], PolicyStatement]] = Field(
         None,
         description="List of policy statements",
     )

--- a/test/plugins/v0_1_0/aws/identity_center/permission_set/test_models.py
+++ b/test/plugins/v0_1_0/aws/identity_center/permission_set/test_models.py
@@ -120,6 +120,36 @@ def test_permission_boundary_with_customer_managed_policy_ref_with_custom_path()
     )
 
 
+def test_statement_as_dict():
+    properties = PermissionSetProperties(
+        name="foo",
+        description="A",
+        statement={
+            "Sid": "Statement1",
+            "Effect": "Deny",
+            "Action": ["s3:ListAllMyBuckets"],
+            "Resource": "*",
+        },
+    )
+    assert properties
+
+
+def test_statement_as_list_of_dict():
+    properties = PermissionSetProperties(
+        name="foo",
+        description="A",
+        statement=[
+            {
+                "Sid": "Statement1",
+                "Effect": "Deny",
+                "Action": ["s3:ListAllMyBuckets"],
+                "Resource": "*",
+            }
+        ],
+    )
+    assert properties
+
+
 def test_description_validation_with_valid_string():
     properties = PermissionSetProperties(name="foo", description="A")
     assert properties.description == "A"


### PR DESCRIPTION
## What changed?
* Supports single statement syntax

## Rationale
* AWS continues to support single statement syntax

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [x] Unit Tests
- [ ] Functional Tests
- [x] Manually Verified
