### PR TITLE
Fix okta pagination handling on apps, groups, and users

### DIFF
--- a/iambic/plugins/v0_1_0/okta/app/utils.py
+++ b/iambic/plugins/v0_1_0/okta/app/utils.py
@@ -150,6 +150,7 @@ async def list_all_apps(okta_organization: OktaOrganization) -> List[App]:
         log.error("Error encountered when listing apps", error=str(err))
         raise Exception("Error encountered when listing apps")
     while resp.has_next():
+        # pagination handling
         async with GlobalRetryController(
             fn_identifier="okta.list_applications"
         ) as retry_controller:
@@ -157,7 +158,7 @@ async def list_all_apps(okta_organization: OktaOrganization) -> List[App]:
         if err:
             log.error("Error encountered when listing apps", error=str(err))
             raise Exception("Error encountered when listing apps")
-        raw_apps.append(next_apps)
+        raw_apps.extend(next_apps)
 
     if not raw_apps:
         return []

--- a/iambic/plugins/v0_1_0/okta/group/utils.py
+++ b/iambic/plugins/v0_1_0/okta/group/utils.py
@@ -51,6 +51,7 @@ async def list_all_users(okta_organization: OktaOrganization) -> List[User]:
             raise Exception(f"Error listing users: {str(err)}")
 
     while resp.has_next():
+        # pagination handling
         async with GlobalRetryController(
             fn_identifier="okta.list_users"
         ) as retry_controller:
@@ -58,7 +59,7 @@ async def list_all_users(okta_organization: OktaOrganization) -> List[User]:
         if err:
             log.error("Error encountered when listing users", error=str(err))
             raise Exception(f"Error listing users: {str(err)}")
-        users.append(next_users)
+        users.extend(next_users)
 
     if not users:
         return []
@@ -158,6 +159,7 @@ async def list_all_groups(okta_organization: OktaOrganization) -> List[Group]:
             raise Exception(f"Error listing groups: {str(err)}")
 
     while resp.has_next():
+        # pagination handling
         async with GlobalRetryController(
             fn_identifier="okta.list_groups"
         ) as retry_controller:
@@ -165,7 +167,7 @@ async def list_all_groups(okta_organization: OktaOrganization) -> List[Group]:
         if err:
             log.error("Error encountered when listing groups", error=str(err))
             raise Exception(f"Error listing groups: {str(err)}")
-        groups.append(next_groups)
+        groups.extend(next_groups)
 
     if not groups:
         log.info(


### PR DESCRIPTION
## What changed?
* Fixed pagination for okta list_applications, list_users, and list_groups

## Rationale
* In pagination, the next_apps|users|groups is type list, instead of append to the existing list, we have to use extend

## How was it tested?
If it was manually verified, list the instructions for your reviewers to follow.
- [ ] Unit Tests
- [ ] Functional Tests
- [ ] Manually Verified

This is a little tricky since our testing infra does not mock or have mechanism for testing okta pagination and okta test env has limit that does not trigger pagination.