### PR TITLE
Only run the functional test related steps if the source of the pull request is noqdev/iambic

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -33,32 +33,32 @@ jobs:
           python3 -m venv env
           . env/bin/activate && pip install poetry setuptools pip --upgrade && poetry install && pre-commit run -a && make test
       - name: Upload coverage reports to Codecov
-        if: ${{ github.repository == 'noqdev/iambic' }}
+        if: ${{ github.event.pull_request.head.repo.full_name == 'noqdev/iambic' }}
         uses: codecov/codecov-action@v3
         with:
           files: cov_unit_tests.xml
           flags: unit_tests
           token: ${{secrets.CODECOV_TOKEN}}
       - name: Configure AWS Credentials
-        if: ${{ github.repository == 'noqdev/iambic' }}
+        if: ${{ github.event.pull_request.head.repo.full_name == 'noqdev/iambic' }}
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: arn:aws:iam::580605962305:role/IambicHubRole
           aws-region: us-east-1
       - name: run-functional-test
-        if: ${{ github.repository == 'noqdev/iambic' }}
+        if: ${{ github.event.pull_request.head.repo.full_name == 'noqdev/iambic' }}
         id: run-functional-test
         run: |
           . env/bin/activate && make functional_test
       - name: Upload coverage reports to Codecov
-        if: ${{ github.repository == 'noqdev/iambic' }}
+        if: ${{ github.event.pull_request.head.repo.full_name == 'noqdev/iambic' }}
         uses: codecov/codecov-action@v3
         with:
           files: cov_functional_tests.xml
           flags: functional_tests
           token: ${{secrets.CODECOV_TOKEN}}
       - name: Upload coverage reports to Codecov
-        if: ${{ github.repository == 'noqdev/iambic' }}
+        if: ${{ github.event.pull_request.head.repo.full_name == 'noqdev/iambic' }}
         uses: codecov/codecov-action@v3
         with:
           files: cov_functional_tests_config_discovery.xml


### PR DESCRIPTION
## What changed?
* Only run the functional test related steps if the source of the pull request is noqdev/iambic

## Rationale
* Previous implementation of GitHub.repository will always be noqdev/iambic if the action is executed in noqdev/iambic (even for external fork pull request if repo maintainer click to run steps). 

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] Manually Verified

can really only verified once this is in main. I get the idea from `https://github.com/orgs/community/discussions/26829#discussioncomment-3253575`