### PR TITLE
Provide mechanism to override docs json schema

### DIFF
--- a/docs/generate_schema.py
+++ b/docs/generate_schema.py
@@ -69,8 +69,6 @@ models = (
 
 
 def model_customization_for_config(json_schema_string):
-    import os
-
     return json_schema_string.replace(
         os.getcwd(), "."
     )  # i want to replace all current directory string with just "."

--- a/docs/generate_schema.py
+++ b/docs/generate_schema.py
@@ -147,6 +147,10 @@ def create_model_schemas(
             )
 
             text = re.sub(re_pattern_replace_br, r"<br \>", text)
+
+            if class_name in SCHEMA_OVERRIDE_BY_CLASS_NAME:
+                text = SCHEMA_OVERRIDE_BY_CLASS_NAME[class_name](text)
+
             f.write(text)
 
     return schema_md_str

--- a/docs/web/docs/3-reference/3-schemas/aws_identity_center_permission_set_template.json
+++ b/docs/web/docs/3-reference/3-schemas/aws_identity_center_permission_set_template.json
@@ -606,10 +606,17 @@
         "statement": {
           "title": "Statement",
           "description": "List of policy statements",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/PolicyStatement"
-          }
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/PolicyStatement"
+              }
+            },
+            {
+              "$ref": "#/definitions/PolicyStatement"
+            }
+          ]
         }
       }
     },

--- a/docs/web/docs/3-reference/3-schemas/aws_identity_center_permission_set_template.mdx
+++ b/docs/web/docs/3-reference/3-schemas/aws_identity_center_permission_set_template.mdx
@@ -194,8 +194,11 @@ configurations for other models used in IAMbic.
       - *string*
       - *string*
   - **`version`** *(string)*
-  - **`statement`** *(array)*: List of policy statements.
-    - **Items**: Refer to *[#/definitions/PolicyStatement](#definitions/PolicyStatement)*.
+  - **`statement`**: List of policy statements.
+    - **Any of**
+      - *array*
+        - **Items**: Refer to *[#/definitions/PolicyStatement](#definitions/PolicyStatement)*.
+      - : Refer to *[#/definitions/PolicyStatement](#definitions/PolicyStatement)*.
 
 <a id="definitions/ManagedPolicyArn"></a>
 

--- a/docs/web/docs/3-reference/3-schemas/config.json
+++ b/docs/web/docs/3-reference/3-schemas/config.json
@@ -41,27 +41,27 @@
       "default": [
         {
           "type": "DIRECTORY_PATH",
-          "location": "/home/ccastrapel/localrepos/iambic/iambic/plugins/v0_1_0/aws",
+          "location": "./iambic/plugins/v0_1_0/aws",
           "version": "v0.1.0"
         },
         {
           "type": "DIRECTORY_PATH",
-          "location": "/home/ccastrapel/localrepos/iambic/iambic/plugins/v0_1_0/google_workspace",
+          "location": "./iambic/plugins/v0_1_0/google_workspace",
           "version": "v0.1.0"
         },
         {
           "type": "DIRECTORY_PATH",
-          "location": "/home/ccastrapel/localrepos/iambic/iambic/plugins/v0_1_0/okta",
+          "location": "./iambic/plugins/v0_1_0/okta",
           "version": "v0.1.0"
         },
         {
           "type": "DIRECTORY_PATH",
-          "location": "/home/ccastrapel/localrepos/iambic/iambic/plugins/v0_1_0/github",
+          "location": "./iambic/plugins/v0_1_0/github",
           "version": "v0.1.0"
         },
         {
           "type": "DIRECTORY_PATH",
-          "location": "/home/ccastrapel/localrepos/iambic/iambic/plugins/v0_1_0/azure_ad",
+          "location": "./iambic/plugins/v0_1_0/azure_ad",
           "version": "v0.1.0"
         }
       ],
@@ -97,7 +97,8 @@
       "description": "Core configuration options for iambic.",
       "default": {
         "minimum_ulimit": 64000,
-        "exception_reporting": null
+        "exception_reporting": null,
+        "detection_messages": null
       },
       "allOf": [
         {
@@ -251,6 +252,20 @@
         "enabled"
       ]
     },
+    "DetectionMessages": {
+      "title": "DetectionMessages",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "title": "Enabled",
+          "description": "Enable or disable detection messages.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "enabled"
+      ]
+    },
     "CoreConfig": {
       "title": "CoreConfig",
       "type": "object",
@@ -262,6 +277,9 @@
         },
         "exception_reporting": {
           "$ref": "#/definitions/ExceptionReporting"
+        },
+        "detection_messages": {
+          "$ref": "#/definitions/DetectionMessages"
         }
       }
     }

--- a/docs/web/docs/3-reference/3-schemas/config.mdx
+++ b/docs/web/docs/3-reference/3-schemas/config.mdx
@@ -17,14 +17,14 @@ configurations for other models used in IAMbic.
   - **All of**
     - : Refer to *[#/definitions/IambicManaged](#definitions/IambicManaged)*.
 - **`version`** *(string)*: Do not change! The version of iambic this repo is compatible with.
-- **`plugins`** *(array)*: The plugins used by your IAMbic template repo. Default: `[{"type": "DIRECTORY_PATH", "location": "/home/ccastrapel/localrepos/iambic/iambic/plugins/v0_1_0/aws", "version": "v0.1.0"}, {"type": "DIRECTORY_PATH", "location": "/home/ccastrapel/localrepos/iambic/iambic/plugins/v0_1_0/google_workspace", "version": "v0.1.0"}, {"type": "DIRECTORY_PATH", "location": "/home/ccastrapel/localrepos/iambic/iambic/plugins/v0_1_0/okta", "version": "v0.1.0"}, {"type": "DIRECTORY_PATH", "location": "/home/ccastrapel/localrepos/iambic/iambic/plugins/v0_1_0/github", "version": "v0.1.0"}, {"type": "DIRECTORY_PATH", "location": "/home/ccastrapel/localrepos/iambic/iambic/plugins/v0_1_0/azure_ad", "version": "v0.1.0"}]`.
+- **`plugins`** *(array)*: The plugins used by your IAMbic template repo. Default: `[{"type": "DIRECTORY_PATH", "location": "/Users/stevenmoy/noqdev/iambic/iambic/plugins/v0_1_0/aws", "version": "v0.1.0"}, {"type": "DIRECTORY_PATH", "location": "/Users/stevenmoy/noqdev/iambic/iambic/plugins/v0_1_0/google_workspace", "version": "v0.1.0"}, {"type": "DIRECTORY_PATH", "location": "/Users/stevenmoy/noqdev/iambic/iambic/plugins/v0_1_0/okta", "version": "v0.1.0"}, {"type": "DIRECTORY_PATH", "location": "/Users/stevenmoy/noqdev/iambic/iambic/plugins/v0_1_0/github", "version": "v0.1.0"}, {"type": "DIRECTORY_PATH", "location": "/Users/stevenmoy/noqdev/iambic/iambic/plugins/v0_1_0/azure_ad", "version": "v0.1.0"}]`.
   - **Items**: Refer to *[#/definitions/PluginDefinition](#definitions/PluginDefinition)*.
 - **`extends`** *(array)*: Default: `[]`.
   - **Items**: Refer to *[#/definitions/ExtendsConfig](#definitions/ExtendsConfig)*.
 - **`secrets`** *(object)*: Secrets should only be used in memory and never serialized out. Default: `{}`.
 - **`plugin_instances`** *(array)*: A list of the plugin instances parsed as part of the plugin paths.
   - **Items**: Refer to *[#/definitions/ProviderPlugin](#definitions/ProviderPlugin)*.
-- **`core`**: Core configuration options for iambic. Default: `{"minimum_ulimit": 64000, "exception_reporting": null}`.
+- **`core`**: Core configuration options for iambic. Default: `{"minimum_ulimit": 64000, "exception_reporting": null, "detection_messages": null}`.
   - **All of**
     - : Refer to *[#/definitions/CoreConfig](#definitions/CoreConfig)*.
 ## Definitions
@@ -75,8 +75,14 @@ configurations for other models used in IAMbic.
   - **`automatically_send_reports`** *(boolean)*: Automatically send reports without asking for user consent.
   - **`email_address`** *(string)*: Email address for correspondence about the exception, if you would like us to communicate with you.
 
+<a id="definitions/DetectionMessages"></a>
+
+- **`DetectionMessages`** *(object)*
+  - **`enabled`** *(boolean)*: Enable or disable detection messages.
+
 <a id="definitions/CoreConfig"></a>
 
 - **`CoreConfig`** *(object)*
   - **`minimum_ulimit`** *(integer)*: Default: `64000`.
   - **`exception_reporting`**: Refer to *[#/definitions/ExceptionReporting](#definitions/ExceptionReporting)*.
+  - **`detection_messages`**: Refer to *[#/definitions/DetectionMessages](#definitions/DetectionMessages)*.

--- a/docs/web/docs/3-reference/3-schemas/config.mdx
+++ b/docs/web/docs/3-reference/3-schemas/config.mdx
@@ -17,7 +17,7 @@ configurations for other models used in IAMbic.
   - **All of**
     - : Refer to *[#/definitions/IambicManaged](#definitions/IambicManaged)*.
 - **`version`** *(string)*: Do not change! The version of iambic this repo is compatible with.
-- **`plugins`** *(array)*: The plugins used by your IAMbic template repo. Default: `[{"type": "DIRECTORY_PATH", "location": "/Users/stevenmoy/noqdev/iambic/iambic/plugins/v0_1_0/aws", "version": "v0.1.0"}, {"type": "DIRECTORY_PATH", "location": "/Users/stevenmoy/noqdev/iambic/iambic/plugins/v0_1_0/google_workspace", "version": "v0.1.0"}, {"type": "DIRECTORY_PATH", "location": "/Users/stevenmoy/noqdev/iambic/iambic/plugins/v0_1_0/okta", "version": "v0.1.0"}, {"type": "DIRECTORY_PATH", "location": "/Users/stevenmoy/noqdev/iambic/iambic/plugins/v0_1_0/github", "version": "v0.1.0"}, {"type": "DIRECTORY_PATH", "location": "/Users/stevenmoy/noqdev/iambic/iambic/plugins/v0_1_0/azure_ad", "version": "v0.1.0"}]`.
+- **`plugins`** *(array)*: The plugins used by your IAMbic template repo. Default: `[{"type": "DIRECTORY_PATH", "location": "./iambic/plugins/v0_1_0/aws", "version": "v0.1.0"}, {"type": "DIRECTORY_PATH", "location": "./iambic/plugins/v0_1_0/google_workspace", "version": "v0.1.0"}, {"type": "DIRECTORY_PATH", "location": "./iambic/plugins/v0_1_0/okta", "version": "v0.1.0"}, {"type": "DIRECTORY_PATH", "location": "./iambic/plugins/v0_1_0/github", "version": "v0.1.0"}, {"type": "DIRECTORY_PATH", "location": "./iambic/plugins/v0_1_0/azure_ad", "version": "v0.1.0"}]`.
   - **Items**: Refer to *[#/definitions/PluginDefinition](#definitions/PluginDefinition)*.
 - **`extends`** *(array)*: Default: `[]`.
   - **Items**: Refer to *[#/definitions/ExtendsConfig](#definitions/ExtendsConfig)*.


### PR DESCRIPTION
## What changed?
* Config model contain absolute file path. We now have a override function to mudge the schema to generate more appropriate docs.

## Rationale
* Config model contain absolute file path. The implementation in the model is fine because it uses module path at runtime. However, the docs generation makes no sense because it encodes the absolute path. So we provide a mechanism to override the absolute file path and replace all occurance of current working directories with "."

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [ ] Unit Tests
- [ ] Functional Tests
- [x] Manually Verified

In vscode,run generate_schema and verify the diffs.