### PR TITLE
Inline jsonschema2md to handle format

### DIFF
--- a/dev_tools/vendor/jsonschema2md/README.md
+++ b/dev_tools/vendor/jsonschema2md/README.md
@@ -1,0 +1,3 @@
+original project: https://github.com/sbrunner/jsonschema2md
+license:  Apache-2.0 license
+pypi: https://pypi.org/project/jsonschema2md/

--- a/dev_tools/vendor/jsonschema2md/__init__.py
+++ b/dev_tools/vendor/jsonschema2md/__init__.py
@@ -1,0 +1,390 @@
+"""Convert JSON Schema to Markdown documentation."""
+
+
+from __future__ import annotations
+
+__author__ = "Stéphane Brunner"
+__email__ = "stephane.brunner@gmail.com"
+__license__ = "Apache-2.0"
+
+
+# disable because of pre-commit complains
+# try:
+#     from importlib.metadata import version
+# except ImportError:
+#     from importlib_metadata import version
+
+import argparse
+import io
+import json
+import re
+import subprocess  # nosec
+import sys
+from collections.abc import Sequence
+from typing import Optional, Union
+
+import yaml
+
+# disable this line because we are inline the entire file
+# __version__ = version("jsonschema2md")
+
+
+class Parser:
+    """
+    JSON Schema to Markdown parser.
+
+    Examples
+    --------
+    >>> import jsonschema2md
+    >>> parser = jsonschema2md.Parser()
+    >>> md_lines = parser.parse_schema(json.load(input_json))
+    """
+
+    tab_size = 2
+
+    def __init__(self, examples_as_yaml: bool = False, show_examples: str = "all"):
+        """
+        Setup JSON Schema to Markdown parser.
+
+        Parameters
+        ----------
+        examples_as_yaml : bool, default False
+            Parse examples in YAML-format instead of JSON.
+        show_examples: str, default 'all'
+            Parse examples for only objects, only properties or all. Valid options are
+            `{"all", "object", "properties"}`.
+
+        """
+        self.examples_as_yaml = examples_as_yaml
+
+        valid_show_examples_options = ["all", "object", "properties"]
+        show_examples = show_examples.lower()
+        if show_examples in valid_show_examples_options:
+            self.show_examples = show_examples
+        else:
+            raise ValueError(
+                f"`show_examples` option should be one of "
+                f"`{valid_show_examples_options}`; `{show_examples}` was passed."
+            )
+
+    def _construct_description_line(
+        self, obj: dict, add_type: bool = False
+    ) -> Sequence[str]:
+        """Construct description line of property, definition, or item."""
+        description_line = []
+
+        if "description" in obj:
+            ending = "" if re.search(r"[.?!;]$", obj["description"]) else "."
+            description_line.append(f"{obj['description']}{ending}")
+        if add_type:
+            if "type" in obj:
+                description_line.append(f"Must be of type *{obj['type']}*.")
+        if "minimum" in obj:
+            description_line.append(f"Minimum: `{obj['minimum']}`.")
+        if "exclusiveMinimum" in obj:
+            description_line.append(f"Exclusive minimum: `{obj['exclusiveMinimum']}`.")
+        if "maximum" in obj:
+            description_line.append(f"Maximum: `{obj['maximum']}`.")
+        if "exclusiveMaximum" in obj:
+            description_line.append(f"Exclusive maximum: `{obj['exclusiveMaximum']}`.")
+        if "minItems" in obj or "maxItems" in obj:
+            length_description = "Length must be "
+            if "minItems" in obj and "maxItems" not in obj:
+                length_description += f"at least {obj['minItems']}."
+            elif "maxItems" in obj and "minItems" not in obj:
+                length_description += f"at most {obj['maxItems']}."
+            elif obj["minItems"] == obj["maxItems"]:
+                length_description += f"equal to {obj['minItems']}."
+            else:
+                length_description += (
+                    f"between {obj['minItems']} and {obj['maxItems']} (inclusive)."
+                )
+            description_line.append(length_description)
+        if "enum" in obj:
+            description_line.append(f"Must be one of: `{json.dumps(obj['enum'])}`.")
+        if "additionalProperties" in obj:
+            if obj["additionalProperties"]:
+                description_line.append("Can contain additional properties.")
+            else:
+                description_line.append("Cannot contain additional properties.")
+        if "$ref" in obj:
+            description_line.append(f"Refer to *[{obj['$ref']}](#{obj['$ref'][2:]})*.")
+        if "default" in obj:
+            description_line.append(f"Default: `{json.dumps(obj['default'])}`.")
+
+        # Only add start colon if items were added
+        if description_line:
+            description_line.insert(0, ":")
+
+        return description_line
+
+    def _construct_examples(
+        self, obj: dict, indent_level: int = 0, add_header: bool = True
+    ) -> Sequence[str]:
+        def dump_json_with_line_head(obj, line_head, **kwargs):
+            result = [
+                line_head + line
+                for line in io.StringIO(json.dumps(obj, **kwargs)).readlines()
+            ]
+            return "".join(result)
+
+        def dump_yaml_with_line_head(obj, line_head, **kwargs):
+            result = [
+                line_head + line
+                for line in io.StringIO(yaml.dump(obj, **kwargs)).readlines()
+            ]
+            return "".join(result).rstrip()
+
+        example_lines = []
+        if "examples" in obj:
+            example_indentation = " " * self.tab_size * (indent_level + 1)
+            if add_header:
+                example_lines.append(f"\n{example_indentation}Examples:\n")
+            for example in obj["examples"]:
+                if self.examples_as_yaml:
+                    lang = "yaml"
+                    dump_fn = dump_yaml_with_line_head
+                else:
+                    lang = "json"
+                    dump_fn = dump_json_with_line_head
+                example_str = dump_fn(example, line_head=example_indentation, indent=4)
+                example_lines.append(
+                    f"{example_indentation}```{lang}\n{example_str}\n{example_indentation}```\n\n"
+                )
+        return example_lines
+
+    def _parse_object(
+        self,
+        obj: Union[dict, list],
+        name: Optional[str],
+        name_monospace: bool = True,
+        output_lines: Optional[list[str]] = None,
+        indent_level: int = 0,
+        path: Optional[list[str]] = None,
+        required: bool = False,
+    ) -> Sequence[str]:
+        """Parse JSON object and its items, definitions, and properties recursively."""
+
+        if not output_lines:
+            output_lines = []
+
+        indentation = " " * self.tab_size * indent_level
+        indentation_items = " " * self.tab_size * (indent_level + 1)
+
+        if isinstance(obj, list):
+            output_lines.append(f"{indentation}- **{name}**:\n")
+
+            for element in obj:
+                output_lines = self._parse_object(
+                    element,
+                    None,
+                    name_monospace=False,
+                    output_lines=output_lines,
+                    indent_level=indent_level + 2,
+                )
+            return output_lines
+
+        if not isinstance(obj, dict):
+            raise TypeError(
+                f"Non-object type found in properties list: `{name}: {obj}`."
+            )
+
+        # Construct full description line
+        description_line_base = self._construct_description_line(obj)
+        description_line = list(
+            map(
+                lambda line: line.replace("\n\n", "<br>" + indentation_items),
+                description_line_base,
+            )
+        )
+
+        # Add full line to output
+        description_line = " ".join(description_line)
+        optional_format_line = ""
+        if name is None:
+            obj_type = f"*{obj['type']}*" if "type" in obj else ""
+            name_formatted = ""
+            # support like string with format like datetime
+            optional_format_line = f" ({obj['format']})" if "format" in obj else ""
+        else:
+            required_str = ", required" if required else ""
+            obj_type = f" *({obj['type']}{required_str})*" if "type" in obj else ""
+            name_formatted = f"**`{name}`**" if name_monospace else f"**{name}**"
+        anchor = f"<a id=\"{'/'.join(path)}\"></a>" if path else ""
+        output_lines.append(
+            f"{indentation}- {anchor}{name_formatted}{obj_type}{optional_format_line}{description_line}\n"
+        )
+
+        # Recursively parse subschemas following schema composition keywords
+        schema_composition_keyword_map = {
+            "allOf": "All of",
+            "anyOf": "Any of",
+            "oneOf": "One of",
+        }
+        for key, label in schema_composition_keyword_map.items():
+            if key in obj:
+                output_lines.append(f"{indentation_items}- **{label}**\n")
+                for child_obj in obj[key]:
+                    output_lines = self._parse_object(
+                        child_obj,
+                        None,
+                        name_monospace=False,
+                        output_lines=output_lines,
+                        indent_level=indent_level + 2,
+                    )
+
+        # Recursively add items and definitions
+        for property_name in ["items", "definitions"]:
+            if property_name in obj:
+                output_lines = self._parse_object(
+                    obj[property_name],
+                    property_name.capitalize(),
+                    name_monospace=False,
+                    output_lines=output_lines,
+                    indent_level=indent_level + 1,
+                )
+
+        # Recursively add additional child properties
+        if "additionalProperties" in obj and isinstance(
+            obj["additionalProperties"], dict
+        ):
+            output_lines = self._parse_object(
+                obj["additionalProperties"],
+                "Additional Properties",
+                name_monospace=False,
+                output_lines=output_lines,
+                indent_level=indent_level + 1,
+            )
+
+        # Recursively add child properties
+        for property_name in ["properties", "patternProperties"]:
+            if property_name in obj:
+                for property_name, property_obj in obj[property_name].items():
+                    output_lines = self._parse_object(
+                        property_obj,
+                        property_name,
+                        output_lines=output_lines,
+                        indent_level=indent_level + 1,
+                        required=property_name in obj.get("required", []),
+                    )
+
+        # Add examples
+        if self.show_examples in ["all", "properties"]:
+            output_lines.extend(
+                self._construct_examples(obj, indent_level=indent_level)
+            )
+
+        return output_lines
+
+    def parse_schema(self, schema_object: dict) -> Sequence[str]:
+        """Parse JSON Schema object to markdown text."""
+        output_lines = []
+
+        # Add title and description
+        if "title" in schema_object:
+            output_lines.append(f"# {schema_object['title']}\n\n")
+        else:
+            output_lines.append("# JSON Schema\n\n")
+        if "description" in schema_object:
+            output_lines.append(f"*{schema_object['description']}*\n\n")
+
+        # Add items
+        if "items" in schema_object:
+            output_lines.append("## Items\n\n")
+            output_lines.extend(
+                self._parse_object(
+                    schema_object["items"], "Items", name_monospace=False
+                )
+            )
+
+        # Add additional properties
+        if "additionalProperties" in schema_object and isinstance(
+            schema_object["additionalProperties"], dict
+        ):
+            output_lines.append("## Additional Properties\n\n")
+            output_lines.extend(
+                self._parse_object(
+                    schema_object["additionalProperties"],
+                    "Additional Properties",
+                    name_monospace=False,
+                )
+            )
+
+        # Add pattern properties
+        if "patternProperties" in schema_object:
+            output_lines.append("## Pattern Properties\n\n")
+            for obj_name, obj in schema_object["patternProperties"].items():
+                output_lines.extend(self._parse_object(obj, obj_name))
+
+        # Add properties and definitions
+        for name in ["properties", "definitions"]:
+            if name in schema_object:
+                output_lines.append(f"## {name.capitalize()}\n\n")
+                for obj_name, obj in schema_object[name].items():
+                    path = [name, obj_name] if name == "definitions" else []
+                    output_lines.extend(self._parse_object(obj, obj_name, path=path))
+
+        # Add examples
+        if "examples" in schema_object and self.show_examples in ["all", "object"]:
+            output_lines.append("## Examples\n\n")
+            output_lines.extend(
+                self._construct_examples(
+                    schema_object, indent_level=0, add_header=False
+                )
+            )
+
+        return output_lines
+
+
+def main():
+    """Convert JSON Schema to Markdown documentation."""
+
+    argparser = argparse.ArgumentParser(
+        "Convert JSON Schema to Markdown documentation."
+    )
+    argparser.add_argument(
+        "--version", action="store_true", help="Show version and exit."
+    )
+    argparser.add_argument(
+        "--pre-commit",
+        action="store_true",
+        help="Run as pre-commit hook after the generation.",
+    )
+    argparser.add_argument(
+        "--examples-as-yaml",
+        action="store_true",
+        help="Parse examples in YAML-format instead of JSON.",
+    )
+    argparser.add_argument(
+        "--show-examples",
+        choices=["all", "properties", "object"],
+        default="all",
+        help="Parse examples for only the main object, only properties, or all.",
+    )
+    argparser.add_argument("input_json", help="Input JSON file.")
+    argparser.add_argument("output_markdown", help="Output Markdown file.")
+
+    args = argparser.parse_args()
+
+    if args.version:
+        # disable because of vendoring
+        # print(__version__)
+        sys.exit(0)
+
+    parser = Parser(
+        examples_as_yaml=args.examples_as_yaml, show_examples=args.show_examples
+    )
+    with open(args.input_json, encoding="utf-8") as input_json:
+        output_md = parser.parse_schema(json.load(input_json))
+
+    with open(args.output_markdown, "w", encoding="utf-8") as output_markdown:
+        output_markdown.writelines(output_md)
+
+    if args.pre_commit:
+        subprocess.run(  # pylint: disable=subprocess-run-check # nosec
+            ["pre-commit", "run", "--color=never", f"--files={args.output_markdown}"]
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/generate_schema.py
+++ b/docs/generate_schema.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import os
 import re
 
-import jsonschema2md2
+# inline jsonschem2md via vendor
+import dev_tools.vendor.jsonschema2md as jsonschema2md2
 
 from iambic.config.dynamic_config import Config, ExtendsConfig
 from iambic.core.logger import log

--- a/docs/web/docs/3-reference/3-schemas/aws_iam_group_template.mdx
+++ b/docs/web/docs/3-reference/3-schemas/aws_iam_group_template.mdx
@@ -20,14 +20,14 @@ configurations for other models used in IAMbic.
 - **`expires_at`**: The date and time the resource will be/was set to deleted.
   - **Any of**
     - *string*
-    - *string*
-    - *string*
+    - *string* (date-time)
+    - *string* (date)
 - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
 - **`expires_at_default`**: A value that is set by IAMbic at run time and should not be set by the user.
   - **Any of**
     - *string*
-    - *string*
-    - *string*
+    - *string* (date-time)
+    - *string* (date)
 - **`template_type`** *(string)*: Default: `"NOQ::AWS::IAM::Group"`.
 - **`template_schema_url`** *(string)*: Default: `"https://docs.iambic.org/reference/schemas/aws_iam_group_template"`.
 - **`owner`** *(string)*: Owner of the group.
@@ -66,14 +66,14 @@ configurations for other models used in IAMbic.
   - **`expires_at`**: The date and time the resource will be/was set to deleted.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
   - **`expires_at_default`**: A value that is set by IAMbic at run time and should not be set by the user.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`included_accounts`** *(array)*: A list of account ids and/or account names this statement applies to. Account ids/names can be represented as a regex and string. Default: `["*"]`.
     - **Items** *(string)*
   - **`excluded_accounts`** *(array)*: A list of account ids and/or account names this statement explicitly does not apply to. Account ids/names can be represented as a regex and string. Default: `[]`.
@@ -82,7 +82,7 @@ configurations for other models used in IAMbic.
     - **Items** *(string)*
   - **`excluded_orgs`** *(array)*: A list of AWS organization ids this statement explicitly does not apply to. Org ids can be represented as a regex and string. Default: `[]`.
     - **Items** *(string)*
-  - **`policy_arn`** *(string)*
+  - **`policy_arn`** *(string, required)*
   - **`policy_name`** *(string)*
 
 <a id="definitions/Principal"></a>
@@ -117,14 +117,14 @@ configurations for other models used in IAMbic.
   - **`expires_at`**: The date and time the resource will be/was set to deleted.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
   - **`expires_at_default`**: A value that is set by IAMbic at run time and should not be set by the user.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`included_accounts`** *(array)*: A list of account ids and/or account names this statement applies to. Account ids/names can be represented as a regex and string. Default: `["*"]`.
     - **Items** *(string)*
   - **`excluded_accounts`** *(array)*: A list of account ids and/or account names this statement explicitly does not apply to. Account ids/names can be represented as a regex and string. Default: `[]`.
@@ -133,7 +133,7 @@ configurations for other models used in IAMbic.
     - **Items** *(string)*
   - **`excluded_orgs`** *(array)*: A list of AWS organization ids this statement explicitly does not apply to. Org ids can be represented as a regex and string. Default: `[]`.
     - **Items** *(string)*
-  - **`effect`** *(string)*: Allow | Deny.
+  - **`effect`** *(string, required)*: Allow | Deny.
   - **`principal`**
     - **Any of**
       - : Refer to *[#/definitions/Principal](#definitions/Principal)*.
@@ -172,14 +172,14 @@ configurations for other models used in IAMbic.
   - **`expires_at`**: The date and time the resource will be/was set to deleted.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
   - **`expires_at_default`**: A value that is set by IAMbic at run time and should not be set by the user.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`included_accounts`** *(array)*: A list of account ids and/or account names this statement applies to. Account ids/names can be represented as a regex and string. Default: `["*"]`.
     - **Items** *(string)*
   - **`excluded_accounts`** *(array)*: A list of account ids and/or account names this statement explicitly does not apply to. Account ids/names can be represented as a regex and string. Default: `[]`.
@@ -188,7 +188,7 @@ configurations for other models used in IAMbic.
     - **Items** *(string)*
   - **`excluded_orgs`** *(array)*: A list of AWS organization ids this statement explicitly does not apply to. Org ids can be represented as a regex and string. Default: `[]`.
     - **Items** *(string)*
-  - **`policy_name`** *(string)*: The name of the policy.
+  - **`policy_name`** *(string, required)*: The name of the policy.
   - **`version`** *(string)*
   - **`statement`**: List of policy statements.
     - **Any of**
@@ -201,7 +201,7 @@ configurations for other models used in IAMbic.
 
 - **`GroupProperties`** *(object)*: A base model class that provides additional helper methods and
 configurations for other models used in IAMbic.
-  - **`group_name`** *(string)*: Name of the group.
+  - **`group_name`** *(string, required)*: Name of the group.
   - **`path`**: Default: `"/"`.
     - **Any of**
       - *string*

--- a/docs/web/docs/3-reference/3-schemas/aws_iam_managed_policy_template.mdx
+++ b/docs/web/docs/3-reference/3-schemas/aws_iam_managed_policy_template.mdx
@@ -20,14 +20,14 @@ configurations for other models used in IAMbic.
 - **`expires_at`**: The date and time the resource will be/was set to deleted.
   - **Any of**
     - *string*
-    - *string*
-    - *string*
+    - *string* (date-time)
+    - *string* (date)
 - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
 - **`expires_at_default`**: A value that is set by IAMbic at run time and should not be set by the user.
   - **Any of**
     - *string*
-    - *string*
-    - *string*
+    - *string* (date-time)
+    - *string* (date)
 - **`template_type`** *(string)*: Default: `"NOQ::AWS::IAM::ManagedPolicy"`.
 - **`template_schema_url`** *(string)*: Default: `"https://docs.iambic.org/reference/schemas/aws_iam_managed_policy_template"`.
 - **`owner`** *(string)*
@@ -105,14 +105,14 @@ configurations for other models used in IAMbic.
   - **`expires_at`**: The date and time the resource will be/was set to deleted.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
   - **`expires_at_default`**: A value that is set by IAMbic at run time and should not be set by the user.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`included_accounts`** *(array)*: A list of account ids and/or account names this statement applies to. Account ids/names can be represented as a regex and string. Default: `["*"]`.
     - **Items** *(string)*
   - **`excluded_accounts`** *(array)*: A list of account ids and/or account names this statement explicitly does not apply to. Account ids/names can be represented as a regex and string. Default: `[]`.
@@ -121,7 +121,7 @@ configurations for other models used in IAMbic.
     - **Items** *(string)*
   - **`excluded_orgs`** *(array)*: A list of AWS organization ids this statement explicitly does not apply to. Org ids can be represented as a regex and string. Default: `[]`.
     - **Items** *(string)*
-  - **`effect`** *(string)*: Allow | Deny.
+  - **`effect`** *(string, required)*: Allow | Deny.
   - **`principal`**
     - **Any of**
       - : Refer to *[#/definitions/Principal](#definitions/Principal)*.
@@ -187,22 +187,22 @@ configurations for other models used in IAMbic.
   - **`expires_at`**: The date and time the resource will be/was set to deleted.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
   - **`expires_at_default`**: A value that is set by IAMbic at run time and should not be set by the user.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
-  - **`key`** *(string)*
-  - **`value`** *(string)*
+      - *string* (date-time)
+      - *string* (date)
+  - **`key`** *(string, required)*
+  - **`value`** *(string, required)*
 
 <a id="definitions/ManagedPolicyProperties"></a>
 
 - **`ManagedPolicyProperties`** *(object)*: A base model class that provides additional helper methods and
 configurations for other models used in IAMbic.
-  - **`policy_name`** *(string)*: The name of the policy.
+  - **`policy_name`** *(string, required)*: The name of the policy.
   - **`path`**: Default: `"/"`.
     - **Any of**
       - *string*

--- a/docs/web/docs/3-reference/3-schemas/aws_iam_role_template.mdx
+++ b/docs/web/docs/3-reference/3-schemas/aws_iam_role_template.mdx
@@ -20,14 +20,14 @@ configurations for other models used in IAMbic.
 - **`expires_at`**: The date and time the resource will be/was set to deleted.
   - **Any of**
     - *string*
-    - *string*
-    - *string*
+    - *string* (date-time)
+    - *string* (date)
 - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
 - **`expires_at_default`**: A value that is set by IAMbic at run time and should not be set by the user.
   - **Any of**
     - *string*
-    - *string*
-    - *string*
+    - *string* (date-time)
+    - *string* (date)
 - **`template_type`** *(string)*: Default: `"NOQ::AWS::IAM::Role"`.
 - **`template_schema_url`** *(string)*: Default: `"https://docs.iambic.org/reference/schemas/aws_iam_role_template"`.
 - **`owner`** *(string)*: Owner of the role.
@@ -74,7 +74,7 @@ configurations for other models used in IAMbic.
     - **Items** *(string)*
   - **`excluded_orgs`** *(array)*: A list of AWS organization ids this statement explicitly does not apply to. Org ids can be represented as a regex and string. Default: `[]`.
     - **Items** *(string)*
-  - **`max_session_duration`** *(integer)*
+  - **`max_session_duration`** *(integer, required)*
 
 <a id="definitions/Path"></a>
 
@@ -104,15 +104,15 @@ configurations for other models used in IAMbic.
   - **`expires_at`**: The date and time the resource will be/was set to deleted.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
   - **`expires_at_default`**: A value that is set by IAMbic at run time and should not be set by the user.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
-  - **`policy_arn`** *(string)*
+      - *string* (date-time)
+      - *string* (date)
+  - **`policy_arn`** *(string, required)*
   - **`permissions_boundary_type`** *(string)*
 
 <a id="definitions/Principal"></a>
@@ -147,14 +147,14 @@ configurations for other models used in IAMbic.
   - **`expires_at`**: The date and time the resource will be/was set to deleted.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
   - **`expires_at_default`**: A value that is set by IAMbic at run time and should not be set by the user.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`included_accounts`** *(array)*: A list of account ids and/or account names this statement applies to. Account ids/names can be represented as a regex and string. Default: `["*"]`.
     - **Items** *(string)*
   - **`excluded_accounts`** *(array)*: A list of account ids and/or account names this statement explicitly does not apply to. Account ids/names can be represented as a regex and string. Default: `[]`.
@@ -163,7 +163,7 @@ configurations for other models used in IAMbic.
     - **Items** *(string)*
   - **`excluded_orgs`** *(array)*: A list of AWS organization ids this statement explicitly does not apply to. Org ids can be represented as a regex and string. Default: `[]`.
     - **Items** *(string)*
-  - **`effect`** *(string)*: Allow | Deny.
+  - **`effect`** *(string, required)*: Allow | Deny.
   - **`principal`**
     - **Any of**
       - : Refer to *[#/definitions/Principal](#definitions/Principal)*.
@@ -229,16 +229,16 @@ configurations for other models used in IAMbic.
   - **`expires_at`**: The date and time the resource will be/was set to deleted.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
   - **`expires_at_default`**: A value that is set by IAMbic at run time and should not be set by the user.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
-  - **`key`** *(string)*
-  - **`value`** *(string)*
+      - *string* (date-time)
+      - *string* (date)
+  - **`key`** *(string, required)*
+  - **`value`** *(string, required)*
 
 <a id="definitions/ManagedPolicyRef"></a>
 
@@ -247,14 +247,14 @@ configurations for other models used in IAMbic.
   - **`expires_at`**: The date and time the resource will be/was set to deleted.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
   - **`expires_at_default`**: A value that is set by IAMbic at run time and should not be set by the user.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`included_accounts`** *(array)*: A list of account ids and/or account names this statement applies to. Account ids/names can be represented as a regex and string. Default: `["*"]`.
     - **Items** *(string)*
   - **`excluded_accounts`** *(array)*: A list of account ids and/or account names this statement explicitly does not apply to. Account ids/names can be represented as a regex and string. Default: `[]`.
@@ -263,7 +263,7 @@ configurations for other models used in IAMbic.
     - **Items** *(string)*
   - **`excluded_orgs`** *(array)*: A list of AWS organization ids this statement explicitly does not apply to. Org ids can be represented as a regex and string. Default: `[]`.
     - **Items** *(string)*
-  - **`policy_arn`** *(string)*
+  - **`policy_arn`** *(string, required)*
   - **`policy_name`** *(string)*
 
 <a id="definitions/PolicyDocument"></a>
@@ -273,14 +273,14 @@ configurations for other models used in IAMbic.
   - **`expires_at`**: The date and time the resource will be/was set to deleted.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
   - **`expires_at_default`**: A value that is set by IAMbic at run time and should not be set by the user.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`included_accounts`** *(array)*: A list of account ids and/or account names this statement applies to. Account ids/names can be represented as a regex and string. Default: `["*"]`.
     - **Items** *(string)*
   - **`excluded_accounts`** *(array)*: A list of account ids and/or account names this statement explicitly does not apply to. Account ids/names can be represented as a regex and string. Default: `[]`.
@@ -289,7 +289,7 @@ configurations for other models used in IAMbic.
     - **Items** *(string)*
   - **`excluded_orgs`** *(array)*: A list of AWS organization ids this statement explicitly does not apply to. Org ids can be represented as a regex and string. Default: `[]`.
     - **Items** *(string)*
-  - **`policy_name`** *(string)*: The name of the policy.
+  - **`policy_name`** *(string, required)*: The name of the policy.
   - **`version`** *(string)*
   - **`statement`**: List of policy statements.
     - **Any of**
@@ -302,7 +302,7 @@ configurations for other models used in IAMbic.
 
 - **`RoleProperties`** *(object)*: A base model class that provides additional helper methods and
 configurations for other models used in IAMbic.
-  - **`role_name`** *(string)*: Name of the role.
+  - **`role_name`** *(string, required)*: Name of the role.
   - **`description`**: Description of the role. Default: `""`.
     - **Any of**
       - *string*
@@ -350,14 +350,14 @@ configurations for other models used in IAMbic.
   - **`expires_at`**: The date and time the resource will be/was set to deleted.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
   - **`expires_at_default`**: A value that is set by IAMbic at run time and should not be set by the user.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`users`** *(array)*: List of users who can assume into the role. Default: `[]`.
     - **Items** *(string)*
   - **`groups`** *(array)*: List of groups. Users in one or more of the groups can assume into the role. Default: `[]`.

--- a/docs/web/docs/3-reference/3-schemas/aws_iam_user_template.mdx
+++ b/docs/web/docs/3-reference/3-schemas/aws_iam_user_template.mdx
@@ -20,14 +20,14 @@ configurations for other models used in IAMbic.
 - **`expires_at`**: The date and time the resource will be/was set to deleted.
   - **Any of**
     - *string*
-    - *string*
-    - *string*
+    - *string* (date-time)
+    - *string* (date)
 - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
 - **`expires_at_default`**: A value that is set by IAMbic at run time and should not be set by the user.
   - **Any of**
     - *string*
-    - *string*
-    - *string*
+    - *string* (date-time)
+    - *string* (date)
 - **`template_type`** *(string)*: Default: `"NOQ::AWS::IAM::User"`.
 - **`template_schema_url`** *(string)*: Default: `"https://docs.iambic.org/reference/schemas/aws_iam_user_template"`.
 - **`owner`** *(string)*
@@ -74,15 +74,15 @@ configurations for other models used in IAMbic.
   - **`expires_at`**: The date and time the resource will be/was set to deleted.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
   - **`expires_at_default`**: A value that is set by IAMbic at run time and should not be set by the user.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
-  - **`policy_arn`** *(string)*
+      - *string* (date-time)
+      - *string* (date)
+  - **`policy_arn`** *(string, required)*
   - **`permissions_boundary_type`** *(string)*
 
 <a id="definitions/Tag"></a>
@@ -100,16 +100,16 @@ configurations for other models used in IAMbic.
   - **`expires_at`**: The date and time the resource will be/was set to deleted.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
   - **`expires_at_default`**: A value that is set by IAMbic at run time and should not be set by the user.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
-  - **`key`** *(string)*
-  - **`value`** *(string)*
+      - *string* (date-time)
+      - *string* (date)
+  - **`key`** *(string, required)*
+  - **`value`** *(string, required)*
 
 <a id="definitions/Group"></a>
 
@@ -126,15 +126,15 @@ configurations for other models used in IAMbic.
   - **`expires_at`**: The date and time the resource will be/was set to deleted.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
   - **`expires_at_default`**: A value that is set by IAMbic at run time and should not be set by the user.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
-  - **`group_name`** *(string)*
+      - *string* (date-time)
+      - *string* (date)
+  - **`group_name`** *(string, required)*
   - **`arn`** *(string)*: ARN of the group. Default: `""`.
   - **`create_date`** *(string)*: Date the group was created. Default: `""`.
   - **`group_id`** *(string)*: ID of the group. Default: `""`.
@@ -148,14 +148,14 @@ configurations for other models used in IAMbic.
   - **`expires_at`**: The date and time the resource will be/was set to deleted.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
   - **`expires_at_default`**: A value that is set by IAMbic at run time and should not be set by the user.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`included_accounts`** *(array)*: A list of account ids and/or account names this statement applies to. Account ids/names can be represented as a regex and string. Default: `["*"]`.
     - **Items** *(string)*
   - **`excluded_accounts`** *(array)*: A list of account ids and/or account names this statement explicitly does not apply to. Account ids/names can be represented as a regex and string. Default: `[]`.
@@ -164,7 +164,7 @@ configurations for other models used in IAMbic.
     - **Items** *(string)*
   - **`excluded_orgs`** *(array)*: A list of AWS organization ids this statement explicitly does not apply to. Org ids can be represented as a regex and string. Default: `[]`.
     - **Items** *(string)*
-  - **`policy_arn`** *(string)*
+  - **`policy_arn`** *(string, required)*
   - **`policy_name`** *(string)*
 
 <a id="definitions/Principal"></a>
@@ -199,14 +199,14 @@ configurations for other models used in IAMbic.
   - **`expires_at`**: The date and time the resource will be/was set to deleted.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
   - **`expires_at_default`**: A value that is set by IAMbic at run time and should not be set by the user.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`included_accounts`** *(array)*: A list of account ids and/or account names this statement applies to. Account ids/names can be represented as a regex and string. Default: `["*"]`.
     - **Items** *(string)*
   - **`excluded_accounts`** *(array)*: A list of account ids and/or account names this statement explicitly does not apply to. Account ids/names can be represented as a regex and string. Default: `[]`.
@@ -215,7 +215,7 @@ configurations for other models used in IAMbic.
     - **Items** *(string)*
   - **`excluded_orgs`** *(array)*: A list of AWS organization ids this statement explicitly does not apply to. Org ids can be represented as a regex and string. Default: `[]`.
     - **Items** *(string)*
-  - **`effect`** *(string)*: Allow | Deny.
+  - **`effect`** *(string, required)*: Allow | Deny.
   - **`principal`**
     - **Any of**
       - : Refer to *[#/definitions/Principal](#definitions/Principal)*.
@@ -254,14 +254,14 @@ configurations for other models used in IAMbic.
   - **`expires_at`**: The date and time the resource will be/was set to deleted.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
   - **`expires_at_default`**: A value that is set by IAMbic at run time and should not be set by the user.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`included_accounts`** *(array)*: A list of account ids and/or account names this statement applies to. Account ids/names can be represented as a regex and string. Default: `["*"]`.
     - **Items** *(string)*
   - **`excluded_accounts`** *(array)*: A list of account ids and/or account names this statement explicitly does not apply to. Account ids/names can be represented as a regex and string. Default: `[]`.
@@ -270,7 +270,7 @@ configurations for other models used in IAMbic.
     - **Items** *(string)*
   - **`excluded_orgs`** *(array)*: A list of AWS organization ids this statement explicitly does not apply to. Org ids can be represented as a regex and string. Default: `[]`.
     - **Items** *(string)*
-  - **`policy_name`** *(string)*: The name of the policy.
+  - **`policy_name`** *(string, required)*: The name of the policy.
   - **`version`** *(string)*
   - **`statement`**: List of policy statements.
     - **Any of**
@@ -283,7 +283,7 @@ configurations for other models used in IAMbic.
 
 - **`UserProperties`** *(object)*: A base model class that provides additional helper methods and
 configurations for other models used in IAMbic.
-  - **`user_name`** *(string)*: Name of the user.
+  - **`user_name`** *(string, required)*: Name of the user.
   - **`path`**: Default: `"/"`.
     - **Any of**
       - *string*

--- a/docs/web/docs/3-reference/3-schemas/aws_identity_center_permission_set_template.mdx
+++ b/docs/web/docs/3-reference/3-schemas/aws_identity_center_permission_set_template.mdx
@@ -12,14 +12,14 @@ configurations for other models used in IAMbic.
 - **`expires_at`**: The date and time the resource will be/was set to deleted.
   - **Any of**
     - *string*
-    - *string*
-    - *string*
+    - *string* (date-time)
+    - *string* (date)
 - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
 - **`expires_at_default`**: A value that is set by IAMbic at run time and should not be set by the user.
   - **Any of**
     - *string*
-    - *string*
-    - *string*
+    - *string* (date-time)
+    - *string* (date)
 - **`template_type`** *(string)*: Default: `"NOQ::AWS::IdentityCenter::PermissionSet"`.
 - **`template_schema_url`** *(string)*: Default: `"https://docs.iambic.org/reference/schemas/aws_identity_center_permission_set_template"`.
 - **`owner`** *(string)*: Owner of the permission set.
@@ -60,7 +60,7 @@ configurations for other models used in IAMbic.
 
 - **`SessionDuration`** *(object)*: A base model class that provides additional helper methods and
 configurations for other models used in IAMbic.
-  - **`session_duration`** *(string)*
+  - **`session_duration`** *(string, required)*
 
 <a id="definitions/CustomerManagedPolicyReference"></a>
 
@@ -69,16 +69,16 @@ configurations for other models used in IAMbic.
   - **`expires_at`**: The date and time the resource will be/was set to deleted.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
   - **`expires_at_default`**: A value that is set by IAMbic at run time and should not be set by the user.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`path`** *(string)*: The path to the IAM policy that you have configured in each account where you want to deploy your permission set. The default is /. For more information, see Friendly names and paths in the IAM User Guide. Default: `"/"`.
-  - **`name`** *(string)*
+  - **`name`** *(string, required)*
 
 <a id="definitions/PermissionBoundary"></a>
 
@@ -87,14 +87,14 @@ configurations for other models used in IAMbic.
   - **`expires_at`**: The date and time the resource will be/was set to deleted.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
   - **`expires_at_default`**: A value that is set by IAMbic at run time and should not be set by the user.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`customer_managed_policy_reference`**: Refer to *[#/definitions/CustomerManagedPolicyReference](#definitions/CustomerManagedPolicyReference)*.
   - **`managed_policy_arn`** *(string)*
 
@@ -130,14 +130,14 @@ configurations for other models used in IAMbic.
   - **`expires_at`**: The date and time the resource will be/was set to deleted.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
   - **`expires_at_default`**: A value that is set by IAMbic at run time and should not be set by the user.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`included_accounts`** *(array)*: A list of account ids and/or account names this statement applies to. Account ids/names can be represented as a regex and string. Default: `["*"]`.
     - **Items** *(string)*
   - **`excluded_accounts`** *(array)*: A list of account ids and/or account names this statement explicitly does not apply to. Account ids/names can be represented as a regex and string. Default: `[]`.
@@ -146,7 +146,7 @@ configurations for other models used in IAMbic.
     - **Items** *(string)*
   - **`excluded_orgs`** *(array)*: A list of AWS organization ids this statement explicitly does not apply to. Org ids can be represented as a regex and string. Default: `[]`.
     - **Items** *(string)*
-  - **`effect`** *(string)*: Allow | Deny.
+  - **`effect`** *(string, required)*: Allow | Deny.
   - **`principal`**
     - **Any of**
       - : Refer to *[#/definitions/Principal](#definitions/Principal)*.
@@ -185,14 +185,14 @@ configurations for other models used in IAMbic.
   - **`expires_at`**: The date and time the resource will be/was set to deleted.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
   - **`expires_at_default`**: A value that is set by IAMbic at run time and should not be set by the user.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`version`** *(string)*
   - **`statement`**: List of policy statements.
     - **Any of**
@@ -207,15 +207,15 @@ configurations for other models used in IAMbic.
   - **`expires_at`**: The date and time the resource will be/was set to deleted.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
   - **`expires_at_default`**: A value that is set by IAMbic at run time and should not be set by the user.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
-  - **`arn`** *(string)*
+      - *string* (date-time)
+      - *string* (date)
+  - **`arn`** *(string, required)*
 
 <a id="definitions/Tag"></a>
 
@@ -232,22 +232,22 @@ configurations for other models used in IAMbic.
   - **`expires_at`**: The date and time the resource will be/was set to deleted.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
   - **`expires_at_default`**: A value that is set by IAMbic at run time and should not be set by the user.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
-  - **`key`** *(string)*
-  - **`value`** *(string)*
+      - *string* (date-time)
+      - *string* (date)
+  - **`key`** *(string, required)*
+  - **`value`** *(string, required)*
 
 <a id="definitions/PermissionSetProperties"></a>
 
 - **`PermissionSetProperties`** *(object)*: A base model class that provides additional helper methods and
 configurations for other models used in IAMbic.
-  - **`name`** *(string)*
+  - **`name`** *(string, required)*
   - **`description`**: Description of the permission set.
     - **Any of**
       - *string*
@@ -275,14 +275,14 @@ configurations for other models used in IAMbic.
   - **`expires_at`**: The date and time the resource will be/was set to deleted.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
   - **`expires_at_default`**: A value that is set by IAMbic at run time and should not be set by the user.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`included_accounts`** *(array)*: A list of account ids and/or account names this statement applies to. Account ids/names can be represented as a regex and string. Default: `["*"]`.
     - **Items** *(string)*
   - **`excluded_accounts`** *(array)*: A list of account ids and/or account names this statement explicitly does not apply to. Account ids/names can be represented as a regex and string. Default: `[]`.

--- a/docs/web/docs/3-reference/3-schemas/awsaccount.mdx
+++ b/docs/web/docs/3-reference/3-schemas/awsaccount.mdx
@@ -53,8 +53,8 @@ For Okta, this is the IDP domain
 <a id="definitions/Variable"></a>
 
 - **`Variable`** *(object)*
-  - **`key`** *(string)*
-  - **`value`** *(string)*
+  - **`key`** *(string, required)*
+  - **`value`** *(string, required)*
 
 <a id="definitions/IdentityCenterDetails"></a>
 

--- a/docs/web/docs/3-reference/3-schemas/awsconfig.mdx
+++ b/docs/web/docs/3-reference/3-schemas/awsconfig.mdx
@@ -61,12 +61,12 @@ configurations for other models used in IAMbic.
     - **All of**
       - : Refer to *[#/definitions/RegionName](#definitions/RegionName)*.
   - **`aws_profile`** *(string)*: The AWS profile used when making calls to the account.
-  - **`hub_role_arn`** *(string)*: The role arn to assume into when making calls to the account.
+  - **`hub_role_arn`** *(string, required)*: The role arn to assume into when making calls to the account.
   - **`external_id`** *(string)*: The external id to use for assuming into a role when making calls to the account.
   - **`boto3_session_map`** *(object)*
   - **`org_name`** *(string)*: Optional friendly name for the organization.
   - **`org_id`** *(string)*: A unique identifier designating the identity of the organization.
-  - **`org_account_id`** *(string)*: The AWS Organization's master account ID.
+  - **`org_account_id`** *(string, required)*: The AWS Organization's master account ID.
   - **`identity_center`**: The AWS Account ID and region of the AWS Identity Center instance to use for this organization.
     - **All of**
       - : Refer to *[#/definitions/AWSIdentityCenter](#definitions/AWSIdentityCenter)*.
@@ -85,8 +85,8 @@ configurations for other models used in IAMbic.
 <a id="definitions/Variable"></a>
 
 - **`Variable`** *(object)*
-  - **`key`** *(string)*
-  - **`value`** *(string)*
+  - **`key`** *(string, required)*
+  - **`value`** *(string, required)*
 
 <a id="definitions/IdentityCenterDetails"></a>
 
@@ -118,7 +118,7 @@ For Okta, this is the IDP domain.
       - : Refer to *[#/definitions/IambicManaged](#definitions/IambicManaged)*.
   - **`account_id`** *(string)*: The AWS Account ID.
   - **`org_id`** *(string)*: A unique identifier designating the identity of the organization.
-  - **`account_name`** *(string)*
+  - **`account_name`** *(string, required)*
   - **`partition`**: The AWS partition the account is in. Options are aws, aws-us-gov, and aws-cn. Default: `"aws"`.
     - **All of**
       - : Refer to *[#/definitions/Partition](#definitions/Partition)*.
@@ -133,7 +133,7 @@ For Okta, this is the IDP domain.
 <a id="definitions/ImportRuleTag"></a>
 
 - **`ImportRuleTag`** *(object)*
-  - **`key`** *(string)*: The key of the tag to match.
+  - **`key`** *(string, required)*: The key of the tag to match.
   - **`value`** *(string)*: The value of the tag to match.
 
 <a id="definitions/ImportAction"></a>

--- a/docs/web/docs/3-reference/3-schemas/azure_active_directory_group_template.mdx
+++ b/docs/web/docs/3-reference/3-schemas/azure_active_directory_group_template.mdx
@@ -20,14 +20,14 @@ configurations for other models used in IAMbic.
 - **`expires_at`**: The date and time the resource will be/was set to deleted.
   - **Any of**
     - *string*
-    - *string*
-    - *string*
+    - *string* (date-time)
+    - *string* (date)
 - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
 - **`expires_at_default`**: A value that is set by IAMbic at run time and should not be set by the user.
   - **Any of**
     - *string*
-    - *string*
-    - *string*
+    - *string* (date-time)
+    - *string* (date)
 - **`properties`**: Properties for the Azure AD Group.
   - **All of**
     - : Refer to *[#/definitions/GroupTemplateProperties](#definitions/GroupTemplateProperties)*.
@@ -49,16 +49,16 @@ configurations for other models used in IAMbic.
   - **`expires_at`**: The date and time the resource will be/was set to deleted.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
   - **`expires_at_default`**: A value that is set by IAMbic at run time and should not be set by the user.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`id`** *(string)*: Unique ID for the member. This value is imported by IAMbic, and doesn't need to be manually set.
-  - **`name`** *(string)*
+  - **`name`** *(string, required)*
   - **`data_type`**: Refer to *[#/definitions/MemberDataType](#definitions/MemberDataType)*.
 
 <a id="definitions/GroupTemplateProperties"></a>
@@ -68,15 +68,15 @@ configurations for other models used in IAMbic.
   - **`expires_at`**: The date and time the resource will be/was set to deleted.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
   - **`expires_at_default`**: A value that is set by IAMbic at run time and should not be set by the user.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
-  - **`name`** *(string)*: Name of the group.
+      - *string* (date-time)
+      - *string* (date)
+  - **`name`** *(string, required)*: Name of the group.
   - **`mail_nickname`** *(string)*: Mail nickname of the group.
   - **`group_id`** *(string)*: Unique Group ID for the group. This value is imported by IAMbic, and doesn't need to be manually set.
   - **`description`** *(string)*: Description of the group. Default: `""`.

--- a/docs/web/docs/3-reference/3-schemas/azure_active_directory_user_template.mdx
+++ b/docs/web/docs/3-reference/3-schemas/azure_active_directory_user_template.mdx
@@ -20,14 +20,14 @@ configurations for other models used in IAMbic.
 - **`expires_at`**: The date and time the resource will be/was set to deleted.
   - **Any of**
     - *string*
-    - *string*
-    - *string*
+    - *string* (date-time)
+    - *string* (date)
 - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
 - **`expires_at_default`**: A value that is set by IAMbic at run time and should not be set by the user.
   - **Any of**
     - *string*
-    - *string*
-    - *string*
+    - *string* (date-time)
+    - *string* (date)
 - **`properties`**: Properties for the Azure AD User.
   - **All of**
     - : Refer to *[#/definitions/UserTemplateProperties](#definitions/UserTemplateProperties)*.
@@ -49,17 +49,17 @@ configurations for other models used in IAMbic.
   - **`expires_at`**: The date and time the resource will be/was set to deleted.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
   - **`expires_at_default`**: A value that is set by IAMbic at run time and should not be set by the user.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`user_id`** *(string)*: Unique identifier for the user. This value is imported by IAMbic, and doesn't need to be manually set. Default: `""`.
-  - **`username`** *(string)*
-  - **`display_name`** *(string)*
+  - **`username`** *(string, required)*
+  - **`display_name`** *(string, required)*
   - **`mail_nickname`** *(string)*
   - **`given_name`** *(string)*
   - **`employee_id`** *(string)*

--- a/docs/web/docs/3-reference/3-schemas/azure_adconfig.mdx
+++ b/docs/web/docs/3-reference/3-schemas/azure_adconfig.mdx
@@ -18,10 +18,10 @@ See [Template Schema Validation](/reference/template_validation_ide) to learn ho
 <a id="definitions/AzureADOrganization"></a>
 
 - **`AzureADOrganization`** *(object)*
-  - **`idp_name`** *(string)*
-  - **`tenant_id`** *(string)*
-  - **`client_id`** *(string)*
-  - **`client_secret`** *(string)*
+  - **`idp_name`** *(string, required)*
+  - **`tenant_id`** *(string, required)*
+  - **`client_id`** *(string, required)*
+  - **`client_secret`** *(string, required)*
   - **`request_timeout`** *(integer)*: Default: `60`.
   - **`client`**
   - **`access_token`** *(string)*: Default: `""`.

--- a/docs/web/docs/3-reference/3-schemas/config.mdx
+++ b/docs/web/docs/3-reference/3-schemas/config.mdx
@@ -42,8 +42,8 @@ configurations for other models used in IAMbic.
 
 - **`PluginDefinition`** *(object)*
   - **`type`**: Refer to *[#/definitions/PluginType](#definitions/PluginType)*.
-  - **`location`** *(string)*: The location of the plugin. For a DIRECTORY_PATH, this is the path to the plugin. For a GIT plugin, this is the git url.
-  - **`version`** *(string)*
+  - **`location`** *(string, required)*: The location of the plugin. For a DIRECTORY_PATH, this is the path to the plugin. For a GIT plugin, this is the git url.
+  - **`version`** *(string, required)*
 
 <a id="definitions/ExtendsConfigKey"></a>
 
@@ -53,24 +53,24 @@ configurations for other models used in IAMbic.
 
 - **`ExtendsConfig`** *(object)*
   - **`key`**: Refer to *[#/definitions/ExtendsConfigKey](#definitions/ExtendsConfigKey)*.
-  - **`value`** *(string)*
+  - **`value`** *(string, required)*
   - **`assume_role_arn`** *(string)*
   - **`external_id`** *(string)*
 
 <a id="definitions/ProviderPlugin"></a>
 
 - **`ProviderPlugin`** *(object)*
-  - **`version`** *(string)*: The version of the plugin.
-  - **`config_name`** *(string)*: The name of the provider configuration in the iambic config file.
+  - **`version`** *(string, required)*: The version of the plugin.
+  - **`config_name`** *(string, required)*: The name of the provider configuration in the iambic config file.
   - **`requires_secret`** *(boolean)*: Whether or not the provider requires a secret to be passed in. Default: `false`.
   - **`provider_config`**: The Pydantic model that is attached to the Config.This will contain the provider specific configuration.These are things like the AWSAccount model, OktaOrganization or GoogleProject.
-  - **`templates`** *(array)*: The list of templates used for this provider.
+  - **`templates`** *(array, required)*: The list of templates used for this provider.
     - **Items**
 
 <a id="definitions/ExceptionReporting"></a>
 
 - **`ExceptionReporting`** *(object)*
-  - **`enabled`** *(boolean)*: Enable or disable exception reporting.
+  - **`enabled`** *(boolean, required)*: Enable or disable exception reporting.
   - **`include_variables`** *(boolean)*: Include local variables in the report. Default: `false`.
   - **`automatically_send_reports`** *(boolean)*: Automatically send reports without asking for user consent.
   - **`email_address`** *(string)*: Email address for correspondence about the exception, if you would like us to communicate with you.
@@ -78,7 +78,7 @@ configurations for other models used in IAMbic.
 <a id="definitions/DetectionMessages"></a>
 
 - **`DetectionMessages`** *(object)*
-  - **`enabled`** *(boolean)*: Enable or disable detection messages.
+  - **`enabled`** *(boolean, required)*: Enable or disable detection messages.
 
 <a id="definitions/CoreConfig"></a>
 

--- a/docs/web/docs/3-reference/3-schemas/github_config.mdx
+++ b/docs/web/docs/3-reference/3-schemas/github_config.mdx
@@ -20,5 +20,5 @@ See [Template Schema Validation](/reference/template_validation_ide) to learn ho
 <a id="definitions/GithubBotApprover"></a>
 
 - **`GithubBotApprover`** *(object)*
-  - **`login`** *(string)*: login for allowed bot approver.
-  - **`es256_pub_key`** *(string)*: ES256 Pub Key for allowed bot approver.
+  - **`login`** *(string, required)*: login for allowed bot approver.
+  - **`es256_pub_key`** *(string, required)*: ES256 Pub Key for allowed bot approver.

--- a/docs/web/docs/3-reference/3-schemas/google_workspace_config.mdx
+++ b/docs/web/docs/3-reference/3-schemas/google_workspace_config.mdx
@@ -14,14 +14,14 @@ See [Template Schema Validation](/reference/template_validation_ide) to learn ho
 <a id="definitions/GoogleSubject"></a>
 
 - **`GoogleSubject`** *(object)*
-  - **`domain`** *(string)*
-  - **`service_account`** *(string)*
+  - **`domain`** *(string, required)*
+  - **`service_account`** *(string, required)*
 
 <a id="definitions/Variable"></a>
 
 - **`Variable`** *(object)*
-  - **`key`** *(string)*
-  - **`value`** *(string)*
+  - **`key`** *(string, required)*
+  - **`value`** *(string, required)*
 
 <a id="definitions/IambicManaged"></a>
 
@@ -30,19 +30,19 @@ See [Template Schema Validation](/reference/template_validation_ide) to learn ho
 <a id="definitions/GoogleProject"></a>
 
 - **`GoogleProject`** *(object)*
-  - **`project_id`** *(string)*
+  - **`project_id`** *(string, required)*
   - **`project_name`** *(string)*
-  - **`subjects`** *(array)*
+  - **`subjects`** *(array, required)*
     - **Items**: Refer to *[#/definitions/GoogleSubject](#definitions/GoogleSubject)*.
-  - **`type`** *(string)*
-  - **`private_key_id`** *(string)*
-  - **`private_key`** *(string)*
-  - **`client_email`** *(string)*
-  - **`client_id`** *(string)*
-  - **`auth_uri`** *(string)*
-  - **`token_uri`** *(string)*
-  - **`auth_provider_x509_cert_url`** *(string)*
-  - **`client_x509_cert_url`** *(string)*
+  - **`type`** *(string, required)*
+  - **`private_key_id`** *(string, required)*
+  - **`private_key`** *(string, required)*
+  - **`client_email`** *(string, required)*
+  - **`client_id`** *(string, required)*
+  - **`auth_uri`** *(string, required)*
+  - **`token_uri`** *(string, required)*
+  - **`auth_provider_x509_cert_url`** *(string, required)*
+  - **`client_x509_cert_url`** *(string, required)*
   - **`variables`** *(array)*: A list of variables to be used when creating templates. Default: `[]`.
     - **Items**: Refer to *[#/definitions/Variable](#definitions/Variable)*.
   - **`iambic_managed`**: Controls the directionality of iambic changes. Default: `"undefined"`.

--- a/docs/web/docs/3-reference/3-schemas/google_workspace_group_template.mdx
+++ b/docs/web/docs/3-reference/3-schemas/google_workspace_group_template.mdx
@@ -12,14 +12,14 @@ configurations for other models used in IAMbic.
 - **`expires_at`**: The date and time the resource will be/was set to deleted.
   - **Any of**
     - *string*
-    - *string*
-    - *string*
+    - *string* (date-time)
+    - *string* (date)
 - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
 - **`expires_at_default`**: A value that is set by IAMbic at run time and should not be set by the user.
   - **Any of**
     - *string*
-    - *string*
-    - *string*
+    - *string* (date-time)
+    - *string* (date)
 - **`template_type`** *(string)*: Default: `"NOQ::GoogleWorkspace::Group"`.
 - **`template_schema_url`** *(string)*: Default: `"https://docs.iambic.org/reference/schemas/google_workspace_group_template"`.
 - **`owner`** *(string)*: Owner of the group.
@@ -58,14 +58,14 @@ configurations for other models used in IAMbic.
   - **`expires_at`**: The date and time the resource will be/was set to deleted.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
   - **`expires_at_default`**: A value that is set by IAMbic at run time and should not be set by the user.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`email`** *(string)*: Email address. However, when the type is CUSTOMER, it represents all users in a domain.
   - **`customer_id`** *(string)*: When the type is CUSTOMER, it represents customer id of a domain.
   - **`expand`** *(boolean)*: Expand the group into the members of the group. This is useful for nested groups. Default: `false`.
@@ -106,12 +106,12 @@ configurations for other models used in IAMbic.
 
 - **`GroupProperties`** *(object)*: A base model class that provides additional helper methods and
 configurations for other models used in IAMbic.
-  - **`name`** *(string)*
-  - **`domain`** *(string)*
-  - **`email`** *(string)*
-  - **`description`** *(string)*
+  - **`name`** *(string, required)*
+  - **`domain`** *(string, required)*
+  - **`email`** *(string, required)*
+  - **`description`** *(string, required)*
   - **`welcome_message`** *(string)*
-  - **`members`** *(array)*
+  - **`members`** *(array, required)*
     - **Items**: Refer to *[#/definitions/GroupMember](#definitions/GroupMember)*.
   - **`who_can_invite`**: Default: `"ALL_MANAGERS_CAN_INVITE"`.
     - **All of**

--- a/docs/web/docs/3-reference/3-schemas/okta_app_template.mdx
+++ b/docs/web/docs/3-reference/3-schemas/okta_app_template.mdx
@@ -12,14 +12,14 @@ configurations for other models used in IAMbic.
 - **`expires_at`**: The date and time the resource will be/was set to deleted.
   - **Any of**
     - *string*
-    - *string*
-    - *string*
+    - *string* (date-time)
+    - *string* (date)
 - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
 - **`expires_at_default`**: A value that is set by IAMbic at run time and should not be set by the user.
   - **Any of**
     - *string*
-    - *string*
-    - *string*
+    - *string* (date-time)
+    - *string* (date)
 - **`template_type`** *(string)*: Default: `"NOQ::Okta::App"`.
 - **`template_schema_url`** *(string)*: Default: `"https://docs.iambic.org/reference/schemas/okta_app_template"`.
 - **`owner`** *(string)*: Owner of the app.
@@ -49,14 +49,14 @@ configurations for other models used in IAMbic.
   - **`expires_at`**: The date and time the resource will be/was set to deleted.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
   - **`expires_at_default`**: A value that is set by IAMbic at run time and should not be set by the user.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`user`** *(string)*: User assigned to the app.
   - **`group`** *(string)*: Group assigned to the app.
 
@@ -67,15 +67,15 @@ configurations for other models used in IAMbic.
   - **`expires_at`**: The date and time the resource will be/was set to deleted.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
   - **`expires_at_default`**: A value that is set by IAMbic at run time and should not be set by the user.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
-  - **`name`** *(string)*: Name of the app.
+      - *string* (date-time)
+      - *string* (date)
+  - **`name`** *(string, required)*: Name of the app.
   - **`status`**: Status of the app.
     - **All of**
       - : Refer to *[#/definitions/Status](#definitions/Status)*.

--- a/docs/web/docs/3-reference/3-schemas/okta_config.mdx
+++ b/docs/web/docs/3-reference/3-schemas/okta_config.mdx
@@ -18,9 +18,9 @@ See [Template Schema Validation](/reference/template_validation_ide) to learn ho
 <a id="definitions/OktaOrganization"></a>
 
 - **`OktaOrganization`** *(object)*
-  - **`idp_name`** *(string)*
-  - **`org_url`** *(string)*
-  - **`api_token`** *(string)*
+  - **`idp_name`** *(string, required)*
+  - **`org_url`** *(string, required)*
+  - **`api_token`** *(string, required)*
   - **`request_timeout`** *(integer)*: Default: `60`.
   - **`client`**
   - **`iambic_managed`**: Controls the directionality of iambic changes. Default: `"undefined"`.

--- a/docs/web/docs/3-reference/3-schemas/okta_group_template.mdx
+++ b/docs/web/docs/3-reference/3-schemas/okta_group_template.mdx
@@ -12,14 +12,14 @@ configurations for other models used in IAMbic.
 - **`expires_at`**: The date and time the resource will be/was set to deleted.
   - **Any of**
     - *string*
-    - *string*
-    - *string*
+    - *string* (date-time)
+    - *string* (date)
 - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
 - **`expires_at_default`**: A value that is set by IAMbic at run time and should not be set by the user.
   - **Any of**
     - *string*
-    - *string*
-    - *string*
+    - *string* (date-time)
+    - *string* (date)
 - **`template_type`** *(string)*: Default: `"NOQ::Okta::Group"`.
 - **`template_schema_url`** *(string)*: Default: `"https://docs.iambic.org/reference/schemas/okta_group_template"`.
 - **`owner`** *(string)*: Owner of the group.
@@ -49,15 +49,15 @@ configurations for other models used in IAMbic.
   - **`expires_at`**: The date and time the resource will be/was set to deleted.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
   - **`expires_at_default`**: A value that is set by IAMbic at run time and should not be set by the user.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
-  - **`username`** *(string)*
+      - *string* (date-time)
+      - *string* (date)
+  - **`username`** *(string, required)*
   - **`status`**: Status for the group.
     - **All of**
       - : Refer to *[#/definitions/UserStatus](#definitions/UserStatus)*.
@@ -80,15 +80,15 @@ configurations for other models used in IAMbic.
   - **`expires_at`**: The date and time the resource will be/was set to deleted.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
+      - *string* (date-time)
+      - *string* (date)
   - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
   - **`expires_at_default`**: A value that is set by IAMbic at run time and should not be set by the user.
     - **Any of**
       - *string*
-      - *string*
-      - *string*
-  - **`name`** *(string)*: Name of the group.
+      - *string* (date-time)
+      - *string* (date)
+  - **`name`** *(string, required)*: Name of the group.
   - **`group_id`** *(string)*: Unique Group ID for the group. This value is imported by IAMbic, and doesn't need to be manually set. Default: `""`.
   - **`description`** *(string)*: Description of the group. Default: `""`.
   - **`extra`**: Extra attributes to store.

--- a/docs/web/docs/3-reference/3-schemas/okta_user_template.mdx
+++ b/docs/web/docs/3-reference/3-schemas/okta_user_template.mdx
@@ -12,14 +12,14 @@ configurations for other models used in IAMbic.
 - **`expires_at`**: The date and time the resource will be/was set to deleted.
   - **Any of**
     - *string*
-    - *string*
-    - *string*
+    - *string* (date-time)
+    - *string* (date)
 - **`deleted`** *(boolean)*: Denotes whether the resource has been removed from AWS.Upon being set to true, the resource will be deleted the next time iambic is ran. Default: `false`.
 - **`expires_at_default`**: A value that is set by IAMbic at run time and should not be set by the user.
   - **Any of**
     - *string*
-    - *string*
-    - *string*
+    - *string* (date-time)
+    - *string* (date)
 - **`template_type`** *(string)*: Default: `"NOQ::Okta::User"`.
 - **`template_schema_url`** *(string)*: Default: `"https://docs.iambic.org/reference/schemas/okta_user_template"`.
 - **`owner`** *(string)*
@@ -45,10 +45,10 @@ configurations for other models used in IAMbic.
 
 - **`UserProperties`** *(object)*: A base model class that provides additional helper methods and
 configurations for other models used in IAMbic.
-  - **`username`** *(string)*: Username of the user.
+  - **`username`** *(string, required)*: Username of the user.
   - **`user_id`** *(string)*: Unique User ID for the user. This value is imported by IAMbic, and doesn't need to be manually set. Default: `""`.
   - **`status`**: Status of the user. Default: `"active"`.
     - **All of**
       - : Refer to *[#/definitions/UserStatus](#definitions/UserStatus)*.
-  - **`profile`** *(object)*
+  - **`profile`** *(object, required)*
   - **`extra`** *(object)*: Extra attributes to store for the user.


### PR DESCRIPTION
## What changed?
* support format from json_schema

## Rationale
* sometimes json schema has a format keyword, and we want to include it. I also inline the jsonschema2md because its simple to inline and it's a compatible license

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [ ] Unit Tests
- [ ] Functional Tests
- [x] Manually Verified
