### PR TITLE
Fix #388 By default, set the roles created by AWS as import only

### DIFF
--- a/iambic/plugins/v0_1_0/aws/iambic_plugin.py
+++ b/iambic/plugins/v0_1_0/aws/iambic_plugin.py
@@ -91,8 +91,27 @@ class AWSConfig(ConfigMixin, BaseModel):
             "If true, it will restrict IAMbic capability in AWS"
         ),
     )
-    import_rules: list[ImportRule] = Field(
-        [],
+    import_rules: Optional[list[ImportRule]] = Field(
+        [
+            ImportRule(
+                match_paths=[
+                    # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/service-role.html
+                    "/service-role/*",
+                    # https://docs.aws.amazon.com/IAM/latest/UserGuide/using-service-linked-roles.html
+                    "/aws-service-role/*",
+                    # https://docs.aws.amazon.com/singlesignon/latest/userguide/using-service-linked-roles.html
+                    "/aws-reserved/*",
+                ],
+                action="set_import_only",
+            ),
+            ImportRule(
+                match_names=[
+                    # https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_accounts_access.html#orgs_manage_accounts_access-cross-account-role
+                    "OrganizationAccountAccessRole",
+                ],
+                action="set_import_only",
+            ),
+        ],
         description=("A list of rules to determine which resources to import from AWS"),
     )
 


### PR DESCRIPTION
## What changed?
*  By default, set the roles created by AWS as import only

## Rationale
* If import_rules is not presented in the AWS Config, we will use the default of the following:
* set import only for path matches /service-role/
* set import only for path matches /aws-service-role/
* set import only for path matches  /aws-reserved/
* set import only for OrganizationAccessRole for name match.

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [ ] Unit Tests
- [ ] Functional Tests
- [x] Manually Verified

Run import on a repo that does not have the import_rule config.

I am able to the inverse by adding the following to override the default behavior. 

```
import_rules: []
```