### PR TITLE
Schema model improvement for Tag

### DIFF
--- a/functional_tests/aws/managed_policy/test_update_template.py
+++ b/functional_tests/aws/managed_policy/test_update_template.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import asyncio
+import os
 from unittest import IsolatedAsyncioTestCase
 
 from functional_tests.aws.managed_policy.utils import (
@@ -13,27 +13,20 @@ from iambic.plugins.v0_1_0.aws.models import Tag
 
 
 class ManagedPolicyUpdateTestCase(IsolatedAsyncioTestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.template = asyncio.run(
-            generate_managed_policy_template_from_base(
-                IAMBIC_TEST_DETAILS.template_dir_path
-            )
+    async def asyncSetUp(self):
+        self.template = await generate_managed_policy_template_from_base(
+            IAMBIC_TEST_DETAILS.template_dir_path
         )
-        cls.all_account_ids = [
+        self.all_account_ids = [
             account.account_id for account in IAMBIC_TEST_DETAILS.config.aws.accounts
         ]
-        # Only include the template in half the accounts
-        # Make the accounts explicit so it's easier to validate account scoped tests
-        cls.template.included_accounts = cls.all_account_ids[
-            : len(cls.all_account_ids) // 2
-        ]
-        asyncio.run(cls.template.apply(IAMBIC_TEST_DETAILS.config.aws))
+        # only test the first two accounts for speed
+        self.template.included_accounts = self.all_account_ids[0:2]
 
-    @classmethod
-    def tearDownClass(cls):
-        cls.template.deleted = True
-        asyncio.run(cls.template.apply(IAMBIC_TEST_DETAILS.config.aws))
+    async def asyncTearDown(self):
+        if os.path.exists(self.template.file_path):
+            self.template.deleted = True
+            await self.template.apply(IAMBIC_TEST_DETAILS.config.aws)
 
     # tag None string value is not acceptable
     async def test_update_tag_with_bad_input(self):

--- a/functional_tests/aws/managed_policy/test_update_template.py
+++ b/functional_tests/aws/managed_policy/test_update_template.py
@@ -37,7 +37,10 @@ class ManagedPolicyUpdateTestCase(IsolatedAsyncioTestCase):
 
     # tag None string value is not acceptable
     async def test_update_tag_with_bad_input(self):
-        self.template.properties.tags = [Tag(key="*", value="")]  # bad input
+        self.template.properties.tags = [
+            Tag(key="a", value=""),
+            Tag(key="a", value=""),
+        ]  # bad input because no repeating tag
         template_change_details = await self.template.apply(
             IAMBIC_TEST_DETAILS.config.aws,
         )

--- a/functional_tests/aws/managed_policy/test_update_template.py
+++ b/functional_tests/aws/managed_policy/test_update_template.py
@@ -7,7 +7,6 @@ from functional_tests.aws.managed_policy.utils import (
     generate_managed_policy_template_from_base,
 )
 from functional_tests.conftest import IAMBIC_TEST_DETAILS
-
 from iambic.core import noq_json as json
 from iambic.output.text import screen_render_resource_changes
 from iambic.plugins.v0_1_0.aws.models import Tag

--- a/functional_tests/aws/role/test_update_template.py
+++ b/functional_tests/aws/role/test_update_template.py
@@ -69,7 +69,10 @@ class UpdateRoleTestCase(IsolatedAsyncioTestCase):
         self.template.properties.description = "{0}_bad_input".format(
             self.template.properties.description
         )  # good input
-        self.template.properties.tags = [Tag(key="*", value="")]  # bad input
+        self.template.properties.tags = [
+            Tag(key="a", value=""),
+            Tag(key="a", value=""),
+        ]  # bad input because you cannot have repeating tag
         try:
             template_change_details = await self.template.apply(
                 IAMBIC_TEST_DETAILS.config.aws

--- a/functional_tests/aws/user/test_update_template.py
+++ b/functional_tests/aws/user/test_update_template.py
@@ -6,9 +6,9 @@ import uuid
 from unittest import IsolatedAsyncioTestCase
 
 import dateparser
+
 from functional_tests.aws.user.utils import generate_user_template_from_base
 from functional_tests.conftest import IAMBIC_TEST_DETAILS
-
 from iambic.core import noq_json as json
 from iambic.core.iambic_enum import Command
 from iambic.core.logger import log

--- a/functional_tests/aws/user/test_update_template.py
+++ b/functional_tests/aws/user/test_update_template.py
@@ -60,7 +60,10 @@ class UpdateUserTestCase(IsolatedAsyncioTestCase):
     # tag None string value is not acceptable
     async def test_update_tag_with_bad_input(self):
         self.template.properties.path = "/engineering/"  # good input
-        self.template.properties.tags = [Tag(key="*", value="")]  # bad input
+        self.template.properties.tags = [
+            Tag(key="a", value=""),
+            Tag(key="a", value=""),
+        ]  # bad input because you cannot have repeating tag
         template_change_details = await self.template.apply(
             IAMBIC_TEST_DETAILS.config.aws
         )

--- a/functional_tests/azure_ad/group/utils.py
+++ b/functional_tests/azure_ad/group/utils.py
@@ -19,14 +19,14 @@ from iambic.plugins.v0_1_0.azure_ad.group.template_generation import (
 def generate_group_template() -> AzureActiveDirectoryGroupTemplate:
     group_dir = os.path.join(
         IAMBIC_TEST_DETAILS.template_dir_path,
-        "resources/azure_ad/group/noq_dev",
+        "resources/azure_ad/group/iambic",
     )
     os.makedirs(group_dir, exist_ok=True)
     identifier = str(random.randint(0, 10000))
     file_path = os.path.join(group_dir, f"iambic_functional_test_{identifier}.yaml")
     group_template = f"""
 template_type: NOQ::AzureAD::Group
-idp_name: noq_dev
+idp_name: iambic
 properties:
   name: Fn Test Group {identifier}
   description: This is the group for running functional tests

--- a/functional_tests/azure_ad/user/utils.py
+++ b/functional_tests/azure_ad/user/utils.py
@@ -10,15 +10,16 @@ from iambic.plugins.v0_1_0.azure_ad.user.models import AzureActiveDirectoryUserT
 def generate_user_template() -> AzureActiveDirectoryUserTemplate:
     user_dir = os.path.join(
         IAMBIC_TEST_DETAILS.template_dir_path,
-        "resources/azure_ad/user/noq_dev",
+        "resources/azure_ad/user/iambic",
     )
     os.makedirs(user_dir, exist_ok=True)
     identifier = str(random.randint(0, 10000))
     file_path = os.path.join(user_dir, f"iambic_functional_test_{identifier}.yaml")
-    username = f"iambic_functional_test_user_{identifier}@noq.dev"
+    # Note: iambicorg.onmicrosoft.com suffix is due to the azure ad setup
+    username = f"iambic_functional_test_user_{identifier}@iambicorg.onmicrosoft.com"
     user_template = f"""
 template_type: NOQ::AzureAD::User
-idp_name: noq_dev
+idp_name: iambic
 properties:
   display_name: Functional Test User {identifier}
   given_name: Fnc Test {identifier}

--- a/iambic/core/models.py
+++ b/iambic/core/models.py
@@ -6,6 +6,7 @@ import glob
 import inspect
 import itertools
 import os
+import re
 import typing
 from enum import Enum
 from hashlib import md5
@@ -71,6 +72,15 @@ def field_schema(field: ModelField, **kwargs: Any) -> Any:
 
 original_field_schema = schema.field_schema
 schema.field_schema = field_schema
+
+
+# use to represent IAMbic var regex
+VARIABLE_REGEX = re.compile(r"\{\{var\.[\w_]+\}}")
+
+
+def strip_out_variables(s: str) -> str:
+    """use this to strip out variable before typical validation"""
+    return VARIABLE_REGEX.sub("", s)
 
 
 class IambicPydanticBaseModel(PydanticBaseModel):

--- a/iambic/core/parser.py
+++ b/iambic/core/parser.py
@@ -67,7 +67,8 @@ def format_validation_error(err, ruamel_dict):
                     lines.append(f"Missing Field: `{canonical_key}`")
             if error["type"].startswith("type_error"):
                 line_num = resolve_location(error["loc"], ruamel_dict)
-                canonical_key = str.lower(".".join(error["loc"]))
+                part_loc_list = [str(x) for x in error["loc"]]
+                canonical_key = str.lower(".".join(part_loc_list))
                 lines.append(f"line {line_num+1}: `{canonical_key}` has type issue")
         return "\n".join(lines)
     except Exception:

--- a/iambic/plugins/v0_1_0/aws/iam/policy/models.py
+++ b/iambic/plugins/v0_1_0/aws/iam/policy/models.py
@@ -278,6 +278,8 @@ class ManagedPolicyProperties(BaseModel):
     tags: Optional[List[Tag]] = Field(
         [],
         description="List of tags attached to the role",
+        # https://docs.aws.amazon.com/IAM/latest/APIReference/API_TagPolicy.html
+        max_items=50,
     )
 
     @property

--- a/iambic/plugins/v0_1_0/aws/iam/role/models.py
+++ b/iambic/plugins/v0_1_0/aws/iam/role/models.py
@@ -90,6 +90,8 @@ class RoleProperties(BaseModel):
     tags: Optional[list[Tag]] = Field(
         [],
         description="List of tags attached to the role",
+        # https://docs.aws.amazon.com/IAM/latest/APIReference/API_TagRole.html
+        max_items=50,
     )
     managed_policies: Optional[list[ManagedPolicyRef]] = Field(
         [],

--- a/iambic/plugins/v0_1_0/aws/iam/user/models.py
+++ b/iambic/plugins/v0_1_0/aws/iam/user/models.py
@@ -129,6 +129,8 @@ class UserProperties(BaseModel):
     tags: Optional[list[Tag]] = Field(
         [],
         description="List of tags attached to the user",
+        # https://docs.aws.amazon.com/IAM/latest/APIReference/API_TagUser.html
+        max_items=50,
     )
     groups: Optional[list[Group]] = Field(
         [],

--- a/iambic/plugins/v0_1_0/aws/models.py
+++ b/iambic/plugins/v0_1_0/aws/models.py
@@ -166,8 +166,8 @@ TAG_VALUE_REGEX = regex.compile(r"[\p{L}\p{Z}\p{N}_.:/=+\-@]*")
 
 
 class Tag(ExpiryModel, AccessModel):
-    key: str = Field(min_length=1, max_length=128)
-    value: str = Field(min_length=0, max_length=256)
+    key: str
+    value: str
 
     @property
     def resource_type(self):
@@ -182,7 +182,7 @@ class Tag(ExpiryModel, AccessModel):
         strip_out_vars = strip_out_variables(v)
         strip_out_vars_len = len(strip_out_vars)
 
-        if strip_out_vars_len == 0:
+        if strip_out_vars != v and strip_out_vars_len == 0:
             # if stripping out variables, we have no data
             # there is no much we can validate until plan time
             return v

--- a/iambic/plugins/v0_1_0/aws/models.py
+++ b/iambic/plugins/v0_1_0/aws/models.py
@@ -10,7 +10,7 @@ import botocore
 import regex
 from aws_error_utils.aws_error_utils import errors
 from pydantic import BaseModel as PydanticBaseModel
-from pydantic import Extra, Field, ValidationError, constr, validator
+from pydantic import Extra, Field, constr, validator
 from ruamel.yaml import YAML, yaml_object
 
 from iambic.core.context import ctx
@@ -165,8 +165,8 @@ TAG_VALUE_REGEX = regex.compile(r"[\p{L}\p{Z}\p{N}_.:/=+\-@]*")
 
 
 class Tag(ExpiryModel, AccessModel):
-    key: str = Field(..., min_length=1, max_length=128)
-    value: str = Field(..., min_length=0, max_length=256)
+    key: str = Field(min_length=1, max_length=128)
+    value: str = Field(min_length=0, max_length=256)
 
     @property
     def resource_type(self):
@@ -182,7 +182,7 @@ class Tag(ExpiryModel, AccessModel):
         if m and m.group() == v:
             return v
         else:
-            raise ValidationError(f"{v} does not match {TAG_KEY_REGEX}")
+            raise ValueError(f"{v} does not match {TAG_KEY_REGEX}")
 
     @validator("value")
     def validate_tag_value(cls, v):
@@ -190,7 +190,7 @@ class Tag(ExpiryModel, AccessModel):
         if m and m.group() == v:
             return v
         else:
-            raise ValidationError(f"{v} does not match {TAG_VALUE_REGEX}")
+            raise ValueError(f"{v} does not match {TAG_VALUE_REGEX}")
 
 
 class BaseAWSAccountAndOrgModel(PydanticBaseModel):

--- a/test/core/test_models.py
+++ b/test/core/test_models.py
@@ -14,7 +14,7 @@ from git.diff import Diff
 import iambic.plugins.v0_1_0.example
 from iambic.config.dynamic_config import load_config
 from iambic.core.iambic_enum import IambicManaged
-from iambic.core.models import BaseTemplate, ExpiryModel
+from iambic.core.models import BaseTemplate, ExpiryModel, strip_out_variables
 from iambic.core.parser import load_templates
 from iambic.core.template_generation import merge_model
 
@@ -249,3 +249,21 @@ async def test_get_body(templates_repo: tuple[str, str]):
     assert template_lines[0] == "# comment line 1"
     assert template_lines[1] == "template_type: NOQ::Example::LocalFile"
     assert template_lines[2] == "template_schema_url: test_url"
+
+
+def test_var_regex():
+    example = "{{var.account_name}}"
+    result = strip_out_variables(example)
+    assert result == ""
+
+
+def test_var_regex_multiple_vars():
+    example = "{{var.account_name}} foo {{var.account_name}}"
+    result = strip_out_variables(example)
+    assert result == " foo "
+
+
+def test_var_regex_multiple_vars_no_underscore():
+    example = "{{var.hello}} foo {{var.var}}"
+    result = strip_out_variables(example)
+    assert result == " foo "

--- a/test/plugins/v0_1_0/aws/iam/policy/test_models.py
+++ b/test/plugins/v0_1_0/aws/iam/policy/test_models.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import json
 
+import pytest
+from pydantic import ValidationError
+
 from iambic.core.template_generation import merge_model
 from iambic.plugins.v0_1_0.aws.iam.policy.models import (
     ManagedPolicyDocument,
@@ -161,6 +164,23 @@ def test_policy_path_validation():
     )  # double check the list is reversed because validation doesn't happen after creation
     properties_1.validate_model_afterward()
     assert properties_1.path == path_1
+
+
+def test_policy_properties_tags_too_many_tags():
+    tags_1 = [
+        {"key": "apple", "value": "red"},
+    ] * 51
+    with pytest.raises(ValidationError):
+        assert ManagedPolicyProperties(
+            policy_name="foo", tags=tags_1, policy_document={}
+        )
+
+
+def test_policy_properties_tags_max_tags():
+    tags_1 = [
+        {"key": "apple", "value": "red"},
+    ] * 50
+    assert ManagedPolicyProperties(policy_name="foo", tags=tags_1, policy_document={})
 
 
 def test_description_validation():

--- a/test/plugins/v0_1_0/aws/iam/role/test_models.py
+++ b/test/plugins/v0_1_0/aws/iam/role/test_models.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import re
 
 import pytest
+from pydantic import ValidationError
 
 from iambic.core.template_generation import merge_model
 from iambic.core.utils import IAMBIC_ERR_MSG
@@ -651,6 +652,21 @@ def test_merge_role_with_multiple_access_removals(aws_accounts: list[AWSAccount]
                 sorted(inline_policy.statement[0].action)
                 == sorted(dev_statement[0]["action"])
             )
+
+
+def test_role_properties_tags_too_many_tags():
+    tags_1 = [
+        {"key": "apple", "value": "red"},
+    ] * 51
+    with pytest.raises(ValidationError):
+        assert RoleProperties(role_name="foo", tags=tags_1)
+
+
+def test_role_properties_tags_max_tags():
+    tags_1 = [
+        {"key": "apple", "value": "red"},
+    ] * 50
+    assert RoleProperties(role_name="foo", tags=tags_1)
 
 
 def test_role_properties_tags():

--- a/test/plugins/v0_1_0/aws/iam/user/test_models.py
+++ b/test/plugins/v0_1_0/aws/iam/user/test_models.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import pytest
+from pydantic import ValidationError
+
 from iambic.core.template_generation import merge_model
 from iambic.plugins.v0_1_0.aws.iam.user.models import Group, UserProperties
 
@@ -64,6 +67,21 @@ def test_user_properties_sorting():
     )
     assert properties.groups[0].group_name == "bar"
     assert properties.groups[1].group_name == "baz"
+
+
+def test_user_properties_tags_too_many_tags():
+    tags_1 = [
+        {"key": "apple", "value": "red"},
+    ] * 51
+    with pytest.raises(ValidationError):
+        assert UserProperties(user_name="foo", tags=tags_1)
+
+
+def test_user_properties_tags_max_tags():
+    tags_1 = [
+        {"key": "apple", "value": "red"},
+    ] * 50
+    assert UserProperties(user_name="foo", tags=tags_1)
 
 
 def test_user_path_validation():

--- a/test/plugins/v0_1_0/aws/test_models.py
+++ b/test/plugins/v0_1_0/aws/test_models.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from iambic.plugins.v0_1_0.aws.models import Tag
+
+
+def test_valid_tag():
+    tag = Tag(key="a", value="")
+    assert tag
+
+
+def test_invalid_tag_key():
+    with pytest.raises(ValidationError):
+        Tag(key="*", value="")
+
+
+def test_invalid_tag_with_empty_string():
+    with pytest.raises(ValidationError):
+        Tag(key="", value="")
+
+
+def test_invalid_tag_with_key_too_long():
+    with pytest.raises(ValidationError):
+        Tag(key="a" * 129, value="")
+
+
+def test_valid_tag_with_max_key_length():
+    assert Tag(key="a" * 128, value="")
+
+
+def test_invalid_tag_value():
+    with pytest.raises(ValidationError):
+        Tag(key="a", value="*")
+
+
+def test_valid_tag_value_with_empty_string():
+    assert Tag(key="a", value="")
+
+
+def test_invalid_tag_with_value_too_long():
+    with pytest.raises(ValidationError):
+        Tag(key="a", value="a" * 257)
+
+
+def test_valid_tag_with_max_value_length():
+    assert Tag(key="a", value="a" * 256)

--- a/test/plugins/v0_1_0/aws/test_models.py
+++ b/test/plugins/v0_1_0/aws/test_models.py
@@ -46,3 +46,7 @@ def test_invalid_tag_with_value_too_long():
 
 def test_valid_tag_with_max_value_length():
     assert Tag(key="a", value="a" * 256)
+
+
+def test_variable_on_tag_key():
+    assert Tag(key="{{var.account_name}}", value="")


### PR DESCRIPTION
## What changed?
* Add the Tag API restriction in the Pedantic models

## Rationale
* We can get plan time validation. 
* Concern is we will be behind if service API change. boto3 actually defer to API validation time checking. 

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [x] Unit Tests
- [ ] Functional Tests
- [ ] Manually Verified

This is the experience if someone made a template validation error: https://github.com/noqdev/iambic-templates-itest/pull/333#issuecomment-1703506031