### PR TITLE
Make import work for BitBucket, CodeCommit and GitLab

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -200,6 +200,17 @@
             "justMyCode": true
         },
         {
+            "name": "Iambic: Simulate Generic Git Provider",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceFolder}/dev_tools/simulate_generic_git_in_aws_lambda/simulate_generic_git.py",
+            "args": [
+            ],
+            "console": "integratedTerminal",
+            "justMyCode": true,
+            "envFile": "${workspaceFolder}/.env",
+        },
+        {
             "name": "Iambic: Simulate Lambda GitHub Webhook",
             "type": "python",
             "request": "launch",

--- a/dev_tools/simulate_generic_git_in_aws_lambda/simulate_generic_git.py
+++ b/dev_tools/simulate_generic_git_in_aws_lambda/simulate_generic_git.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import os
+from functools import cache
+from unittest.mock import patch
+
+import boto3
+import yaml
+
+from iambic.plugins.v0_1_0.generic_git_provider.aws_lambda_handler import run_handler
+
+DEV_REGION = os.environ.get("DEV_REGION", "us-west-2")
+DEV_EMAIL_DOMAIN_SUFFIX = os.environ.get("DEV_EMAIL_DOMAIN_SUFFIX", "@example.com")
+DEV_ACCOUNT_ID = os.environ.get("DEV_ACCOUNT_ID", "")
+GIT_PROVIDER_UNDER_TEST = os.environ.get("GIT_PROVIDER_UNDER_TEST", "")
+
+# GIT_PROVIDER_UNDER_TEST valid ones are
+# bitbucket
+# codecommit
+# gitlab
+
+# You cannot proceed without these values. Check your environment setup.
+assert DEV_ACCOUNT_ID
+assert GIT_PROVIDER_UNDER_TEST
+
+
+@cache
+def _get_app_secrets_as_lambda_context_current() -> dict:
+    # Create a Secrets Manager client
+    session = boto3.session.Session()
+    client = session.client(service_name="secretsmanager", region_name=DEV_REGION)
+
+    try:
+        get_secret_value_response = client.get_secret_value(
+            SecretId="iambic-dev/generic-git-providers-secrets"
+        )
+    except Exception as e:
+        # For a list of exceptions thrown, see
+        # https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_GetSecretValue.html
+        raise e
+
+    # Decrypts secret using the associated KMS key.
+    return yaml.safe_load(get_secret_value_response["SecretString"])["git_providers"][
+        GIT_PROVIDER_UNDER_TEST
+    ]
+
+
+if __name__ == "__main__":
+    # to simulate lambda, we are pretending to be a lambda function
+    os.environ["AWS_LAMBDA_FUNCTION_NAME"] = "simulate_generic_git.py"
+
+    req = {"source": "EventBridgeCron", "command": "import"}
+
+    with patch(
+        "iambic.plugins.v0_1_0.generic_git_provider.aws_lambda_handler._get_app_secrets_as_lambda_context_current",
+        new=_get_app_secrets_as_lambda_context_current,
+    ):
+        run_handler(req, None)

--- a/iambic/plugins/v0_1_0/generic_git_provider/aws_lambda_handler.py
+++ b/iambic/plugins/v0_1_0/generic_git_provider/aws_lambda_handler.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+import traceback
+from functools import cache
+from typing import Callable
+
+import boto3
+import yaml
+from botocore.exceptions import ClientError
+
+import iambic.core.utils
+import iambic.plugins.v0_1_0.github.github
+from iambic.core.logger import log
+from iambic.plugins.v0_1_0.generic_git_provider.generic_git_client import (
+    create_git_client,
+)
+from iambic.plugins.v0_1_0.github.github import (
+    _handle_import,
+    get_session_name,
+    iambic_app,
+)
+
+
+def run_handler(event=None, context=None):
+    """
+    Default handler for AWS Lambda. It is split out from the actual
+    handler so we can also run via IDE run configurations
+    """
+
+    # debug
+    print("Event: ", event)
+
+    # Check if the event source is CloudWatch Events
+    if isinstance(event, dict) and event.get("source") == "EventBridgeCron":
+        return handle_events_cron(event, context)
+
+
+@cache
+def _get_app_secrets_as_lambda_context_current() -> dict:
+    # Create a Secrets Manager client
+    session = boto3.session.Session()
+    client = session.client(service_name="secretsmanager")
+
+    try:
+        get_secret_value_response = client.get_secret_value(
+            SecretId="iambic/github-app-secrets"
+        )
+    except ClientError as e:
+        # For a list of exceptions thrown, see
+        # https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_GetSecretValue.html
+        raise e
+
+    # Decrypts secret using the associated KMS key.
+    return yaml.safe_load(get_secret_value_response["SecretString"])
+
+
+def handle_events_cron(event=None, context=None) -> None:
+    secrets = _get_app_secrets_as_lambda_context_current()
+    git_client = create_git_client(secrets)
+
+    command = event["command"]
+
+    if not (callable := AWS_EVENTS_WORKFLOW_DISPATCH_MAP.get(command)):
+        log_params = {"command": command}
+        log.error("handle_events_cron: Unable to find command", **log_params)
+        return
+
+    repo_url = git_client.repo_url
+
+    # TODO, don't have a generic GitProviderRepo interface yet
+    # templates_repo = git_client.get_repo(REPOSITORY_FULL_NAME)
+    # TODO, don't have a generic GitProviderRepoFullName interface yet
+    default_branch = git_client.default_branch_name
+    repo_full_name = git_client.repo_full_name
+    temp_templates_directory = tempfile.mkdtemp(prefix="lambda")
+    os.chdir(temp_templates_directory)
+    getattr(iambic_app, "lambda").app.init_plan_output_path()
+    getattr(iambic_app, "lambda").app.init_repo_base_path()
+    iambic.plugins.v0_1_0.github.github.init_shared_data_directory()
+    iambic.core.utils.init_writable_directory()
+
+    return callable(
+        git_client,
+        None,  # TODO, don't have a generic GitProviderRepo interface yet
+        repo_full_name,
+        repo_url,
+        default_branch,
+        proposed_changes_path=getattr(iambic_app, "lambda").app.PLAN_OUTPUT_PATH,
+    )
+
+
+def workflow_wrapper(workflow_func: Callable, ux_op_name: str) -> Callable:
+    def wrapped_workflow_func(
+        github_client,
+        templates_repo,
+        repo_name: str,
+        repo_url: str,
+        default_branch: str,
+        proposed_changes_path: str = None,
+    ):
+        pull_number = (
+            0  # 0 is not a valid pull number in github. workflow implementation
+        )
+        # does not have an associated PR. This is the path of least resistance adaption
+        # for stable session name
+        session_name = get_session_name(repo_name, pull_number)
+        os.environ["IAMBIC_SESSION_NAME"] = session_name
+
+        try:
+            if proposed_changes_path:
+                # code smell to have to change a module variable
+                # to control the destination of proposed_changes.yaml
+                # It's questionable if we still need to depend on the lambda interface
+                # because lambda interface was created to dynamic populate template config
+                # but templates config is now already stored in the templates repo itself.
+                getattr(
+                    iambic_app, "lambda"
+                ).app.PLAN_OUTPUT_PATH = proposed_changes_path
+
+            template_changes = workflow_func(
+                repo_url,
+                default_branch,
+                github_client=github_client,
+                templates_repo=templates_repo,
+            )
+
+            if template_changes:
+                # TODO This is here just so pre-commit won't yell at me
+                assert True
+
+            # TODO disable _post_artifact_to_companion_repository because i don't have an interface defined yet
+            # _process_template_changes(
+            #     github_client,
+            #     templates_repo,
+            #     None,
+            #     pull_number,
+            #     proposed_changes_path,
+            #     template_changes,
+            #     f"{ux_op_name}",  # TODO this can probably be improved for user-experience
+            # )
+        except Exception as e:
+            captured_traceback = traceback.format_exc()
+            log.error("fault", exception=captured_traceback)
+            try:
+                temp_dir = tempfile.mkdtemp(suffix=None, prefix=None, dir=None)
+                with open(f"{temp_dir}/crash.txt", "w") as f:
+                    f.write(captured_traceback)
+                # TODO disable _post_artifact_to_companion_repository because i don't have an interface defined yet
+                # _post_artifact_to_companion_repository(
+                #     github_client,
+                #     templates_repo,
+                #     pull_number,
+                #     f"{ux_op_name}",
+                #     f"{temp_dir}/crash.txt",
+                #     captured_traceback,
+                #     default_base_name="crash.txt",
+                # )
+            except Exception:
+                captured_traceback = traceback.format_exc()
+                log.error(
+                    "fail to post exception to companion repo",
+                    exception=captured_traceback,
+                )
+            finally:
+                if temp_dir:
+                    shutil.rmtree(temp_dir)
+            raise e
+
+    return wrapped_workflow_func
+
+
+AWS_EVENTS_WORKFLOW_DISPATCH_MAP: dict[str, Callable] = {
+    # "enforce": workflow_wrapper(_handle_enforce, "enforce"),
+    # "expire": workflow_wrapper(_handle_expire, "expire"),
+    "import": workflow_wrapper(_handle_import, "import"),
+    # "detect": workflow_wrapper(
+    #     _handle_detect_changes_from_eventbridge, "detect"
+    # ),
+}

--- a/iambic/plugins/v0_1_0/generic_git_provider/generic_git_client.py
+++ b/iambic/plugins/v0_1_0/generic_git_provider/generic_git_client.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import urllib
+
+
+class GenericGitClient(object):
+    def __init__(self, secrets):
+        """
+        secrets has to be a dictionary format as the following
+
+        username: non-empty string (before url_quote_plus)
+        token: non-empty string (before url_quote_plus)
+        clone_url: typically https://git-provider.com/group/repo_name (must be https:// protocol)
+        default_branch_name: typically main or master
+        repo_full_name: must be in group/repo format (like example_corp/iambic-templates)
+        """
+        self.username = secrets["username"]
+        self.token = secrets["token"]
+        self.clone_url = secrets["clone_url"]
+        self.default_branch_name = secrets["default_branch_name"]
+        self.repo_full_name = secrets["repo_full_name"]
+
+        # we should always take the precaution someone did not give us a non-https url
+        assert self.clone_url.startswith("https://")
+        # we should always take the precaution someone did not sneak an @ in the url
+        # that may accidentally be a password. A simple assert may print the potential
+        # url with password
+        if "@" in self.clone_url:
+            raise ValueError("@ is detected in url")
+        self.clone_url_without_protocol = self.clone_url.replace("https://", "")
+
+    @property
+    def repo_url(self):
+        encoded_username = urllib.parse.quote_plus(self.username)
+        encoded_token = urllib.parse.quote_plus(self.token)
+        return f"https://{encoded_username}:{encoded_token}@{self.clone_url_without_protocol}"
+
+
+def create_git_client(secrets):
+    return GenericGitClient(secrets)


### PR DESCRIPTION
## What changed?
* Generic Git Provider that that uses https protocol to check out code. 

## Rationale
* Building the most generic git provider. https checkout capability. The branch does not have any fancy things like comment on pull request. Since I am still sketching out the interface.

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [ ] Unit Tests
- [ ] Functional Tests
- [x] Manually Verified

Run VSCode action: "Iambic: Simulate Generic Git Provider" with GIT_PROVIDER_UNDER_TEST with either `bitbucket`, `codecommit`, or `gitlab`