### PR TITLE
Fixed issue #610 on prompting user they are not using an account capable of setting up AWS Organization

### DIFF
--- a/iambic/config/wizard.py
+++ b/iambic/config/wizard.py
@@ -1105,6 +1105,16 @@ class ConfigurationWizard:
                 # need bootstrapping
                 self.boto3_session = boto3.Session(region_name=self.aws_default_region)
                 self.autodetected_org_settings = {}
+                try:
+                    org_client = self.boto3_session.client("organizations")
+                    self.autodetected_org_settings = org_client.describe_organization()[
+                        "Organization"
+                    ]
+                except Exception:
+                    # we are wrapping inside a try-except block because the user
+                    # may not have organization setup yet, so we don't want to
+                    # crash in that case.
+                    pass
 
             default_caller_identity = self.boto3_session.client(
                 "sts", region_name=self.aws_default_region
@@ -1350,17 +1360,25 @@ class ConfigurationWizard:
                 return True
             else:
                 # Currently only 1 org per config is supported.
-                click.echo(
-                    "\nIf you would like to use AWS Organizations, the IAMbic hub account you configured must be the same "
-                    "AWS account as your AWS Organization."
+                log.error(
+                    "If you would like to use AWS Organizations, the IAMbic hub account you"
+                    "\nconfigured must be the same AWS account as your AWS Organization."
+                    "\nPlease follow AWS guide to setup an AWS organization first. If you already have an organization setup,"
+                    "\nmake sure you are using the organization management account before running IAMbic setup"
                 )
-                return questionary.confirm("Is this the case?").unsafe_ask()
+                raise ValueError("Not AWS Organization management account")
 
-        if maybe_prompt():
-            if self.config.aws and self.config.aws.organizations:
-                self.configuration_wizard_aws_organizations_edit()
+        try:
+            if maybe_prompt():
+                if self.config.aws and self.config.aws.organizations:
+                    self.configuration_wizard_aws_organizations_edit()
+                else:
+                    self.configuration_wizard_aws_organizations_add()
+        except ValueError as e:
+            if e.args[0] == "Not AWS Organization management account":
+                return
             else:
-                self.configuration_wizard_aws_organizations_add()
+                raise
 
     def configuration_wizard_aws(self):
         self.setup_aws_configuration()


### PR DESCRIPTION
## What changed?
* Fixed issue #610 on prompting user they are not using an account capable of setting up AWS Organization

## Rationale
* User is informed they are not using the right AWS account when setting up AWS Organization.

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [ ] Unit Tests
- [ ] Functional Tests
- [x] Manually Verified

export AWS env variable of a member account. get the message.

```
2023/08/23 14:30:28 [error    ] If you would like to use AWS Organizations, the IAMbic hub account you
configured must be the same AWS account as your AWS Organization.
Please follow AWS guide to setup an AWS organization first. If you already have an organization setup,
make sure you are using the organization management account before running IAMbic setup
```

export AWS env variable of a organization account, proceed as expected:

```
We recommend configuring IAMbic with AWS Organizations, but you may also manually configure accounts.
? What would you like to configure in AWS? AWS Organizations

What is the AWS Organization ID?
It can be found here https://us-east-1.console.aws.amazon.com/organizations/v2/home/accounts
? AWS Organization ID:  <redacted>
```