### PR TITLE
Fix error handling for detect not able to create gist

### DIFF
--- a/iambic/plugins/v0_1_0/github/github.py
+++ b/iambic/plugins/v0_1_0/github/github.py
@@ -932,11 +932,18 @@ def _handle_detect_changes_from_eventbridge(
             log.info("handle_detect no changes")
             return []
 
-        url = __save_detection_messages(
-            temp_file_path=temp_file_path,
-            github_client=github_client,
-            templates_repo=templates_repo,
-        )
+        url = None
+        try:
+            url = __save_detection_messages(
+                temp_file_path=temp_file_path,
+                github_client=github_client,
+                templates_repo=templates_repo,
+            )
+        except Exception as e:
+            captured_traceback = traceback.format_exc()
+            log.error("__save_detection_messages failed", exception=captured_traceback)
+            # continue because it's possible the gist crashes but
+            # we still want to capture the cloud changes
 
         url_snippet = f"For cloudtrail details, see {url}"
         commit_log = COMMIT_MESSAGE_FOR_DETECT

--- a/iambic/plugins/v0_1_0/github/github.py
+++ b/iambic/plugins/v0_1_0/github/github.py
@@ -939,7 +939,7 @@ def _handle_detect_changes_from_eventbridge(
                 github_client=github_client,
                 templates_repo=templates_repo,
             )
-        except Exception as e:
+        except Exception:
             captured_traceback = traceback.format_exc()
             log.error("__save_detection_messages failed", exception=captured_traceback)
             # continue because it's possible the gist crashes but


### PR DESCRIPTION
## What changed?
* If detect not able to create gist, the template should still be updated.

## Rationale
* If detect not able to create gist, the template should still be updated.

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [ ] Unit Tests
- [ ] Functional Tests
- [x] Manually Verified

I deny the GitHub app to push into gist via branch protection and make sure it can still update the template. 