### PR TITLE
Optimize GitHub PR plan time

### DIFF
--- a/iambic/config/utils.py
+++ b/iambic/config/utils.py
@@ -14,6 +14,12 @@ CF_INVALID_TAGS_MSG = "Format has to be either blank or `key1=value1"
 
 
 async def resolve_config_template_path(repo_dir: str) -> pathlib.Path:
+    """
+    Given a directory, recursively find the config path.
+
+    This is slow because it needs to recurse into the directory.
+
+    """
     config_template_file_path = await gather_templates(repo_dir, "Core::Config")
     if len(config_template_file_path) == 0:
         raise RuntimeError(

--- a/iambic/main.py
+++ b/iambic/main.py
@@ -370,12 +370,26 @@ def plan(templates: list, plan_output: str, repo_dir: str, git_aware: bool):
 def run_git_plan(
     output_path: str,
     repo_dir: str = str(pathlib.Path.cwd()),
+    config_path: pathlib.Path = None,
+    config: Config = None,
+    skip_flag_expired_resources_phase: bool = False,
 ) -> list[TemplateChangeDetails]:
     ctx.eval_only = True
-    config_path = asyncio.run(resolve_config_template_path(repo_dir))
-    config = asyncio.run(load_config(config_path))
+
+    if config_path is None:
+        config_path = asyncio.run(resolve_config_template_path(repo_dir))
+
+    if config is None:
+        config = asyncio.run(load_config(config_path))
     check_and_update_resource_limit(config)
-    template_changes = asyncio.run(plan_git_changes(config_path, repo_dir))
+    template_changes = asyncio.run(
+        plan_git_changes(
+            config_path,
+            repo_dir,
+            config=config,
+            skip_flag_expired_resources_phase=skip_flag_expired_resources_phase,
+        )
+    )
     output_proposed_changes(template_changes, output_path, exit_on_error=False)
     screen_render_resource_changes(template_changes)
     return template_changes

--- a/iambic/request_handler/git_plan.py
+++ b/iambic/request_handler/git_plan.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
+from iambic.config.dynamic_config import Config
 from iambic.core.context import ctx
 from iambic.core.models import TemplateChangeDetails
 from iambic.request_handler.git_apply import apply_git_changes
 
 
 async def plan_git_changes(
-    config_path: str, repo_dir: str
+    config_path: str,
+    repo_dir: str,
+    config: Config = None,
+    skip_flag_expired_resources_phase: bool = False,  # use your judgement to decide if you want so skip expire resource phase
 ) -> list[TemplateChangeDetails]:
     """Retrieves files added/updated/or removed when comparing the current branch to master
 
@@ -24,7 +28,12 @@ async def plan_git_changes(
     ctx.eval_only = True
     changes = []
     try:
-        changes = await apply_git_changes(config_path, repo_dir)
+        changes = await apply_git_changes(
+            config_path,
+            repo_dir,
+            config=config,
+            skip_flag_expired_resources_phase=skip_flag_expired_resources_phase,
+        )
     finally:
         ctx.eval_only = ctx_eval_only_original_value
         return changes

--- a/test/plugins/v0_1_0/github/test_github.py
+++ b/test/plugins/v0_1_0/github/test_github.py
@@ -273,10 +273,12 @@ def test_plan_issue_comment_with_clean_mergeable_state_and_lambda_handler_crashe
     mock_github_client,
     issue_comment_git_plan_context,
     mock_resolve_config_template_path,
+    mock_load_config,
     mock_lint_git_changes,
     mock_run_git_plan,
     mock_repository,
 ):
+    assert mock_load_config
     mock_pull_request = mock_github_client.get_repo.return_value.get_pull.return_value
     mock_pull_request.mergeable_state = MERGEABLE_STATE_CLEAN
     mock_pull_request.head.sha = issue_comment_git_plan_context["sha"]
@@ -363,10 +365,12 @@ def test_issue_comment_with_git_plan(
     mock_github_client,
     issue_comment_git_plan_context,
     mock_resolve_config_template_path,
+    mock_load_config,
     mock_lint_git_changes,
     mock_run_git_plan,
     mock_repository,
 ):
+    assert mock_load_config
     mock_pull_request = mock_github_client.get_repo.return_value.get_pull.return_value
     mock_pull_request.mergeable_state = MERGEABLE_STATE_CLEAN
     mock_pull_request.head.sha = issue_comment_git_plan_context["sha"]


### PR DESCRIPTION
## What changed?
* Optimize GitHub PR plan time

## Rationale
Upon a pull request is open, automation consists of linting and actual planning. Both operation requires the usage of config object. Introduce optional parameters to pass in the config object to avoid additional loading time.

Skip flagging expired resources during plan and let either main branch apply or git apply to handle the resource expiration.

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [ ] Unit Tests
- [ ] Functional Tests
- [x] Manually Verified

Rely on existing test suite, manually open pull request against iambic-templates-itest to run the simulation GitHub action to watch the interaction.