### PR TITLE
Fixed EN-2401 Check parent directory truthy-ness before attempt to create it

### DIFF
--- a/iambic/config/dynamic_config.py
+++ b/iambic/config/dynamic_config.py
@@ -451,7 +451,11 @@ class Config(ConfigMixin, BaseTemplate):
         )
 
         file_path = os.path.expanduser(self.file_path)
-        os.makedirs(os.path.dirname(file_path), exist_ok=True)
+        parent_directory = os.path.dirname(file_path)
+        # if the user feeds in a filename like 'xyz.yaml'
+        # parent_directory is '', which is not acceptable
+        # to makedirs
+        os.makedirs(parent_directory, exist_ok=True)
         with open(file_path, "w") as f:
             f.write(yaml.dump(sorted_input_dict))
 

--- a/iambic/core/models.py
+++ b/iambic/core/models.py
@@ -629,7 +629,12 @@ class BaseTemplate(
         self.validate_model_afterward()
 
         as_yaml = self.get_body(exclude_none, exclude_unset, exclude_defaults)
-        os.makedirs(os.path.dirname(os.path.expanduser(self.file_path)), exist_ok=True)
+        parent_directory = os.path.dirname(os.path.expanduser(self.file_path))
+        # if the user feeds in a filename like 'xyz.yaml'
+        # parent_directory is '', which is not acceptable
+        # to makedirs
+        if parent_directory:
+            os.makedirs(parent_directory, exist_ok=True)
         with open(self.file_path, "w") as f:
             f.write(as_yaml)
 


### PR DESCRIPTION
## What changed?
* Fixed EN-2401 Check parent directory truthy-ness before attempt to create it

## Rationale
* when user runs `iambic apply foo.yaml`, foo.yaml's directory name is consider ''. You cannot pass '' to makers.

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [ ] Unit Tests
- [ ] Functional Tests
- [x] Manually Verified
